### PR TITLE
update kmesh start script to exit when kmesh exit

### DIFF
--- a/build/docker/start_kmesh.sh
+++ b/build/docker/start_kmesh.sh
@@ -18,24 +18,24 @@ if [ $? -ne 0 ]; then
 fi
 
 kmesh-daemon $@ &
+pid = $!
 
+# pass SIGTERM to kmesh process
 function stop_kmesh() {
-        pkill kmesh-daemon
+        kill $pid
+}
 
-        lsmod | grep kmesh > /dev/null
-        if [ $? == 0 ]; then
-                rmmod kmesh
-        fi
+function cleanup(){
+          lsmod | grep kmesh > /dev/null
+          if [ $? == 0 ]; then
+                  rmmod kmesh
+          fi
 
-        umount -t cgroup2 /mnt/kmesh_cgroup2/
-        rm -rf /mnt/kmesh_cgroup2
-        rm -rf /sys/fs/bpf/bpf_kmesh
+          umount -t cgroup2 /mnt/kmesh_cgroup2/
+          rm -rf /mnt/kmesh_cgroup2
+          rm -rf /sys/fs/bpf/bpf_kmesh
 }
 
 trap 'stop_kmesh' SIGTERM
-
-while true;
-do
-    sleep 60 &
-    wait $!
-done
+wait # wait child process exit
+cleanup


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

/kind enhancement

**What this PR does / why we need it**:

WIth it, when kmesh daemon exit on error, the pod entrypoint process can exit, so this allows k8s to restart the container.
Otherwise, we can see the kmesh daemon pod is still running.

Long term, i think we can add some liveness probe

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
