### PR TITLE
fix can't load BPF from ELF

### DIFF
--- a/bpf/kmesh/include/kmesh_common.h
+++ b/bpf/kmesh/include/kmesh_common.h
@@ -61,7 +61,7 @@ static inline int bpf__strncmp (char *dst, int n, const char *src) {
 	for (int i = 0; i < BPF_DATA_MAX_LEN; i++) {
 		if (dst[i] != src[i])
 			return dst[i] - src[i];
-		else if (dst[i] == '\0' || i >= n - 1)
+		else if (dst[i] == '\0' || i == n - 1)
 			return 0;
 	}
 	return 0;
@@ -80,7 +80,7 @@ static inline char *bpf_strncpy(char *dst, int n, const char *src) {
 			dst[i] = '\0';
 		else
 			dst[i] = src[i];
-		if (i >= n - 1)
+		if (i == n - 1)
 			break;
 	}
 	return dst;


### PR DESCRIPTION
in  unenhanced kernel 5.10, build reports the following error
Compiled /root/zmy/github/1103/kmesh/bpf/kmesh/bpf2go/kmeshcgroupsock_bpfel.o
Stripped /root/zmy/github/1103/kmesh/bpf/kmesh/bpf2go/kmeshcgroupsock_bpfel.o
Error: can't write /root/zmy/github/1103/kmesh/bpf/kmesh/bpf2go/kmeshcgroupsock_bpfel.go: can't load BPF from ELF: section "cgroup/connect4": string is not stack allocated: not supported
exit status 1
bpf/kmesh/bpf2go/bpf2go.go:24: running "go": exit status 1
make: *** [Makefile:39: all] Error 1

Some syntax is not supported in this kernel version, modify the syntax.
