### PR TITLE
mini-test adapt

### DIFF
--- a/test/testcases/kmesh/libs/cni.conflist
+++ b/test/testcases/kmesh/libs/cni.conflist
@@ -1,0 +1,9 @@
+{
+  "cniVersion": "0.0.1",
+  "name": "kmesh",
+  "plugins": [
+    {
+      "type": "kmesh-cni"
+    }
+  ]
+}


### PR DESCRIPTION
due to kmesh multiple dataplane work, we need to adapt kmesh min-test:
add a cni.conflist and adapt test script, add the test script process to the cgroup net_cls and tag with kmesh

fixes https://github.com/kmesh-net/kmesh/issues/56