### PR TITLE
fix ubuntu  environments compile errors

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,10 +21,11 @@ function set_enhanced_kernel_env() {
 }
 
 function prepare() {
-    sh kmesh_macros_env.sh
-    sh kmesh_bpf_env.sh
+    bash kmesh_macros_env.sh
+    bash kmesh_bpf_env.sh
     if [ "$(arch)" == "x86_64" ]; then
             export EXTRA_CDEFINE="-D__x86_64__"
+	    export C_INCLUDE_PATH=/usr/include/x86_64-linux-gnu:$C_INCLUDE_PATH
     fi
 
     export EXTRA_GOFLAGS="-gcflags=\"-N -l\""


### PR DESCRIPTION
1、In Ubnutu the default shell (sh) for executing scripts is not bash, enforce it to be bash. 
2、In Ubuntu ，files for the x86_64 architecture such as asm are located in the /usr/include/x86_64-linux-gnu directory, add it to the default include directory for C.