### PR TITLE
kernel:update the kmesh feature patches for kernel-5.10

### DIFF
--- a/kernel/patches/5.10.0/0001-bpf-sockmap-add-extra-return-value-for-sockops.patch
+++ b/kernel/patches/5.10.0/0001-bpf-sockmap-add-extra-return-value-for-sockops.patch
@@ -1,0 +1,29 @@
+From ab2a6465a9af8e5fffb4638fe22fc17ee6858c69 Mon Sep 17 00:00:00 2001
+From: kongweibin <kongweibin2@huawei.com>
+Date: Fri, 13 Oct 2023 17:57:38 +0800
+Subject: [PATCH 1/8] bpf,sockmap: add extra return value for sockops
+
+Sockops was previously returned only through replylong[0]. Now we
+extend it to support returning replylong[1]~replylong[3]
+
+Signed-off-by: kongweibin <kongweibin2@huawei.com>
+---
+ net/core/filter.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/net/core/filter.c b/net/core/filter.c
+index 2e4edda72..c36dbcee6 100644
+--- a/net/core/filter.c
++++ b/net/core/filter.c
+@@ -8206,7 +8206,7 @@ static bool sock_ops_is_valid_access(int off, int size,
+ 
+ 	if (type == BPF_WRITE) {
+ 		switch (off) {
+-		case offsetof(struct bpf_sock_ops, reply):
++		case bpf_ctx_range_till(struct bpf_sock_ops, reply, replylong[3]):
+ 		case offsetof(struct bpf_sock_ops, sk_txhash):
+ 			if (size != size_default)
+ 				return false;
+-- 
+2.33.0
+

--- a/kernel/patches/5.10.0/0002-net-ipv4-A-new-bit-is-added-to-indicate-whether-to-d.patch
+++ b/kernel/patches/5.10.0/0002-net-ipv4-A-new-bit-is-added-to-indicate-whether-to-d.patch
@@ -1,0 +1,54 @@
+From 16b1ffe4eae8a45a366fc34871312257c2033e66 Mon Sep 17 00:00:00 2001
+From: kongweibin <kongweibin2@huawei.com>
+Date: Fri, 13 Oct 2023 18:04:54 +0800
+Subject: [PATCH 2/8] net, ipv4: A new bit is added to indicate whether to
+ delay link establishment using bpf
+
+The bpf_defer_connect bit is added for inet_sock to indicate
+whether the current socket is changed to the bpf program to
+delay link establishment.
+
+Signed-off-by: kongweibin <kongweibin2@huawei.com>
+---
+ include/net/inet_sock.h | 7 ++++++-
+ net/ipv4/tcp.c          | 3 ++-
+ 2 files changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/include/net/inet_sock.h b/include/net/inet_sock.h
+index 91668b1cd..ef860886c 100644
+--- a/include/net/inet_sock.h
++++ b/include/net/inet_sock.h
+@@ -240,10 +240,15 @@ struct inet_sock {
+ 				nodefrag:1;
+ 	__u8			bind_address_no_port:1,
+ 				recverr_rfc4884:1,
+-				defer_connect:1; /* Indicates that fastopen_connect is set
++				defer_connect:1, /* Indicates that fastopen_connect is set
+ 						  * and cookie exists so we defer connect
+ 						  * until first data frame is written
+ 						  */
++				bpf_defer_connect:1; /* specifies the ebpf program for
++						      * traffic orchestration so we defer
++						      * connect until first data frame is
++						      * written
++						      */
+ 	__u8			rcv_tos;
+ 	__u8			convert_csum;
+ 	int			uc_index;
+diff --git a/net/ipv4/tcp.c b/net/ipv4/tcp.c
+index f009d7846..d88de88bb 100644
+--- a/net/ipv4/tcp.c
++++ b/net/ipv4/tcp.c
+@@ -590,7 +590,8 @@ __poll_t tcp_poll(struct file *file, struct socket *sock, poll_table *wait)
+ 
+ 		if (tp->urg_data & TCP_URG_VALID)
+ 			mask |= EPOLLPRI;
+-	} else if (state == TCP_SYN_SENT && inet_sk(sk)->defer_connect) {
++	} else if (state == TCP_SYN_SENT &&
++			(inet_sk(sk)->defer_connect || inet_sk(sk)->bpf_defer_connect)) {
+ 		/* Active TCP fastopen socket with defer_connect
+ 		 * Return EPOLLOUT so application can call write()
+ 		 * in order for kernel to generate SYN+data
+-- 
+2.33.0
+

--- a/kernel/patches/5.10.0/0003-ipv4-bpf-Introduced-to-support-the-ULP-to-modify.patch
+++ b/kernel/patches/5.10.0/0003-ipv4-bpf-Introduced-to-support-the-ULP-to-modify.patch
@@ -1,0 +1,34 @@
+From 2b40ef8d75316e6fb005ac8c3844b3b096850b07 Mon Sep 17 00:00:00 2001
+From: kongweibin <kongweibin2@huawei.com>
+Date: Fri, 13 Oct 2023 18:06:31 +0800
+Subject: [PATCH 3/8] ipv4, bpf: Introduced to support the ULP to modify
+
+Currently, the ebpf program can distinguish sockets according to
+the address accessed by the client, and use the ULP framework to
+modify the matched sockets to delay link establishment.
+
+Signed-off-by: kongweibin <kongweibin2@huawei.com>
+---
+ net/core/filter.c | 6 +++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/net/core/filter.c b/net/core/filter.c
+index c36dbcee6..6a0fdc5ce 100644
+--- a/net/core/filter.c
++++ b/net/core/filter.c
+@@ -4838,6 +4838,12 @@ static int _bpf_setsockopt(struct sock *sk, int level, int optname,
+ 						    TCP_CA_NAME_MAX-1));
+ 			name[TCP_CA_NAME_MAX-1] = 0;
+ 			ret = tcp_set_congestion_control(sk, name, false, true);
++		} else if (optname == TCP_ULP) {
++			char name[TCP_ULP_NAME_MAX] = {0};
++
++			strncpy(name, optval, min_t(long, optlen,
++						    TCP_ULP_NAME_MAX - 1));
++			return tcp_set_ulp(sk, name);
+ 		} else {
+ 			struct inet_connection_sock *icsk = inet_csk(sk);
+ 			struct tcp_sock *tp = tcp_sk(sk);
+-- 
+2.33.0
+

--- a/kernel/patches/5.10.0/0004-net-bpf-Add-a-writeable_tracepoint-to-inet_stream_co.patch
+++ b/kernel/patches/5.10.0/0004-net-bpf-Add-a-writeable_tracepoint-to-inet_stream_co.patch
@@ -1,0 +1,58 @@
+From d5b47c94aa31cb0447207b298be6aac3d9bf16d9 Mon Sep 17 00:00:00 2001
+From: kongweibin <kongweibin2@huawei.com>
+Date: Fri, 13 Oct 2023 18:08:30 +0800
+Subject: [PATCH 4/8] net, bpf: Add a writeable_tracepoint to
+ inet_stream_connect
+
+A trace point is added to the connection process. Theebpf program
+can be mounted to modify the return value of the function. This is
+mandatory for delaying the establishment of an ebpf link. After
+the connection is complete, a message is returned immediately and
+no unnecessary operation is performed.
+
+Signed-off-by: kongweibin <kongweibin2@huawei.com>
+---
+ include/trace/events/sock.h | 14 ++++++++++++++
+ net/ipv4/af_inet.c          |  1 +
+ 2 files changed, 15 insertions(+)
+
+diff --git a/include/trace/events/sock.h b/include/trace/events/sock.h
+index 905b151bc..841627e15 100644
+--- a/include/trace/events/sock.h
++++ b/include/trace/events/sock.h
+@@ -203,6 +203,20 @@ TRACE_EVENT(inet_sock_set_state,
+ 			show_tcp_state_name(__entry->newstate))
+ );
+ 
++#undef NET_DECLARE_TRACE
++#ifdef DECLARE_TRACE_WRITABLE
++#define NET_DECLARE_TRACE(call, proto, args, size) \
++	DECLARE_TRACE_WRITABLE(call, PARAMS(proto), PARAMS(args), size)
++#else
++#define NET_DECLARE_TRACE(call, proto, args, size) \
++	DECLARE_TRACE(call, PARAMS(proto), PARAMS(args))
++#endif
++
++NET_DECLARE_TRACE(connect_ret,
++	TP_PROTO(int *err),
++	TP_ARGS(err),
++	sizeof(int));
++
+ #endif /* _TRACE_SOCK_H */
+ 
+ /* This part must be outside protection */
+diff --git a/net/ipv4/af_inet.c b/net/ipv4/af_inet.c
+index 4ddbfccfd..6c9b39e96 100644
+--- a/net/ipv4/af_inet.c
++++ b/net/ipv4/af_inet.c
+@@ -729,6 +729,7 @@ int inet_stream_connect(struct socket *sock, struct sockaddr *uaddr,
+ 	lock_sock(sock->sk);
+ 	err = __inet_stream_connect(sock, uaddr, addr_len, flags, 0);
+ 	release_sock(sock->sk);
++	trace_connect_ret(&err);
+ 	return err;
+ }
+ EXPORT_SYMBOL(inet_stream_connect);
+-- 
+2.33.0
+

--- a/kernel/patches/5.10.0/0005-bpf-Introduces-a-new-state-to-identify-the-location-.patch
+++ b/kernel/patches/5.10.0/0005-bpf-Introduces-a-new-state-to-identify-the-location-.patch
@@ -1,0 +1,43 @@
+From d52cfd2c8c1f4ac198e32c8b4e71edb61ad3715e Mon Sep 17 00:00:00 2001
+From: kongweibin <kongweibin2@huawei.com>
+Date: Fri, 13 Oct 2023 18:11:16 +0800
+Subject: [PATCH 5/8] bpf: Introduces a new state to identify the location of
+ the sockops call
+
+Currently, a permission status code is required to identify
+that the access to the sockops is from the delayed link establishment
+scenario. Therefore, "BPF_SOCK_OPS_TCP_DEFFER_CONNECT_CB"
+
+Signed-off-by: kongweibin <kongweibin2@huawei.com>
+---
+ include/uapi/linux/bpf.h       | 1 +
+ tools/include/uapi/linux/bpf.h | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/include/uapi/linux/bpf.h b/include/uapi/linux/bpf.h
+index 9373abafc..0ac3b2af3 100644
+--- a/include/uapi/linux/bpf.h
++++ b/include/uapi/linux/bpf.h
+@@ -4879,6 +4879,7 @@ enum {
+ 					 * by the kernel or the
+ 					 * earlier bpf-progs.
+ 					 */
++	BPF_SOCK_OPS_TCP_DEFER_CONNECT_CB,/* call ebpf to defer connect*/
+ };
+ 
+ /* List of TCP states. There is a build check in net/ipv4/tcp.c to detect
+diff --git a/tools/include/uapi/linux/bpf.h b/tools/include/uapi/linux/bpf.h
+index 41bc2f496..584d20c56 100644
+--- a/tools/include/uapi/linux/bpf.h
++++ b/tools/include/uapi/linux/bpf.h
+@@ -4879,6 +4879,7 @@ enum {
+ 					 * by the kernel or the
+ 					 * earlier bpf-progs.
+ 					 */
++	BPF_SOCK_OPS_TCP_DEFER_CONNECT_CB,/* call ebpf to defer connect*/
+ };
+ 
+ /* List of TCP states. There is a build check in net/ipv4/tcp.c to detect
+-- 
+2.33.0
+

--- a/kernel/patches/5.10.0/0006-bpf-Introduce-the-string-processing-helper.patch
+++ b/kernel/patches/5.10.0/0006-bpf-Introduce-the-string-processing-helper.patch
@@ -1,0 +1,202 @@
+From 6a1d535cdf4ce994084f7bf36089e866aa46a0c7 Mon Sep 17 00:00:00 2001
+From: kongweibin <kongweibin2@huawei.com>
+Date: Fri, 13 Oct 2023 18:12:12 +0800
+Subject: [PATCH 6/8] bpf: Introduce the string processing helper
+
+Currently, some character strings need to be processed in the ebpf
+function. Some character string helper processing functions, such
+as strlen and strnstr, need to be introduced.
+
+Signed-off-by: kongweibin <kongweibin2@huawei.com>
+---
+ include/uapi/linux/bpf.h       | 23 +++++++++++++++++
+ kernel/bpf/helpers.c           | 47 ++++++++++++++++++++++++++++++++++
+ tools/include/uapi/linux/bpf.h | 43 +++++++++++++++++++++++--------
+ 3 files changed, 103 insertions(+), 10 deletions(-)
+
+diff --git a/include/uapi/linux/bpf.h b/include/uapi/linux/bpf.h
+index 0ac3b2af3..187404c0b 100644
+--- a/include/uapi/linux/bpf.h
++++ b/include/uapi/linux/bpf.h
+@@ -3878,6 +3878,26 @@ union bpf_attr {
+  *		Check the ipaddr is local address or not.
+  *	Return
+  *		1 is local address, 0 is not.
++ *
++ * void *bpf_strncpy(char *dst, u32 dst_size, char *src)
++ * Description
++ * 		Copies a string that starts with the src address and ends with the
++ * 		NULL character to the address space that starts with dst.
++ * 	Return
++ * 		Returns a apointer to dst. 
++ *
++ * void *bpf_strnstr(void *s1, void *s2, u32 size)
++ * 	Description
++ * 		Search for s2 in the first position character string os s1.
++ * 	Return
++ * 		If s2 exists, returns the position of s2 in s1. If s2 is not found,
++ * 		return NULL.
++ *
++ * u64 bpf_strnlen(char *buff, u32 size)
++ * 	Description
++ * 		Obtains the length of a character string.
++ * 	Return
++ * 		Length of the string.
+  */
+ #define __BPF_FUNC_MAPPER(FN)		\
+ 	FN(unspec),			\
+@@ -4051,6 +4071,9 @@ union bpf_attr {
+ 	FN(cpumask_op),			\
+ 	FN(cpus_share_cache),		\
+ 	FN(is_local_ipaddr),		\
++	FN(strncpy),			\
++	FN(strnstr),			\
++	FN(strnlen),			\
+ 	/* */
+ 
+ /* integer value in 'imm' field of BPF_CALL instruction selects which helper
+diff --git a/kernel/bpf/helpers.c b/kernel/bpf/helpers.c
+index 5fccf3319..6e03fbb42 100644
+--- a/kernel/bpf/helpers.c
++++ b/kernel/bpf/helpers.c
+@@ -653,6 +653,47 @@ const struct bpf_func_proto bpf_this_cpu_ptr_proto = {
+ 	.arg1_type	= ARG_PTR_TO_PERCPU_BTF_ID,
+ };
+ 
++BPF_CALL_2(bpf_strnlen, void *, src, size_t, len)
++{
++	return strnlen(src, len);
++}
++
++const struct bpf_func_proto bpf_strnlen_proto = {
++	.func		= bpf_strnlen,
++	.gpl_only	= false,
++	.ret_type	= RET_INTEGER,
++	.arg1_type	= ARG_ANYTHING,
++	.arg2_type	= ARG_ANYTHING,
++};
++
++BPF_CALL_3(bpf_strnstr, void *, s1, void *, s2, size_t, len)
++{
++	return strnstr(s1, s2, len);
++}
++
++const struct bpf_func_proto bpf_strnstr_proto = {
++	.func		= bpf_strnstr,
++	.gpl_only	= false,
++	.ret_type	= RET_PTR_TO_ALLOC_MEM_OR_NULL,
++	.arg1_type	= ARG_ANYTHING,
++	.arg2_type	= ARG_ANYTHING,
++	.arg3_type	= ARG_ANYTHING,
++};
++
++BPF_CALL_3(bpf_strncpy, void *, dst, u32, dst_size, void *, src)
++{
++	return strncpy(dst, src, dst_size);
++}
++
++const struct bpf_func_proto bpf_strncpy_proto = {
++	.func		= bpf_strncpy,
++	.gpl_only	= false,
++	.ret_type	= RET_PTR_TO_ALLOC_MEM_OR_NULL,
++	.arg1_type	= ARG_ANYTHING,
++	.arg2_type	= ARG_ANYTHING,
++	.arg3_type	= ARG_ANYTHING,
++};
++
+ const struct bpf_func_proto bpf_get_current_task_proto __weak;
+ const struct bpf_func_proto bpf_probe_read_user_proto __weak;
+ const struct bpf_func_proto bpf_probe_read_user_str_proto __weak;
+@@ -705,6 +746,12 @@ bpf_base_func_proto(enum bpf_func_id func_id)
+ 		return &bpf_sched_tg_tag_of_proto;
+ 	case BPF_FUNC_sched_task_tag_of:
+ 		return &bpf_sched_task_tag_of_proto;
++	case BPF_FUNC_strnlen:
++		return &bpf_strnlen_proto;
++	case BPF_FUNC_strncpy:
++		return &bpf_strncpy_proto;
++	case BPF_FUNC_strnstr:
++		return &bpf_strnstr_proto;
+ 	default:
+ 		break;
+ 	}
+diff --git a/tools/include/uapi/linux/bpf.h b/tools/include/uapi/linux/bpf.h
+index 584d20c56..187404c0b 100644
+--- a/tools/include/uapi/linux/bpf.h
++++ b/tools/include/uapi/linux/bpf.h
+@@ -2169,8 +2169,8 @@ union bpf_attr {
+  *
+  * 			# sysctl kernel.perf_event_max_stack=<new value>
+  * 	Return
+- * 		A non-negative value equal to or less than *size* on success,
+- * 		or a negative error in case of failure.
++ * 		The non-negative copied *buf* length equal to or less than
++ * 		*size* on success, or a negative error in case of failure.
+  *
+  * long bpf_skb_load_bytes_relative(const void *skb, u32 offset, void *to, u32 len, u32 start_header)
+  * 	Description
+@@ -3454,8 +3454,8 @@ union bpf_attr {
+  *
+  *			# sysctl kernel.perf_event_max_stack=<new value>
+  *	Return
+- *		A non-negative value equal to or less than *size* on success,
+- *		or a negative error in case of failure.
++ * 		The non-negative copied *buf* length equal to or less than
++ * 		*size* on success, or a negative error in case of failure.
+  *
+  * long bpf_load_hdr_opt(struct bpf_sock_ops *skops, void *searchby_res, u32 len, u64 flags)
+  *	Description
+@@ -3871,13 +3871,33 @@ union bpf_attr {
+  *	Description
+  *		check src_cpu whether share cache with dst_cpu.
+  *	Return
+- *		true yes, false no.
++ *		yes 1, no 0.
+  *
+  * long bpf_is_local_ipaddr(u32 ipaddr)
+- *     Description
+- *             Check the ipaddr is local address or not.
+- *     Return
+- *             1 is local address, 0 is not.
++ *	Description
++ *		Check the ipaddr is local address or not.
++ *	Return
++ *		1 is local address, 0 is not.
++ *
++ * void *bpf_strncpy(char *dst, u32 dst_size, char *src)
++ * Description
++ * 		Copies a string that starts with the src address and ends with the
++ * 		NULL character to the address space that starts with dst.
++ * 	Return
++ * 		Returns a apointer to dst. 
++ *
++ * void *bpf_strnstr(void *s1, void *s2, u32 size)
++ * 	Description
++ * 		Search for s2 in the first position character string os s1.
++ * 	Return
++ * 		If s2 exists, returns the position of s2 in s1. If s2 is not found,
++ * 		return NULL.
++ *
++ * u64 bpf_strnlen(char *buff, u32 size)
++ * 	Description
++ * 		Obtains the length of a character string.
++ * 	Return
++ * 		Length of the string.
+  */
+ #define __BPF_FUNC_MAPPER(FN)		\
+ 	FN(unspec),			\
+@@ -4050,7 +4070,10 @@ union bpf_attr {
+ 	FN(sched_entity_to_tg),		\
+ 	FN(cpumask_op),			\
+ 	FN(cpus_share_cache),		\
+-	FN(is_local_ipaddr),            \
++	FN(is_local_ipaddr),		\
++	FN(strncpy),			\
++	FN(strnstr),			\
++	FN(strnlen),			\
+ 	/* */
+ 
+ /* integer value in 'imm' field of BPF_CALL instruction selects which helper
+-- 
+2.33.0
+

--- a/kernel/patches/5.10.0/0007-bpf-add-strncmp-helper-function.patch
+++ b/kernel/patches/5.10.0/0007-bpf-add-strncmp-helper-function.patch
@@ -1,0 +1,109 @@
+From c3fe29a918c97be693dca8608d2fa9f68cedb176 Mon Sep 17 00:00:00 2001
+From: kongweibin <kongweibin2@huawei.com>
+Date: Sat, 14 Oct 2023 14:38:35 +0800
+Subject: [PATCH 7/8] bpf: add strncmp helper function
+
+A helper function is added for character string comparison.
+
+Signed-off-by: kongweibin <kongweibin2@huawei.com>
+---
+ include/uapi/linux/bpf.h       | 11 +++++++++++
+ kernel/bpf/helpers.c           | 16 ++++++++++++++++
+ tools/include/uapi/linux/bpf.h | 11 +++++++++++
+ 3 files changed, 38 insertions(+)
+
+diff --git a/include/uapi/linux/bpf.h b/include/uapi/linux/bpf.h
+index 187404c0b..703c6f124 100644
+--- a/include/uapi/linux/bpf.h
++++ b/include/uapi/linux/bpf.h
+@@ -3898,6 +3898,16 @@ union bpf_attr {
+  * 		Obtains the length of a character string.
+  * 	Return
+  * 		Length of the string.
++ *
++ * long bpf__strncmp(const char *s1, u32 s1_sz, const char *s2)
++ *	Description
++ *		Do strncmp() between **s1** and **s2**. **s1** doesn't need
++ *		to be null-terminated and **s1_sz** is the maximum storage
++ *		size of **s1**. **s2** must be a read-only string.
++ *	Return
++ *		An integer less than, equal to, or greater than zero
++ *		if the first **s1_sz** bytes of **s1** is found to be
++ *		less than, to match, or be greater than **s2**.
+  */
+ #define __BPF_FUNC_MAPPER(FN)		\
+ 	FN(unspec),			\
+@@ -4074,6 +4084,7 @@ union bpf_attr {
+ 	FN(strncpy),			\
+ 	FN(strnstr),			\
+ 	FN(strnlen),			\
++	FN(_strncmp),			\
+ 	/* */
+ 
+ /* integer value in 'imm' field of BPF_CALL instruction selects which helper
+diff --git a/kernel/bpf/helpers.c b/kernel/bpf/helpers.c
+index 6e03fbb42..af0861af2 100644
+--- a/kernel/bpf/helpers.c
++++ b/kernel/bpf/helpers.c
+@@ -694,6 +694,20 @@ const struct bpf_func_proto bpf_strncpy_proto = {
+ 	.arg3_type	= ARG_ANYTHING,
+ };
+ 
++BPF_CALL_3(bpf__strncmp, const char *, s1, u32, s1_sz, const char *, s2)
++{
++	return strncmp(s1, s2, s1_sz);
++}
++
++const struct bpf_func_proto bpf__strncmp_proto = {
++	.func		= bpf__strncmp,
++	.gpl_only	= false,
++	.ret_type	= RET_INTEGER,
++	.arg1_type	= ARG_ANYTHING,
++	.arg2_type	= ARG_ANYTHING,
++	.arg3_type	= ARG_ANYTHING,
++};
++
+ const struct bpf_func_proto bpf_get_current_task_proto __weak;
+ const struct bpf_func_proto bpf_probe_read_user_proto __weak;
+ const struct bpf_func_proto bpf_probe_read_user_str_proto __weak;
+@@ -752,6 +766,8 @@ bpf_base_func_proto(enum bpf_func_id func_id)
+ 		return &bpf_strncpy_proto;
+ 	case BPF_FUNC_strnstr:
+ 		return &bpf_strnstr_proto;
++	case BPF_FUNC__strncmp:
++		return &bpf__strncmp_proto;
+ 	default:
+ 		break;
+ 	}
+diff --git a/tools/include/uapi/linux/bpf.h b/tools/include/uapi/linux/bpf.h
+index 187404c0b..703c6f124 100644
+--- a/tools/include/uapi/linux/bpf.h
++++ b/tools/include/uapi/linux/bpf.h
+@@ -3898,6 +3898,16 @@ union bpf_attr {
+  * 		Obtains the length of a character string.
+  * 	Return
+  * 		Length of the string.
++ *
++ * long bpf__strncmp(const char *s1, u32 s1_sz, const char *s2)
++ *	Description
++ *		Do strncmp() between **s1** and **s2**. **s1** doesn't need
++ *		to be null-terminated and **s1_sz** is the maximum storage
++ *		size of **s1**. **s2** must be a read-only string.
++ *	Return
++ *		An integer less than, equal to, or greater than zero
++ *		if the first **s1_sz** bytes of **s1** is found to be
++ *		less than, to match, or be greater than **s2**.
+  */
+ #define __BPF_FUNC_MAPPER(FN)		\
+ 	FN(unspec),			\
+@@ -4074,6 +4084,7 @@ union bpf_attr {
+ 	FN(strncpy),			\
+ 	FN(strnstr),			\
+ 	FN(strnlen),			\
++	FN(_strncmp),			\
+ 	/* */
+ 
+ /* integer value in 'imm' field of BPF_CALL instruction selects which helper
+-- 
+2.33.0
+

--- a/kernel/patches/5.10.0/0008-bpf-Two-helper-functions-are-introduced-to-parse-use.patch
+++ b/kernel/patches/5.10.0/0008-bpf-Two-helper-functions-are-introduced-to-parse-use.patch
@@ -1,0 +1,184 @@
+From 4a5efa4af9074eda5146ba72f7015dabdfc0b37f Mon Sep 17 00:00:00 2001
+From: kongweibin <kongweibin2@huawei.com>
+Date: Sat, 14 Oct 2023 14:42:36 +0800
+Subject: [PATCH 8/8] bpf: Two helper functions are introduced to parse
+ user-mode messages.
+
+User messages need to be parsed when the bpf link establishment
+is delayed. In this case, two helpers need to be introduced. One is
+to parse user-mode messages, and the other is to obtain the parsed
+data.
+
+Signed-off-by: kongweibin <kongweibin2@huawei.com>
+---
+ include/uapi/linux/bpf.h       | 21 ++++++++++++++++++
+ net/core/filter.c              | 40 ++++++++++++++++++++++++++++++++++
+ scripts/bpf_helpers_doc.py     |  1 +
+ tools/include/uapi/linux/bpf.h | 21 ++++++++++++++++++
+ 4 files changed, 83 insertions(+)
+
+diff --git a/include/uapi/linux/bpf.h b/include/uapi/linux/bpf.h
+index 703c6f124..8883598eb 100644
+--- a/include/uapi/linux/bpf.h
++++ b/include/uapi/linux/bpf.h
+@@ -3908,6 +3908,20 @@ union bpf_attr {
+  *		An integer less than, equal to, or greater than zero
+  *		if the first **s1_sz** bytes of **s1** is found to be
+  *		less than, to match, or be greater than **s2**.
++ *
++ * long bpf_parse_header_msg(struct bpf_mem_ptr *msg)
++ * 	Description
++ * 		Parses the content of the msg. User can use `parse_protocol_func`
++ * 		to define the parse function.
++ * 	Return
++ * 		User-defined return value.
++ *
++ * void *bpf_get_msg_header_element(void *name)
++ * 	Description
++ * 		Reads the content of the parsed msg. User can use
++ * 		`get_protocol_element_func` to define the content.
++ * 	Return
++ * 		Contains a pointer to the data and the length of the data.
+  */
+ #define __BPF_FUNC_MAPPER(FN)		\
+ 	FN(unspec),			\
+@@ -4085,6 +4099,8 @@ union bpf_attr {
+ 	FN(strnstr),			\
+ 	FN(strnlen),			\
+ 	FN(_strncmp),			\
++	FN(parse_header_msg),		\
++	FN(get_msg_header_element),	\
+ 	/* */
+ 
+ /* integer value in 'imm' field of BPF_CALL instruction selects which helper
+@@ -5222,6 +5238,11 @@ struct btf_ptr {
+ 	__u32 flags;		/* BTF ptr flags; unused at present. */
+ };
+ 
++struct bpf_mem_ptr {
++	void *ptr;
++	__u32 size;
++};
++
+ /*
+  * Flags to control bpf_snprintf_btf() behaviour.
+  *     - BTF_F_COMPACT: no formatting around type information
+diff --git a/net/core/filter.c b/net/core/filter.c
+index 6a0fdc5ce..ee9aa48d3 100644
+--- a/net/core/filter.c
++++ b/net/core/filter.c
+@@ -6991,6 +6991,42 @@ static const struct bpf_func_proto bpf_sock_ops_reserve_hdr_opt_proto = {
+ 	.arg3_type	= ARG_ANYTHING,
+ };
+ 
++typedef int (*bpf_parse_protocol_func)(struct bpf_mem_ptr* msg);
++bpf_parse_protocol_func parse_protocol_func = NULL;
++EXPORT_SYMBOL(parse_protocol_func);
++
++typedef void* (*bpf_get_protocol_element_func)(char *key);
++bpf_get_protocol_element_func get_protocol_element_func = NULL;
++EXPORT_SYMBOL(get_protocol_element_func);
++
++BPF_CALL_1(bpf_parse_header_msg, struct bpf_mem_ptr *, msg)
++{
++	if (!parse_protocol_func)
++		return -ENOTSUPP;
++	return parse_protocol_func(msg);
++}
++
++static const struct bpf_func_proto bpf_parse_header_msg_proto = {
++	.func		= bpf_parse_header_msg,
++	.gpl_only	= false,
++	.ret_type	= RET_INTEGER,
++	.arg1_type	= ARG_ANYTHING,
++};
++
++BPF_CALL_1(bpf_get_msg_header_element, char *, key)
++{
++	if (!get_protocol_element_func)
++		return -ENOTSUPP;
++	return get_protocol_element_func(key);
++}
++
++static const struct bpf_func_proto bpf_get_msg_header_element_proto = {
++	.func		= bpf_get_msg_header_element,
++	.gpl_only	= false,
++	.ret_type	= RET_PTR_TO_ALLOC_MEM_OR_NULL,
++	.arg1_type	= ARG_ANYTHING,
++};
++
+ #endif /* CONFIG_INET */
+ 
+ bool bpf_helper_changes_pkt_data(void *func)
+@@ -7419,6 +7455,10 @@ sock_ops_func_proto(enum bpf_func_id func_id, const struct bpf_prog *prog)
+ 		return &bpf_sock_ops_reserve_hdr_opt_proto;
+ 	case BPF_FUNC_tcp_sock:
+ 		return &bpf_tcp_sock_proto;
++	case BPF_FUNC_parse_header_msg:
++		return &bpf_parse_header_msg_proto;
++	case BPF_FUNC_get_msg_header_element:
++		return &bpf_get_msg_header_element_proto;
+ #endif /* CONFIG_INET */
+ 	case BPF_FUNC_is_local_ipaddr:
+ 		return &bpf_is_local_ipaddr_proto;
+diff --git a/scripts/bpf_helpers_doc.py b/scripts/bpf_helpers_doc.py
+index fc51d6f0d..74cc376b0 100755
+--- a/scripts/bpf_helpers_doc.py
++++ b/scripts/bpf_helpers_doc.py
+@@ -496,6 +496,7 @@ class PrinterHelpers(Printer):
+             'struct cpumask_op_args',
+             'struct sched_migrate_ctx',
+             'struct sched_affine_ctx',
++            'struct bpf_mem_ptr',
+     }
+     mapped_types = {
+             'u8': '__u8',
+diff --git a/tools/include/uapi/linux/bpf.h b/tools/include/uapi/linux/bpf.h
+index 703c6f124..8883598eb 100644
+--- a/tools/include/uapi/linux/bpf.h
++++ b/tools/include/uapi/linux/bpf.h
+@@ -3908,6 +3908,20 @@ union bpf_attr {
+  *		An integer less than, equal to, or greater than zero
+  *		if the first **s1_sz** bytes of **s1** is found to be
+  *		less than, to match, or be greater than **s2**.
++ *
++ * long bpf_parse_header_msg(struct bpf_mem_ptr *msg)
++ * 	Description
++ * 		Parses the content of the msg. User can use `parse_protocol_func`
++ * 		to define the parse function.
++ * 	Return
++ * 		User-defined return value.
++ *
++ * void *bpf_get_msg_header_element(void *name)
++ * 	Description
++ * 		Reads the content of the parsed msg. User can use
++ * 		`get_protocol_element_func` to define the content.
++ * 	Return
++ * 		Contains a pointer to the data and the length of the data.
+  */
+ #define __BPF_FUNC_MAPPER(FN)		\
+ 	FN(unspec),			\
+@@ -4085,6 +4099,8 @@ union bpf_attr {
+ 	FN(strnstr),			\
+ 	FN(strnlen),			\
+ 	FN(_strncmp),			\
++	FN(parse_header_msg),		\
++	FN(get_msg_header_element),	\
+ 	/* */
+ 
+ /* integer value in 'imm' field of BPF_CALL instruction selects which helper
+@@ -5222,6 +5238,11 @@ struct btf_ptr {
+ 	__u32 flags;		/* BTF ptr flags; unused at present. */
+ };
+ 
++struct bpf_mem_ptr {
++	void *ptr;
++	__u32 size;
++};
++
+ /*
+  * Flags to control bpf_snprintf_btf() behaviour.
+  *     - BTF_F_COMPACT: no formatting around type information
+-- 
+2.33.0
+


### PR DESCRIPTION
Compared to the previous implementation of kmesh on oe2203, the kernel side implementation of kmesh has been adjusted to use ULP framework and the replylong parameter has been used，etc. so,we need update kernel patches.