### PR TITLE
fix kmesh http parse header bug

### DIFF
--- a/kernel/ko_src/kmesh/kmesh_parse_http_1_1.c
+++ b/kernel/ko_src/kmesh/kmesh_parse_http_1_1.c
@@ -307,7 +307,10 @@ static bool parse_header(struct bpf_mem_ptr *context)
 					continue;
 				field_value_begin_position = i;
 				field_value_end_position = i;
-				current_state = ST_FIELD_VALUE;
+				if (ch == CR)
+					current_state = ST_NEW_LINE;
+				else
+					current_state = ST_FIELD_VALUE;
 				break;
 			case ST_FIELD_VALUE:
 				if (ch != SPACE)

--- a/kernel/ko_src/kmesh/kmesh_parse_http_1_1.c
+++ b/kernel/ko_src/kmesh/kmesh_parse_http_1_1.c
@@ -310,7 +310,7 @@ static bool parse_header(struct bpf_mem_ptr *context)
 				current_state = ST_FIELD_VALUE;
 				break;
 			case ST_FIELD_VALUE:
-				if (ch != SPACE && ch != CR)
+				if (ch != SPACE)
 					field_value_end_position = i;
 
 				if (unlikely(ch == CR))
@@ -331,12 +331,12 @@ static bool parse_header(struct bpf_mem_ptr *context)
 				old_field = kmesh_protocol_data_search(new_field->keystring);
 				if (unlikely(old_field)) {
 					old_field->value.ptr = context->ptr + field_value_begin_position;
-					old_field->value.size = field_value_end_position - field_value_begin_position + 1;
+					old_field->value.size = field_value_end_position - field_value_begin_position;
 					delete_kmesh_data_node(&new_field);
 					old_field = NULL;
 				} else {
 					new_field->value.ptr = context->ptr + field_value_begin_position;
-					new_field->value.size = field_value_end_position - field_value_begin_position + 1;
+					new_field->value.size = field_value_end_position - field_value_begin_position;
 
 					if (!kmesh_protocol_data_insert(new_field)) {
 						delete_kmesh_data_node(&new_field);


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug

-->

**What this PR does / why we need it**:
Fixed an issue with Kmesh failing to parse HTTP headers. When a field in the HTTP header has an empty value, Kmesh would fail to parse it, leading to routing issues. 

**Which issue(s) this PR fixes**:
Fixes #https://github.com/kmesh-net/kmesh/issues/186

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
