### PR TITLE
Optimize the code for invoking the tail-call prog command and unify the return value of the bpf prog command.

### DIFF
--- a/bpf/kmesh/include/cluster.h
+++ b/bpf/kmesh/include/cluster.h
@@ -314,20 +314,18 @@ int cluster_manager(ctx_buff_t *ctx)
 
 	DECLARE_VAR_ADDRESS(ctx, addr);
 
-	ctx_key.address = addr;
-	ctx_key.tail_call_index = KMESH_TAIL_CALL_CLUSTER + bpf_get_current_task();
-
+	KMESH_TAIL_CALL_CTX_KEY(ctx_key, KMESH_TAIL_CALL_CLUSTER, addr);
 	ctx_val = kmesh_tail_lookup_ctx(&ctx_key);
 	if (ctx_val == NULL)
-		return convert_sock_errno(ENOENT);
+		return KMESH_TAIL_CALL_RET(ENOENT);
 
 	cluster = map_lookup_cluster(ctx_val->data);
 	kmesh_tail_delete_ctx(&ctx_key);
 	if (cluster == NULL)
-		return convert_sock_errno(ENOENT);
+		return KMESH_TAIL_CALL_RET(ENOENT);
 
 	ret = cluster_handle_loadbalance(cluster, &addr, ctx);
-	return convert_sock_errno(ret);
+	return KMESH_TAIL_CALL_RET(ret);
 }
 
 #endif

--- a/bpf/kmesh/include/kmesh_common.h
+++ b/bpf/kmesh/include/kmesh_common.h
@@ -39,6 +39,7 @@
 							   small that make compile success */
 #define BPF_INNER_MAP_DATA_LEN	  1300
 
+#define BPF_OK						1
 
 #define _(P)								   \
 	({										 \
@@ -134,16 +135,6 @@ enum kmesh_l7_msg_type {
 #define KMESH_PROTO_TYPE_WIDTH (8)
 #define GET_RET_PROTO_TYPE(n) ((n) & 0xff)
 #define GET_RET_MSG_TYPE(n) (((n) >> KMESH_PROTO_TYPE_WIDTH) & 0xff)
-
-static inline int convert_sock_errno(int err)
-{
-	return err == 0 ? CGROUP_SOCK_OK : CGROUP_SOCK_ERR;
-}
-
-static inline int convert_sockops_ret(int err)
-{
-	return 0;
-}
 
 static inline void *kmesh_get_ptr_val(const void *ptr)
 {

--- a/bpf/kmesh/include/listener.h
+++ b/bpf/kmesh/include/listener.h
@@ -125,20 +125,10 @@ static inline int listener_manager(ctx_buff_t *ctx, Listener__Listener *listener
 	}
 	
 	/* exec filter chain */
-	ctx_key.address = addr;
-	ctx_key.tail_call_index = KMESH_TAIL_CALL_FILTER_CHAIN + bpf_get_current_task();
-	ctx_val.val = filter_chain_idx;
-	ctx_val.msg = msg;
-	ret = kmesh_tail_update_ctx(&ctx_key, &ctx_val);
-	if (ret != 0) {
-		BPF_LOG(ERR, LISTENER, "kmesh tail update failed:%d\n", ret);
-		return ret;
-	}
+	KMESH_TAIL_CALL_CTX_KEY(ctx_key, KMESH_TAIL_CALL_FILTER_CHAIN, addr);
+	KMESH_TAIL_CALL_CTX_VAL(ctx_val, msg, filter_chain_idx);
 
-	kmesh_tail_call(ctx, KMESH_TAIL_CALL_FILTER_CHAIN);
-	(void)kmesh_tail_delete_ctx(&ctx_key);
-
-	BPF_LOG(ERR, LISTENER, "listener_manager exit\n");
-	return ret;
+	KMESH_TAIL_CALL_WITH_CTX(KMESH_TAIL_CALL_FILTER_CHAIN, ctx_key, ctx_val);
+	return KMESH_TAIL_CALL_RET(ret);
 }
 #endif

--- a/bpf/kmesh/sockops.c
+++ b/bpf/kmesh/sockops.c
@@ -62,14 +62,14 @@ int sockops_prog(struct bpf_sock_ops *skops)
 	struct bpf_mem_ptr *msg = NULL;
 
 	if (skops->family != AF_INET)
-		return 0;
+		return BPF_OK;
 
 	switch (skops->op) {
 		case BPF_SOCK_OPS_TCP_DEFER_CONNECT_CB:
 			msg = (struct bpf_mem_ptr *)BPF_CONSTRUCT_PTR(skops->args[0], skops->args[1]);
 			(void)sockops_traffic_control(skops, msg);
 	}
-	return 0;
+	return BPF_OK;
 }
 
 #endif


### PR DESCRIPTION
Optimize the code for invoking the tail-call prog command and unify the return value of the bpf prog command.
1. When the tail-call prog is invoked, the context information needs to be prepared. The macro is encapsulated to prepare the context key and value, and the context update/delete and tail call invoking are encapsulated into a macro to avoid CTX map leakage.
2. The BPF_OK macro is encapsulated.
3. The Kmesh is a data plane acceleration program. When the traffic governance logic fails to be executed, the original forwarding process should be downgraded, and the bpf prog should always return a success message.