### PR TITLE
Enable xdp auth when kmesh works in workload mode

### DIFF
--- a/pkg/bpf/bpf_kmesh_workload.go
+++ b/pkg/bpf/bpf_kmesh_workload.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cilium/ebpf/link"
 
 	"kmesh.net/kmesh/bpf/kmesh/bpf2go"
+	"kmesh.net/kmesh/pkg/constants"
 )
 
 type BpfSockConnWorkload struct {
@@ -459,7 +460,7 @@ func (xa *BpfXdpAuthWorkload) LoadXdpAuth() error {
 		return err
 	}
 
-	prog := spec.Programs["xdp_shutdown"]
+	prog := spec.Programs[constants.XDP_PROG_NAME]
 	xa.Info.Type = prog.Type
 	xa.Info.AttachType = prog.AttachType
 

--- a/pkg/bpf/config.go
+++ b/pkg/bpf/config.go
@@ -23,12 +23,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"kmesh.net/kmesh/pkg/constants"
 	"kmesh.net/kmesh/pkg/options"
-)
-
-const (
-	AdsMode      = "ads"
-	WorkloadMode = "workload"
 )
 
 var (
@@ -87,9 +83,9 @@ func GetConfig() *Config {
 }
 
 func (c *Config) AdsEnabled() bool {
-	return c.Mode == AdsMode
+	return c.Mode == constants.AdsMode
 }
 
 func (c *Config) WdsEnabled() bool {
-	return c.Mode == WorkloadMode
+	return c.Mode == constants.WorkloadMode
 }

--- a/pkg/cni/chained_test.go
+++ b/pkg/cni/chained_test.go
@@ -298,7 +298,7 @@ func TestInsertCNIConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.beforeFunc()
-			_, err := insertCNIConfig(tt.utconfig)
+			_, err := insertCNIConfig(tt.utconfig, "workload")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("insertCNIConfig() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/cni/install.go
+++ b/pkg/cni/install.go
@@ -26,13 +26,13 @@ import (
 
 var log = logger.NewLoggerField("cni installer")
 
-func addCniConfig() error {
+func addCniConfig(mode string) error {
 	var err error
 	if config.CniConfigChained {
 		// "chained" is an cni type
 		// information: www.cni.dev/docs/spec/#overview-1
 		log.Infof("kmesh cni use chained\n")
-		err = chainedKmeshCniPlugin()
+		err = chainedKmeshCniPlugin(mode)
 		if err != nil {
 			return err
 		}
@@ -52,7 +52,7 @@ func removeCniConfig() error {
 func Start() error {
 	if bpf.GetConfig().AdsEnabled() || bpf.GetConfig().WdsEnabled() {
 		log.Info("start write CNI config\n")
-		return addCniConfig()
+		return addCniConfig(bpf.GetConfig().Mode)
 	}
 	return nil
 }

--- a/pkg/cni/plugin/plugin.go
+++ b/pkg/cni/plugin/plugin.go
@@ -12,9 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: bitcoffee
- * Create: 2023-11-19
  */
 
 package plugin
@@ -28,27 +25,25 @@ import (
 	"strings"
 	"syscall"
 
-	netns "github.com/containernetworking/plugins/pkg/ns"
-
 	"github.com/cilium/ebpf"
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	cniv1 "github.com/containernetworking/cni/pkg/types/100"
 	"github.com/containernetworking/cni/pkg/version"
+	netns "github.com/containernetworking/plugins/pkg/ns"
 	"github.com/vishvananda/netlink"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 
+	"kmesh.net/kmesh/pkg/constants"
 	"kmesh.net/kmesh/pkg/logger"
 	"kmesh.net/kmesh/pkg/utils"
 )
 
 var (
-	log               = logger.NewLoggerFieldWithoutStdout("plugin/cniplugin")
-	ENABLE_KMESH_MARK = "0x1000"
-	XDP_PROG_NAME     = "xdp_shutdown"
+	log = logger.NewLoggerFieldWithoutStdout("plugin/cniplugin")
 )
 
 // Config is whatever you expect your configuration json to be. This is whatever
@@ -256,7 +251,7 @@ func enableXdpAuth(ifname string) error {
 		link netlink.Link
 	)
 
-	if xdp, err = utils.GetProgramByName(XDP_PROG_NAME); err != nil {
+	if xdp, err = utils.GetProgramByName(constants.XDP_PROG_NAME); err != nil {
 		return err
 	}
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -17,5 +17,8 @@
 package constants
 
 const (
+	AdsMode      = "ads"
+	WorkloadMode = "workload"
+
 	XDP_PROG_NAME = "xdp_shutdown"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package constants
+
+const (
+	XDP_PROG_NAME = "xdp_shutdown"
+)


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement


<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

By passing working mode as cni configuration. With this, the config now looks like below:

```
    {
      "kubeConfig": "/etc/cni/net.d/kmesh-cni-kubeconfig",
      "mode": "ads",
      "type": "kmesh-cni"
    }

```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
