### PR TITLE
support tcp proxy independent without kernel enhanced

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,11 @@ all:
 	
 	$(call printlog, BUILD, $(APPS1))
 	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-		$(GO) build -o $(APPS1) $(GOFLAGS) ./daemon/main.go)
+		$(GO) build -tags $(ENHANCED_KERNEL) -o $(APPS1) $(GOFLAGS) ./daemon/main.go)
 	
 	$(call printlog, BUILD, $(APPS2))
 	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-		$(GO) build -o $(APPS2) $(GOFLAGS) ./cmd/main.go)
+		$(GO) build -tags $(ENHANCED_KERNEL) -o $(APPS2) $(GOFLAGS) ./cmd/main.go)
 	
 	$(call printlog, BUILD, "kernel")
 	$(QUIET) make -C kernel/ko_src

--- a/bpf/include/common.h
+++ b/bpf/include/common.h
@@ -25,11 +25,14 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <linux/bpf.h>
-#include <bpf_helper_defs_ext.h>
 #include <bpf/bpf_helpers.h>
 #include <bpf/bpf_endian.h>
 
 #include "errno.h"
+
+#if ENHANCED_KERNEL
+#include <bpf_helper_defs_ext.h>
+#endif
 
 #define bpf_unused __attribute__((__unused__))
 

--- a/bpf/kmesh/cgroup_sock.c
+++ b/bpf/kmesh/cgroup_sock.c
@@ -49,7 +49,7 @@ static inline int sock4_traffic_control(struct bpf_sock_addr *ctx)
 	}
 	BPF_LOG(DEBUG, KMESH, "bpf find listener addr=[%u:%u]\n", ctx->user_ip4, ctx->user_port);
 
-#if KMESH_ENABLE_HTTP
+#if ENHANCED_KERNEL
 	// todo build when kernel support http parse and route
 	// defer conn
 	ret = bpf_setsockopt(ctx, IPPROTO_TCP, TCP_ULP, (void *)kmesh_module_name, sizeof(kmesh_module_name));

--- a/config/kmesh_marcos_def.h
+++ b/config/kmesh_marcos_def.h
@@ -68,3 +68,10 @@
  * the corresponding scenarios.
  */
 #define ITER_TYPE_IS_UBUF   0
+
+/*
+ * Kmesh’s Layer 7 acceleration proxy capability relies on kernel enhancements.
+ * It’s necessary to determine whether the current environment has an
+ * enhanced kernel in order to enable Kmesh’s capabilities.
+ */
+#define ENHANCED_KERNEL	0

--- a/kernel/ko_src/Makefile
+++ b/kernel/ko_src/Makefile
@@ -3,7 +3,7 @@ DIRS := $(shell find $(CURRENT_PATH) -maxdepth 1 -type d)
 BASE_DIRS := $(basename $(patsubst $(CURRENT_PATH)/%, %, $(DIRS)))
 BASE_DIRS := $(filter-out $(CURRENT_PATH), $(BASE_DIRS))
 
-
+ifeq ($(ENHANCED_KERNEL), enhanced)
 all:
 	@for dir in ${BASE_DIRS}; do 	\
 		make -C $(CURRENT_PATH)/$$dir;	\
@@ -24,3 +24,13 @@ clean:
 	@for dir in ${BASE_DIRS}; do 	\
 		make -C $(CURRENT_PATH)/$$dir clean > /dev/null 2>&1||exit; done
 	@rm -rf ../ko/*
+else
+all:
+
+install:
+
+uninstall:
+
+clean:
+
+endif

--- a/kmesh_macros_env.sh
+++ b/kmesh_macros_env.sh
@@ -14,6 +14,7 @@ function set_config_oe2303() {
     set_config MDA_PORT_OFFSET 0
     set_config OE_23_03 1
     set_config ITER_TYPE_IS_UBUF 1
+    set_config ENHANCED_KERNEL 1
 }
 
 function set_config_all_disabled() {
@@ -23,6 +24,7 @@ function set_config_all_disabled() {
     set_config MDA_PORT_OFFSET 1
     set_config OE_23_03 0
     set_config ITER_TYPE_IS_UBUF 0
+    set_config ENHANCED_KERNEL 0
 }
 
 function set_kmesh_env_config() {

--- a/pkg/bpf/bpf_kmesh_common.go
+++ b/pkg/bpf/bpf_kmesh_common.go
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2023 The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+
+ * Author: lec-bit
+ * Create: 2023-11-02
+ */
+
+package bpf
+
+// #cgo pkg-config: bpf api-v2-c
+// #include "kmesh/include/kmesh_common.h"
+import "C"
+import (
+	"os"
+	"reflect"
+	"syscall"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	"oncn.io/mesh/bpf/kmesh/bpf2go"
+)
+
+var KMESH_TAIL_CALL_LISTENER = uint32(C.KMESH_TAIL_CALL_LISTENER)
+var KMESH_TAIL_CALL_FILTER_CHAIN = uint32(C.KMESH_TAIL_CALL_FILTER_CHAIN)
+var KMESH_TAIL_CALL_FILTER = uint32(C.KMESH_TAIL_CALL_FILTER)
+var KMESH_TAIL_CALL_ROUTER = uint32(C.KMESH_TAIL_CALL_ROUTER)
+var KMESH_TAIL_CALL_CLUSTER = uint32(C.KMESH_TAIL_CALL_CLUSTER)
+var KMESH_TAIL_CALL_ROUTER_CONFIG = uint32(C.KMESH_TAIL_CALL_ROUTER_CONFIG)
+var BPF_INNER_MAP_DATA_LEN = uint32(C.BPF_INNER_MAP_DATA_LEN)
+
+type BpfSockConn struct {
+	Info BpfInfo
+	Link link.Link
+	bpf2go.KmeshCgroupSockObjects
+}
+
+func (sc *BpfSockConn) NewBpf(cfg *Config) error {
+	sc.Info.Config = *cfg
+	sc.Info.MapPath = sc.Info.BpfFsPath + "/bpf_kmesh/map/"
+	sc.Info.BpfFsPath += "/bpf_kmesh/sockconn/"
+
+	if err := os.MkdirAll(sc.Info.MapPath,
+		syscall.S_IRUSR|syscall.S_IWUSR|syscall.S_IXUSR|
+			syscall.S_IRGRP|syscall.S_IXGRP); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	if err := os.MkdirAll(sc.Info.BpfFsPath,
+		syscall.S_IRUSR|syscall.S_IWUSR|syscall.S_IXUSR|
+			syscall.S_IRGRP|syscall.S_IXGRP); err != nil && !os.IsExist(err) {
+		return err
+	}
+
+	return nil
+}
+
+func SetInnerMap(spec *ebpf.CollectionSpec) {
+	var (
+		InnerMapKeySize    uint32 = 4
+		InnerMapDataLength uint32 = BPF_INNER_MAP_DATA_LEN
+		InnerMapMaxEntries uint32 = 1
+	)
+	for _, v := range spec.Maps {
+		if v.Name == "outer_map" {
+			v.InnerMap = &ebpf.MapSpec{
+				Type:       ebpf.Array,
+				KeySize:    InnerMapKeySize,
+				ValueSize:  InnerMapDataLength, // C.BPF_INNER_MAP_DATA_LEN
+				MaxEntries: InnerMapMaxEntries,
+			}
+		}
+	}
+}
+
+func (sc *BpfSockConn) loadKmeshSockConnObjects() (*ebpf.CollectionSpec, error) {
+	var (
+		err  error
+		spec *ebpf.CollectionSpec
+		opts ebpf.CollectionOptions
+	)
+	opts.Maps.PinPath = sc.Info.MapPath
+	opts.Programs.LogSize = sc.Info.BpfVerifyLogSize
+
+	spec, err = bpf2go.LoadKmeshCgroupSock()
+
+	if err != nil || spec == nil {
+		return nil, err
+	}
+
+	SetInnerMap(spec)
+	setMapPinType(spec, ebpf.PinByName)
+	if err = spec.LoadAndAssign(&sc.KmeshCgroupSockObjects, &opts); err != nil {
+		return nil, err
+	}
+
+	value := reflect.ValueOf(sc.KmeshCgroupSockObjects.KmeshCgroupSockPrograms)
+	if err = pinPrograms(&value, sc.Info.BpfFsPath); err != nil {
+		return nil, err
+	}
+
+	return spec, nil
+}
+
+func (sc *BpfSockConn) LoadSockConn() error {
+	/* load kmesh sockops main bpf prog */
+	spec, err := sc.loadKmeshSockConnObjects()
+	if err != nil {
+		return err
+	}
+
+	prog := spec.Programs["cgroup_connect4_prog"]
+	sc.Info.Type = prog.Type
+	sc.Info.AttachType = prog.AttachType
+
+	// update tail call prog
+	err = sc.KmeshTailCallProg.Update(
+		uint32(KMESH_TAIL_CALL_FILTER_CHAIN),
+		uint32(sc.FilterChainManager.FD()),
+		ebpf.UpdateAny)
+	if err != nil {
+		return err
+	}
+
+	err = sc.KmeshTailCallProg.Update(
+		uint32(KMESH_TAIL_CALL_FILTER),
+		uint32(sc.FilterManager.FD()),
+		ebpf.UpdateAny)
+	if err != nil {
+		return err
+	}
+
+	err = sc.KmeshTailCallProg.Update(
+		uint32(KMESH_TAIL_CALL_CLUSTER),
+		uint32(sc.ClusterManager.FD()),
+		ebpf.UpdateAny)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (sc *BpfSockConn) close() error {
+	if err := sc.KmeshCgroupSockObjects.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sc *BpfSockConn) Attach() error {
+	cgopt := link.CgroupOptions{
+		Path:    sc.Info.Cgroup2Path,
+		Attach:  sc.Info.AttachType,
+		Program: sc.KmeshCgroupSockObjects.CgroupConnect4Prog,
+	}
+
+	lk, err := link.AttachCgroup(cgopt)
+	if err != nil {
+		return err
+	}
+	sc.Link = lk
+
+	return nil
+}
+
+func (sc *BpfSockConn) Detach() error {
+	var value reflect.Value
+
+	if err := sc.close(); err != nil {
+		return err
+	}
+
+	value = reflect.ValueOf(sc.KmeshCgroupSockObjects.KmeshCgroupSockPrograms)
+	if err := unpinPrograms(&value); err != nil {
+		return err
+	}
+	value = reflect.ValueOf(sc.KmeshCgroupSockObjects.KmeshCgroupSockMaps)
+	if err := unpinMaps(&value); err != nil {
+		return err
+	}
+
+	if err := os.RemoveAll(sc.Info.BpfFsPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	if sc.Link != nil {
+		return sc.Link.Close()
+	}
+	return nil
+}
+
+

--- a/pkg/bpf/bpf_kmesh_l4.go
+++ b/pkg/bpf/bpf_kmesh_l4.go
@@ -1,0 +1,124 @@
+// +build !enhanced
+
+/*
+ * Copyright 2023 The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+
+ * Author: lec-bit
+ * Create: 2023-11-02
+ */
+
+package bpf
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/cilium/ebpf"
+)
+
+type BpfKmesh struct {
+	SockConn BpfSockConn
+}
+
+func NewBpfKmesh(cfg *Config) (BpfKmesh, error) {
+	var err error
+
+	sc := BpfKmesh{}
+
+	if err = sc.SockConn.NewBpf(cfg); err != nil {
+		return sc, err
+	}
+	return sc, nil
+}
+
+func (sc *BpfKmesh) Load() error {
+	var err error
+
+	if err = sc.SockConn.LoadSockConn(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (sc *BpfKmesh) ApiEnvCfg() error {
+	var err error
+	var info *ebpf.MapInfo
+	var id ebpf.MapID
+
+	info, err = Obj.Kmesh.SockConn.KmeshCgroupSockMaps.KmeshListener.Info()
+
+	if err != nil {
+		return err
+	}
+
+	id, _ = info.ID()
+	stringId := strconv.Itoa(int(id))
+	if err = os.Setenv("Listener", stringId); err != nil {
+		return err
+	}
+
+	info, _ = Obj.Kmesh.SockConn.KmeshCgroupSockMaps.OuterMap.Info()
+	id, _ = info.ID()
+	stringId = strconv.Itoa(int(id))
+	if err = os.Setenv("OUTTER_MAP_ID", stringId); err != nil {
+		return err
+	}
+
+	info, _ = Obj.Kmesh.SockConn.KmeshCgroupSockMaps.InnerMap.Info()
+	id, _ = info.ID()
+	stringId = strconv.Itoa(int(id))
+	if err = os.Setenv("INNER_MAP_ID", stringId); err != nil {
+		return err
+	}
+
+	info, _ = Obj.Kmesh.SockConn.KmeshCluster.Info()
+	id, _ = info.ID()
+	stringId = strconv.Itoa(int(id))
+	if err = os.Setenv("Cluster", stringId); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sc *BpfKmesh) Attach() error {
+	var err error
+
+	if err = sc.SockConn.Attach(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (sc *BpfKmesh) close() error {
+	var err error
+
+	if err = sc.SockConn.close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (sc *BpfKmesh) Detach() error {
+	var err error
+
+	if err = sc.SockConn.Detach(); err != nil {
+		return err
+	}
+	return nil
+}
+


### PR DESCRIPTION
A new compilation macro, ISKERNEL_ENHANCED, has been introduced to determine whether the current running environment is an enhanced kernel.

On an enhanced kernel, all capabilities of kmesh are supported. On a non-enhanced kernel, only the L4 proxy capability of kmesh is supported.

To implement these capabilities, the following modifications have been made to the code:

1、Code that cannot be compiled or run due to kernel dependencies is included using compilation macros. For Go code, file-level conditional compilation is used. A new file bpf_kmesh_l4.go has been added, which is derived from the bpf_kmesh.go file by removing the parts of the code that depend on the enhanced kernel. add bpf_kmesh_common.go，it is L4 common function.

2、The compilation script does not compile or load kmesh.ko.

3、Custom functions are used to replace the structures and bpf_helper functions provided by the enhanced kernel. 
              The structure bpf_mem_ptr and the functions bpf_strncmp, bpf_strncpy are replaced with custom implementations.