### PR TITLE
Rectify false positives in L4 test cases

### DIFF
--- a/test/testcases/kmesh/libs/common.sh
+++ b/test/testcases/kmesh/libs/common.sh
@@ -14,7 +14,9 @@ function env_init()
 
     insmod /lib/modules/kmesh/kmesh.ko
     lsmod | grep kmesh
-    CHECK_RESULT $? 0 0 "insmod kmesh.ko failed"
+    if [ $? -ne 0 ]; then
+        echo "insmod kmesh.ko failed"
+    fi
 }
 
 # start fortio server


### PR DESCRIPTION
After the Kmesh supports multi-OS version compilation, the Kmesh compiled in the non-enhanced OS environment does not contain the ko file (used in the L7 governance scenario). The mini-test cases related to L4 traffic governance do not need to check whether the ko file is successfully loaded.