### PR TITLE
fix :can't obtain cluster config when image start up

### DIFF
--- a/build/docker/kmesh.yaml
+++ b/build/docker/kmesh.yaml
@@ -25,7 +25,10 @@ spec:
              path: /lib/modules
          - name: kube-config-path
            hostPath:
-             path: /root/.kube
+             # location of the k8s config file in the current cluster environment
+             # may vary depending on the method used to create the cluster, 
+             # and needs to be specified by the user
+             path: /root/.kube/config
          # k8s default cni conflist path
          - name: cni 
            hostPath:
@@ -74,7 +77,7 @@ spec:
              mountPath: /lib/modules
              readOnly: false
            - name: kube-config-path
-             mountPath: /root/.kube
+             mountPath: /root/.kube/config
              readOnly: true
            # k8s default cni conflist path
            - name: cni


### PR DESCRIPTION
The location of the config file varies according to the Kubernetes cluster creation mode. 
You need to specify the location of the config file in the cluster environment. 
Kmesh.yaml In this project, the default location of the config file is /root/.kube/config. Most cluster creation methods place files here