### PR TITLE
kmesh marcos optimization

### DIFF
--- a/config/kmesh_marcos_def.h
+++ b/config/kmesh_marcos_def.h
@@ -37,18 +37,6 @@
 */
 #define MDA_GID_UID_FILTER	1
 
-/* In the kernel network protocol stack, the port is stored in u16, 
- * but in the bpf network module, the port is stored in u32. Therefore, 
- * after the endian conversion, the 16-bit port needs to be obtained from 
- * the 32-bit data structure. You need to find the position of the valid 
- * 16 bits. Generally, after the port is extended from 16 bits to 32 bits, 
- * the port is in the upper 16 bits after the endian conversion. 
- * Therefore, you need to offset the port before using the u16 RX port.
- * In some specific kernels, the port stored in sockops is in the lower 
- * 16 bits and does not need to be offset.
- */
-#define MDA_PORT_OFFSET		1
-
 /*
  * openEuler-23.03 is an innovative version of openEuler, in the early time, we
  * developed kmesh based on openEuler-23.03, and the implementation of kmesh was
@@ -59,7 +47,16 @@
  * openEuler-23.03 version are as follows:
  * 1. Use replylong parameter instead of directly modifying the remote IP and Port;
  * 2. Use bpf__strncmp instead of bpf_strncmp for string comparison;
- * 3. Fix Port shift bug on openEuler-23.03.
+ * 3. Fix Port shift bug on openEuler-23.03.In the kernel network protocol
+ *    stack, the port is stored in u16, but in the bpf network module, 
+ *    the port is stored in u32. Therefore, after the endian conversion, 
+ *    the 16-bit port needs to be obtained from the 32-bit data structure. 
+ *    You need to find the position of the valid 16 bits. Generally, 
+ *    after the port is extended from 16 bits to 32 bits, the port is in 
+ *    the upper 16 bits after the endian conversion. Therefore, you need
+ *    to offset the port before using the u16 RX port. In some specific 
+ *    kernels, the port stored in sockops is in the lower 16 bits and does 
+ *    not need to be offset.
  */
 #define OE_23_03            0
 

--- a/kmesh_macros_env.sh
+++ b/kmesh_macros_env.sh
@@ -1,39 +1,50 @@
 #!/bin/bash
   
-VERSION=$(uname -r | cut -d '.' -f 1,2)
-OE_VERSION=$(uname -r | grep -o 'oe[^.]*')
+VERSION=$(uname -r | cut -d '.' -f 1)
+OE_VERSION=$(cat /etc/openEuler-release | awk '{print $3}')
 
 function set_config() {
     sed -i -r -e "s/($1)([ \t]*)([0-9]+)/\1\2$2/" config/kmesh_marcos_def.h
 }
 
-function set_config_oe2303() {
-    set_config MDA_LOOPBACK_ADDR 1
-    set_config MDA_NAT_ACCEL 0
-    set_config MDA_GID_UID_FILTER 0
-    set_config MDA_PORT_OFFSET 0
-    set_config OE_23_03 1
-    set_config ITER_TYPE_IS_UBUF 1
-    set_config ENHANCED_KERNEL 1
-}
+# MDA_LOOPBACK_ADDR
+if grep "FN(get_netns_cookie)" /usr/include/linux/bpf.h; then
+	set_config MDA_LOOPBACK_ADDR 1
+else
+	set_config MDA_LOOPBACK_ADDR 0
+fi
 
-function set_config_all_disabled() {
-    set_config MDA_LOOPBACK_ADDR 0
-    set_config MDA_NAT_ACCEL 0
-    set_config MDA_GID_UID_FILTER 0
-    set_config MDA_PORT_OFFSET 1
-    set_config OE_23_03 0
-    set_config ITER_TYPE_IS_UBUF 0
-    set_config ENHANCED_KERNEL 0
-}
+# MDA_NAT_ACCEL
+if grep "FN(sk_original_addr)" /usr/include/linux/bpf.h; then
+	set_config MDA_NAT_ACCEL 1
+else
+	set_config MDA_NAT_ACCEL 0
+fi
 
-function set_kmesh_env_config() {
+# MDA_GID_UID_FILTER
+if grep "FN(get_sockops_uid_gid)" /usr/include/linux/bpf.h; then
+	set_config MDA_GID_UID_FILTER 1
+else
+	set_config MDA_GID_UID_FILTER 0
+fi
 
-   # openEuler 2303
-    if [ "$OE_VERSION" == "oe2303" ]; then
-            set_config_oe2303
-    else
-            set_config_all_disabled
-    fi
-}
-set_kmesh_env_config
+# OE_23_03
+if [ "$OE_VERSION" == "23.03" ]; then
+	set_config OE_23_03 1
+else
+	set_config OE_23_03 0
+fi
+
+# ITER_TYPE_IS_UBUF
+if [ "$VERSION" -ge 6 ]; then
+	set_config ITER_TYPE_IS_UBUF 1
+else
+	set_config ITER_TYPE_IS_UBUF 0
+fi
+
+# ENHANCED_KERNEL
+if grep "FN(parse_header_msg)" /usr/include/linux/bpf.h; then
+	set_config ENHANCED_KERNEL 1
+else
+	set_config ENHANCED_KERNEL 0
+fi

--- a/oncn-mda/ebpf_src/sock_ops.c
+++ b/oncn-mda/ebpf_src/sock_ops.c
@@ -230,7 +230,7 @@ static void extract_key4_from_ops(struct bpf_sock_ops* const ops, struct sock_ke
 	key->sport = (bpf_htonl(ops->local_port) >> FORMAT_IP_LENGTH);
 	key->dip4 = ops->remote_ip4;
 
-#if MDA_PORT_OFFSET
+#if !OE_23_03
 	key->dport = (force_read(ops->remote_port) >> FORMAT_IP_LENGTH);
 #else	
 	key->dport = (force_read(ops->remote_port));


### PR DESCRIPTION
1、Merge duplicate semantic macro definitions.
2、Optimize the logic of the macro build script. Determine the feature capabilities supported by the current environment during compilation, and then set the values of the macros accordingly.