### PR TITLE
Donot intercept traffic from sidecar

### DIFF
--- a/cniplugin/main.go
+++ b/cniplugin/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/version"
 
-	"kmesh.net/kmesh/pkg/cni_plg/plugin"
+	"kmesh.net/kmesh/pkg/cni/plugin"
 )
 
 const (

--- a/daemon/manager/manager.go
+++ b/daemon/manager/manager.go
@@ -22,13 +22,13 @@ package manager
 
 import (
 	"fmt"
-	"kmesh.net/kmesh/pkg/cni"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"kmesh.net/kmesh/cmd/command"
 	"kmesh.net/kmesh/pkg/bpf" // nolint
+	"kmesh.net/kmesh/pkg/cni"
 	"kmesh.net/kmesh/pkg/controller"
 	"kmesh.net/kmesh/pkg/logger"
 	"kmesh.net/kmesh/pkg/options"

--- a/daemon/manager/manager.go
+++ b/daemon/manager/manager.go
@@ -22,13 +22,13 @@ package manager
 
 import (
 	"fmt"
+	"kmesh.net/kmesh/pkg/cni"
 	"os"
 	"os/signal"
 	"syscall"
 
 	"kmesh.net/kmesh/cmd/command"
 	"kmesh.net/kmesh/pkg/bpf" // nolint
-	"kmesh.net/kmesh/pkg/cni_plg"
 	"kmesh.net/kmesh/pkg/controller"
 	"kmesh.net/kmesh/pkg/logger"
 	"kmesh.net/kmesh/pkg/options"
@@ -84,12 +84,12 @@ func Execute() {
 		_ = command.StopServer()
 	}()
 
-	if err = cni_plg.Start(); err != nil {
+	if err = cni.Start(); err != nil {
 		log.Error(err)
 		return
 	}
 	log.Info("command Start cni successful")
-	defer cni_plg.Stop()
+	defer cni.Stop()
 
 	setupCloseHandler()
 }

--- a/pkg/cni/chained.go
+++ b/pkg/cni/chained.go
@@ -17,7 +17,7 @@
  * Create: 2023-11-19
  */
 
-package cni_plg
+package cni
 
 import (
 	"encoding/json"

--- a/pkg/cni/config.go
+++ b/pkg/cni/config.go
@@ -17,7 +17,7 @@
  * Create: 2023-11-19
  */
 
-package cni_plg
+package cni
 
 import (
 	"flag"

--- a/pkg/cni/install.go
+++ b/pkg/cni/install.go
@@ -17,14 +17,14 @@
  * Create: 2023-11-19
  */
 
-package cni_plg
+package cni
 
 import (
 	"kmesh.net/kmesh/pkg/bpf" // nolint
 	"kmesh.net/kmesh/pkg/logger"
 )
 
-var log = logger.NewLoggerField("cniplugin")
+var log = logger.NewLoggerField("cni installer")
 
 func addCniConfig() error {
 	var err error
@@ -37,7 +37,7 @@ func addCniConfig() error {
 			return err
 		}
 	} else {
-		log.Error("currently kmesh can not support cni with no chained mode\n")
+		log.Error("currently kmesh only support chained cni mode\n")
 	}
 	return nil
 }

--- a/pkg/cni/kubeconfig.go
+++ b/pkg/cni/kubeconfig.go
@@ -29,7 +29,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-package cni_plg
+package cni
 
 import (
 	"fmt"

--- a/pkg/cni/plugin/plugin.go
+++ b/pkg/cni/plugin/plugin.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	v1 "k8s.io/api/core/v1"
 	"os"
 	"path"
 	"strconv"
@@ -33,6 +32,7 @@ import (
 	"github.com/containernetworking/cni/pkg/types"
 	cniv1 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/cni/pkg/version"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 

--- a/pkg/cni/plugin/plugin.go
+++ b/pkg/cni/plugin/plugin.go
@@ -231,7 +231,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 		return types.PrintResult(preResult, cniConf.CNIVersion)
 	}
 
-	if err := enableKmeshControl(clientSet, podName, podNamespace); err != nil {
+	if err := enableKmeshControl(clientSet, pod); err != nil {
 		log.Error("failed to enable kmesh control")
 		return err
 	}

--- a/pkg/cni/plugin/plugin.go
+++ b/pkg/cni/plugin/plugin.go
@@ -149,7 +149,7 @@ func enableKmeshControl(clientSet *kubernetes.Clientset, pod *v1.Pod) error {
 		annotationPatch,
 		metav1.PatchOptions{},
 	); err != nil {
-		log.Error("failed to annotate kmesh redirection: %v", err)
+		log.Errorf("failed to annotate kmesh redirection: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->
/kind enhancement

**What this PR does / why we need it**:

With this patch, kmesh now donot take charge of traffic from sidecar. Even in case, kmesh and sidecar both simultaneously enabled, we now prioritize sidecar. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
