### PR TITLE
fix the issue of failure to update bpf map data in Ubuntu environment

### DIFF
--- a/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.c
+++ b/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.c
@@ -676,7 +676,7 @@ int deserial_update_elem(void *key, void *value)
 	const char *map_name = NULL;
 	struct op_context context = {.inner_map_object = NULL};
 	const ProtobufCMessageDescriptor *desc;
-	struct bpf_map_info outter_info, inner_info, info;
+	struct bpf_map_info outter_info = {0}, inner_info = {0}, info = {0};
 	int map_fd, outter_fd = 0, inner_fd = 0;
 	unsigned int id, outter_id = 0, inner_id = 0;
 
@@ -972,7 +972,7 @@ void* deserial_lookup_elem(void *key, const void *msg_desciptor)
 	const char *map_name = NULL;
 	struct op_context context = {.inner_map_object = NULL};
 	const ProtobufCMessageDescriptor *desc;
-	struct bpf_map_info outter_info, inner_info, info;
+	struct bpf_map_info outter_info = {0}, inner_info = {0}, info = {0};
 	int map_fd, outter_fd = 0, inner_fd = 0;
 	unsigned int id, outter_id = 0, inner_id = 0;
 
@@ -1240,7 +1240,7 @@ int deserial_delete_elem(void *key, const void *msg_desciptor)
 	const char *map_name = NULL;
 	struct op_context context = {.inner_map_object = NULL};
 	const ProtobufCMessageDescriptor *desc;
-	struct bpf_map_info outter_info, inner_info, info;
+	struct bpf_map_info outter_info = {0}, inner_info = {0}, info = {0};
 	int map_fd, outter_fd = 0, inner_fd = 0;
 	unsigned int id, outter_id = 0, inner_id = 0;
 	char *inner_map_object = NULL;


### PR DESCRIPTION
In the Ubuntu environment, a message is displayed indicating that the map data fails to be updated during the Kmesh test in the Istio cluster deployed using Kind.
![image](https://github.com/kmesh-net/kmesh/assets/85690076/5c11e2ac-c1d9-44ab-8949-9712631024a9)

Reason:
1. When the xds configuration is converted to bpf map data, the deserial_update_elem-> get_map_fd_info -> bpf_obj_get_info_by_fd returns - 1 and errno is - 7.
2. Trace the bpf_obj_get_info_by_fd system call. If the value of bpf_obj_get_info_by_fd-> bpf_map_get_info_by_fd -> bpf_check_uarg_tail_zero -> check_zeroed_user is not 0, an error is reported when the input parameter buffer is not all 0s.
Analyze the invoking point. It is found that the input variable struct bpf_map_info is not initialized.

Modification scheme:
The code is checked and variable initialization is performed in a unified manner.