### PR TITLE
Kmesh: Add waypoint support for connect and deliver encoder dst info to sendmsg ebpf

### DIFF
--- a/bpf/kmesh/workload/include/tail_call.h
+++ b/bpf/kmesh/workload/include/tail_call.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _KMESH_WORKLOAD_TAIL_CALL_H_
+#define _KMESH_WORKLOAD_TAIL_CALL_H_
+
+#include "workload_common.h"
+
+#define MAP_SIZE_OF_TAIL_CALL_PROG 4
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __uint(key_size, sizeof(__u32));
+    __uint(value_size, sizeof(__u32));
+    __uint(max_entries, MAP_SIZE_OF_TAIL_CALL_PROG);
+    __uint(map_flags, 0);
+} map_of_tail_call_prog SEC(".maps");
+
+static inline void kmesh_workload_tail_call(ctx_buff_t *ctx, const __u32 index)
+{
+    bpf_tail_call(ctx, &map_of_tail_call_prog, index);
+}
+
+#endif

--- a/bpf/kmesh/workload/sockops_tuple.c
+++ b/bpf/kmesh/workload/sockops_tuple.c
@@ -20,6 +20,7 @@
 #include "bpf_log.h"
 #include "workload.h"
 #include "config.h"
+#include "encoder.h"
 
 #define FORMAT_IP_LENGTH		(16) 
 
@@ -140,6 +141,14 @@ static inline void clean_auth_map(struct bpf_sock_ops *skops)
 		BPF_LOG(INFO, SOCKOPS, "map_of_auth bpf_map_delete_elem failed, ret: %d\n", ret);
 }
 
+static inline void clean_dstinfo_map(struct bpf_sock_ops *skops)
+{
+    __u32 *key = (__u32 *)skops->sk;
+    long ret = bpf_map_delete_elem(&map_of_dst_info, &key);
+    if(ret && ret != -ENOENT)
+        BPF_LOG(INFO, SOCKOPS, "map_of_dst_info bpf_map_delete_elem failed, ret: %d\n", ret);
+}
+
 // insert an IPv4 tuple into the ringbuf
 static inline void auth_ip_tuple(struct bpf_sock_ops *skops)
 {
@@ -193,6 +202,7 @@ int record_tuple(struct bpf_sock_ops *skops)
 			if(skops->args[1] == BPF_TCP_CLOSE || skops->args[1] == BPF_TCP_CLOSE_WAIT 
 			|| skops->args[1] == BPF_TCP_FIN_WAIT1)
 				clean_auth_map(skops);
+				clean_dstinfo_map(skops);
 			break;
 		default:
 			break;

--- a/bpf/kmesh/workload/sockops_tuple.c
+++ b/bpf/kmesh/workload/sockops_tuple.c
@@ -146,7 +146,7 @@ static inline void clean_dstinfo_map(struct bpf_sock_ops *skops)
     __u32 *key = (__u32 *)skops->sk;
     long ret = bpf_map_delete_elem(&map_of_dst_info, &key);
     if(ret && ret != -ENOENT)
-        BPF_LOG(INFO, SOCKOPS, "map_of_dst_info bpf_map_delete_elem failed, ret: %d\n", ret);
+        BPF_LOG(INFO, SOCKOPS, "bpf map delete destination info failed, ret: %d\n", ret);
 }
 
 // insert an IPv4 tuple into the ringbuf

--- a/pkg/bpf/bpf_kmesh_workload.go
+++ b/pkg/bpf/bpf_kmesh_workload.go
@@ -99,6 +99,13 @@ func (sc *BpfSockConnWorkload) LoadSockConn() error {
 	sc.Info.Type = prog.Type
 	sc.Info.AttachType = prog.AttachType
 
+	if err = sc.MapOfTailCallProg.Update(
+		uint32(0),
+		uint32(sc.CgroupConnect4Prog.FD()),
+		ebpf.UpdateAny); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Ebpf connect4 program support connect to waypoint if the backend config waypoint ip and port.

Waypoint need dst info to routing, now connect4 can deliver these info to sendmsg ebpf, sendmsg can encode dst info by TLV.

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind feature

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
