### PR TITLE
BPF_F_NO_PREALLOC flag is specified during map declaration

### DIFF
--- a/bpf/kmesh/include/cluster.h
+++ b/bpf/kmesh/include/cluster.h
@@ -32,7 +32,7 @@ struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
 	__uint(key_size, CLUSTER_NAME_MAX_LEN);
 	__uint(value_size, sizeof(Cluster__Cluster));
-	__uint(map_flags, 0);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
 	__uint(max_entries, MAP_SIZE_OF_CLUSTER);
 } map_of_cluster SEC(".maps");
 
@@ -53,7 +53,7 @@ struct {
 	__uint(key_size, CLUSTER_NAME_MAX_LEN);
 	__uint(value_size, sizeof(struct cluster_endpoints));
 	__uint(max_entries, MAP_SIZE_OF_ENDPOINT);
-	__uint(map_flags, 0);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
 } map_of_cluster_eps SEC(".maps");
 
 struct {

--- a/bpf/kmesh/include/listener.h
+++ b/bpf/kmesh/include/listener.h
@@ -28,7 +28,7 @@ struct {
 	__uint(key_size, sizeof(address_t));
 	__uint(value_size, sizeof(Listener__Listener));
 	__uint(max_entries, MAP_SIZE_OF_LISTENER);
-	__uint(map_flags, 0);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
 } map_of_listener SEC(".maps");
 
 static inline Listener__Listener *map_lookup_listener(const address_t *addr)

--- a/bpf/kmesh/include/route_config.h
+++ b/bpf/kmesh/include/route_config.h
@@ -31,7 +31,7 @@ struct {
 	__uint(key_size, ROUTER_NAME_MAX_LEN);
 	__uint(value_size, sizeof(Route__RouteConfiguration));
 	__uint(max_entries, MAP_SIZE_OF_ROUTE);
-	__uint(map_flags, 0);
+	__uint(map_flags, BPF_F_NO_PREALLOC);
 } map_of_router_config SEC(".maps");
 
 static inline Route__RouteConfiguration *map_lookup_route_config(const char *route_name)

--- a/bpf/kmesh/include/tail_call.h
+++ b/bpf/kmesh/include/tail_call.h
@@ -59,7 +59,7 @@ struct {
     __uint(key_size, sizeof(ctx_key_t));
     __uint(value_size, sizeof(ctx_val_t));
     __uint(max_entries, MAP_SIZE_OF_TAIL_CALL_CTX);
-    __uint(map_flags, 0);
+    __uint(map_flags, BPF_F_NO_PREALLOC);
 } map_of_tail_call_ctx SEC(".maps");
 
 static inline ctx_val_t *kmesh_tail_lookup_ctx(const ctx_key_t *key)


### PR DESCRIPTION
When defining the bpf map, specify the BPF_F_NO_PREALLOC flag to reduce the Kmesh resource overhead in the case of no load. The test results are as follows:

1. Memory overhead when the Kmesh system is not started:
[root@localhost ~]# cat /proc/meminfo | grep -e Slab -e VmallocUsed -e PageTables -e KernelStack -e HardwareCorrupted -e Bounce
Slab:             142288 kB
KernelStack:        5408 kB
PageTables:         2592 kB
Bounce:                0 kB
VmallocUsed:       53860 kB
HardwareCorrupted:     0 kB

2. If Kmesh is enabled before optimization, the system memory consumption is as follows:
[root@localhost ~]# cat /proc/meminfo | grep -e Slab -e VmallocUsed -e PageTables -e KernelStack -e HardwareCorrupted -e Bounce
Slab:             142580 kB
KernelStack:        5520 kB
PageTables:         2756 kB
Bounce:                0 kB
VmallocUsed:       65196 kB
HardwareCorrupted:     0 kB

3. After the optimization, the system memory consumption is as follows when Kmesh is started:
[root@localhost ~]# cat /proc/meminfo | grep -e Slab -e VmallocUsed -e PageTables -e KernelStack -e HardwareCorrupted -e Bounce
Slab:             141904 kB
KernelStack:        5424 kB
PageTables:         2844 kB
Bounce:                0 kB
VmallocUsed:       54216 kB
HardwareCorrupted:     0 kB