### PR TITLE
add bypass logic for kmesh

### DIFF
--- a/bpf/include/bpf_common.h
+++ b/bpf/include/bpf_common.h
@@ -17,6 +17,16 @@
 #define map_of_manager      kmesh_manage
 #define MAP_SIZE_OF_MANAGER 8192
 
+/*
+ * This map is used to store the cookie information
+ * of pods managed by kmesh. The key represents the
+ * cookie, and the value represents whether it is bypassed.
+ * The default value is 0, indicating it is not
+ * bypassed by default. A value of 1 represents bypassed
+ * status. Whether it is managed by kmesh is unrelated
+ * to the value. The only determining factor is whether
+ * there is cookie information for this pod in the map.
+ */
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __type(key, __u64);
@@ -25,29 +35,88 @@ struct {
     __uint(map_flags, 0);
 } map_of_manager SEC(".maps");
 
-static inline void record_netns_cookie(struct bpf_sock_addr *ctx)
+static inline void record_netns_cookie(struct bpf_map *map, struct bpf_sock_addr *ctx)
 {
     int err;
     int value = 0;
     __u64 cookie = bpf_get_netns_cookie(ctx);
-    err = bpf_map_update_elem(&map_of_manager, &cookie, &value, BPF_NOEXIST);
+    err = bpf_map_update_elem(map, &cookie, &value, BPF_NOEXIST);
     if (err)
         BPF_LOG(ERR, KMESH, "record netcookie failed!, err is %d\n", err);
 }
 
-static inline void remove_netns_cookie(struct bpf_sock_addr *ctx)
+void record_kmesh_netns_cookie(struct bpf_sock_addr *ctx)
 {
-    int err;
+    BPF_LOG(DEBUG, KMESH, "record_manager_netns_cookie");
+    record_netns_cookie(&map_of_manager, ctx);
+}
+
+void set_netns_cookie_value(struct bpf_sock_addr *ctx, int value)
+{
     __u64 cookie = bpf_get_netns_cookie(ctx);
-    err = bpf_map_delete_elem(&map_of_manager, &cookie);
-    if (err && err != -ENOENT)
-        BPF_LOG(ERR, KMESH, "remove netcookie failed!, err is %d\n", err);
+    int *old_value = bpf_map_lookup_elem(&map_of_manager, &cookie);
+    if (!old_value || *old_value == value)
+        return;
+
+    int err = bpf_map_update_elem(&map_of_manager, &cookie, &value, BPF_EXIST);
+    if (err)
+        BPF_LOG(ERR, KMESH, "set netcookie failed!, err is %d\n", err);
+}
+
+void record_bypass_netns_cookie(struct bpf_sock_addr *ctx)
+{
+    BPF_LOG(DEBUG, KMESH, "record_bypass_netns_cookie");
+    set_netns_cookie_value(ctx, 1);
 }
 
 static inline bool check_kmesh_enabled(struct bpf_sock_addr *ctx)
 {
     __u64 cookie = bpf_get_netns_cookie(ctx);
     return bpf_map_lookup_elem(&map_of_manager, &cookie);
+}
+
+static inline bool check_bypass_enabled(struct bpf_sock_addr *ctx)
+{
+    __u64 cookie = bpf_get_netns_cookie(ctx);
+    int *value = bpf_map_lookup_elem(&map_of_manager, &cookie);
+
+    if (!value)
+        return false;
+
+    return (*value == 1);
+}
+
+static inline void remove_netns_cookie(struct bpf_map *map, struct bpf_sock_addr *ctx)
+{
+    int err;
+    __u64 cookie = bpf_get_netns_cookie(ctx);
+    err = bpf_map_delete_elem(map, &cookie);
+    if (err && err != -ENOENT)
+        BPF_LOG(ERR, KMESH, "remove netcookie failed!, err is %d\n", err);
+}
+
+void remove_kmesh_netns_cookie(struct bpf_sock_addr *ctx)
+{
+    remove_netns_cookie(&map_of_manager, ctx);
+}
+
+void remove_bypass_netns_cookie(struct bpf_sock_addr *ctx)
+{
+    set_netns_cookie_value(ctx, 0);
+}
+
+static inline bool conn_from_bypass_sim_add(struct bpf_sock_addr *ctx)
+{
+    // daemon sim connect 0.0.0.0:931(0x3a3)
+    // 0x3a3 is the specific port handled by the daemon for enable bypass
+    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == 0x3a30000));
+}
+
+static inline bool conn_from_bypass_sim_delete(struct bpf_sock_addr *ctx)
+{
+    // daemon sim connect 0.0.0.1:932(0x3a4)
+    // 0x3a4 is the specific port handled by the daemon for disable bypass
+    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == 0x3a40000));
 }
 
 static inline bool conn_from_cni_sim_add(struct bpf_sock_addr *ctx)

--- a/bpf/include/bpf_common.h
+++ b/bpf/include/bpf_common.h
@@ -16,11 +16,23 @@
 
 #define map_of_manager      kmesh_manage
 #define MAP_SIZE_OF_MANAGER 8192
+/*0x3a10000 is the specific port handled by the cni to enable kmesh*/
+#define ENABLE_KMESH_PORT 0x3a10000
+/*0x3a20000 is the specific port handled by the cni to enable kmesh*/
+#define DISABLE_KMESH_PORT 0x3a20000
+/*0x3a30000 is the specific port handled by the daemon to enable bypass*/
+#define ENABLE_BYPASS_PORT 0x3a30000
+/*0x3a40000 is the specific port handled by the daemon to enable bypass*/
+#define DISABLE_BYPASS_PORT 0x3a40000
 
+typedef struct {
+    __u32 is_bypassed;
+} manager_value_t;
 /*
  * This map is used to store the cookie information
  * of pods managed by kmesh. The key represents the
- * cookie, and the value represents whether it is bypassed.
+ * cookie, and the value of is_bypassed represents
+ * whether it is bypassed.
  * The default value is 0, indicating it is not
  * bypassed by default. A value of 1 represents bypassed
  * status. Whether it is managed by kmesh is unrelated
@@ -30,63 +42,56 @@
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __type(key, __u64);
-    __type(value, __u32);
+    __type(value, manager_value_t);
     __uint(max_entries, MAP_SIZE_OF_MANAGER);
     __uint(map_flags, 0);
 } map_of_manager SEC(".maps");
 
-static inline void record_netns_cookie(struct bpf_map *map, struct bpf_sock_addr *ctx)
+static inline void record_manager_netns_cookie(struct bpf_map *map, struct bpf_sock_addr *ctx)
 {
     int err;
-    int value = 0;
+    manager_value_t value = {
+        .is_bypassed = 0,
+    };
+
     __u64 cookie = bpf_get_netns_cookie(ctx);
     err = bpf_map_update_elem(map, &cookie, &value, BPF_NOEXIST);
     if (err)
         BPF_LOG(ERR, KMESH, "record netcookie failed!, err is %d\n", err);
 }
 
-void record_kmesh_netns_cookie(struct bpf_sock_addr *ctx)
+static inline void set_netns_bypass_value(struct bpf_sock_addr *sock_addr, int new_bypass_value)
 {
-    BPF_LOG(DEBUG, KMESH, "record_manager_netns_cookie");
-    record_netns_cookie(&map_of_manager, ctx);
-}
-
-void set_netns_cookie_value(struct bpf_sock_addr *ctx, int value)
-{
-    __u64 cookie = bpf_get_netns_cookie(ctx);
-    int *old_value = bpf_map_lookup_elem(&map_of_manager, &cookie);
-    if (!old_value || *old_value == value)
+    __u64 cookie = bpf_get_netns_cookie(sock_addr);
+    manager_value_t *current_value = bpf_map_lookup_elem(&map_of_manager, &cookie);
+    if (!current_value || current_value->is_bypassed == new_bypass_value)
         return;
 
-    int err = bpf_map_update_elem(&map_of_manager, &cookie, &value, BPF_EXIST);
+    current_value->is_bypassed = new_bypass_value;
+
+    int err = bpf_map_update_elem(&map_of_manager, &cookie, current_value, BPF_EXIST);
     if (err)
         BPF_LOG(ERR, KMESH, "set netcookie failed!, err is %d\n", err);
 }
 
-void record_bypass_netns_cookie(struct bpf_sock_addr *ctx)
-{
-    BPF_LOG(DEBUG, KMESH, "record_bypass_netns_cookie");
-    set_netns_cookie_value(ctx, 1);
-}
-
-static inline bool check_kmesh_enabled(struct bpf_sock_addr *ctx)
+static inline bool is_kmesh_enabled(struct bpf_sock_addr *ctx)
 {
     __u64 cookie = bpf_get_netns_cookie(ctx);
     return bpf_map_lookup_elem(&map_of_manager, &cookie);
 }
 
-static inline bool check_bypass_enabled(struct bpf_sock_addr *ctx)
+static inline bool is_bypass_enabled(struct bpf_sock_addr *ctx)
 {
     __u64 cookie = bpf_get_netns_cookie(ctx);
-    int *value = bpf_map_lookup_elem(&map_of_manager, &cookie);
+    manager_value_t *value = bpf_map_lookup_elem(&map_of_manager, &cookie);
 
     if (!value)
         return false;
 
-    return (*value == 1);
+    return value->is_bypassed;
 }
 
-static inline void remove_netns_cookie(struct bpf_map *map, struct bpf_sock_addr *ctx)
+static inline void remove_manager_netns_cookie(struct bpf_map *map, struct bpf_sock_addr *ctx)
 {
     int err;
     __u64 cookie = bpf_get_netns_cookie(ctx);
@@ -95,40 +100,68 @@ static inline void remove_netns_cookie(struct bpf_map *map, struct bpf_sock_addr
         BPF_LOG(ERR, KMESH, "remove netcookie failed!, err is %d\n", err);
 }
 
-void remove_kmesh_netns_cookie(struct bpf_sock_addr *ctx)
-{
-    remove_netns_cookie(&map_of_manager, ctx);
-}
-
-void remove_bypass_netns_cookie(struct bpf_sock_addr *ctx)
-{
-    set_netns_cookie_value(ctx, 0);
-}
-
 static inline bool conn_from_bypass_sim_add(struct bpf_sock_addr *ctx)
 {
     // daemon sim connect 0.0.0.0:931(0x3a3)
-    // 0x3a3 is the specific port handled by the daemon for enable bypass
-    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == 0x3a30000));
+    // 0x3a3 is the specific port handled by the daemon to enable bypass
+    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == ENABLE_BYPASS_PORT));
 }
 
 static inline bool conn_from_bypass_sim_delete(struct bpf_sock_addr *ctx)
 {
     // daemon sim connect 0.0.0.1:932(0x3a4)
-    // 0x3a4 is the specific port handled by the daemon for disable bypass
-    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == 0x3a40000));
+    // 0x3a4 is the specific port handled by the daemon to disable bypass
+    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == DISABLE_BYPASS_PORT));
 }
 
 static inline bool conn_from_cni_sim_add(struct bpf_sock_addr *ctx)
 {
     // cni sim connect 0.0.0.0:929(0x3a1)
-    // 0x3a1 is the specific port handled by the cni for enable Kmesh
-    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == 0x3a10000));
+    // 0x3a1 is the specific port handled by the cni to enable Kmesh
+    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == ENABLE_KMESH_PORT));
 }
 
 static inline bool conn_from_cni_sim_delete(struct bpf_sock_addr *ctx)
 {
     // cni sim connect 0.0.0.1:930(0x3a2)
-    // 0x3a2 is the specific port handled by the cni for disable Kmesh
-    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == 0x3a20000));
+    // 0x3a2 is the specific port handled by the cni to disable Kmesh
+    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == DISABLE_KMESH_PORT));
+}
+
+/* This function is used to store and delete cookie
+ * records of pods managed by kmesh. When the record exists
+ * and the value is 0, it means it is managed by kmesh.
+ */
+static inline bool handle_kmesh_manage_process(struct bpf_sock_addr *ctx)
+{
+    if (conn_from_cni_sim_add(ctx)) {
+        record_manager_netns_cookie(&map_of_manager, ctx);
+        // return failed, cni sim connect 0.0.0.1:929(0x3a1)
+        // A normal program will not connect to this IP address
+        return true;
+    }
+
+    if (conn_from_cni_sim_delete(ctx)) {
+        remove_manager_netns_cookie(&map_of_manager, ctx);
+        return true;
+    }
+    return false;
+}
+
+/* This function is used to modify the value of the
+ * record in the manager map. When the value is 0, it
+ * means that it has not been bypassed. When it is 1,
+ * it means that it has been bypassed.
+ */
+static inline bool handle_bypass_process(struct bpf_sock_addr *ctx)
+{
+    if (conn_from_bypass_sim_add(ctx)) {
+        set_netns_bypass_value(ctx, 1);
+        return true;
+    }
+    if (conn_from_bypass_sim_delete(ctx)) {
+        set_netns_bypass_value(ctx, 0);
+        return true;
+    }
+    return false;
 }

--- a/bpf/kmesh/ads/cgroup_sock.c
+++ b/bpf/kmesh/ads/cgroup_sock.c
@@ -33,13 +33,44 @@
 
 static const char kmesh_module_name[] = "kmesh_defer";
 
+static inline bool check_kmesh_managed_process(struct bpf_sock_addr *ctx)
+{
+    if (conn_from_cni_sim_add(ctx)) {
+        record_kmesh_netns_cookie(ctx);
+        // return failed, cni sim connect 0.0.0.1:929(0x3a1)
+        // A normal program will not connect to this IP address
+        return true;
+    }
+
+    if (conn_from_cni_sim_delete(ctx)) {
+        remove_kmesh_netns_cookie(ctx);
+        return true;
+    }
+    return false;
+}
+
+static inline bool check_bypass_process(struct bpf_sock_addr *ctx)
+{
+    if (conn_from_bypass_sim_add(ctx)) {
+        record_bypass_netns_cookie(ctx);
+        // return failed, cni sim connect 0.0.0.1:929(0x3a1)
+        // A normal program will not connect to this IP address
+        return true;
+    }
+    if (conn_from_bypass_sim_delete(ctx)) {
+        remove_bypass_netns_cookie(ctx);
+        return true;
+    }
+    return false;
+}
+
 static inline int sock4_traffic_control(struct bpf_sock_addr *ctx)
 {
     int ret;
 
     Listener__Listener *listener = NULL;
 
-    if (!check_kmesh_enabled(ctx) || ctx->protocol != IPPROTO_TCP)
+    if (ctx->protocol != IPPROTO_TCP)
         return 0;
 
     DECLARE_VAR_ADDRESS(ctx, address);
@@ -73,14 +104,10 @@ static inline int sock4_traffic_control(struct bpf_sock_addr *ctx)
 SEC("cgroup/connect4")
 int cgroup_connect4_prog(struct bpf_sock_addr *ctx)
 {
-    if (conn_from_cni_sim_add(ctx)) {
-        record_netns_cookie(ctx);
-        // return failed, cni sim connect 0.0.0.1:929(0x3a1)
-        // A normal program will not connect to this IP address
+    if (check_kmesh_managed_process(ctx) || !check_kmesh_enabled(ctx)) {
         return CGROUP_SOCK_OK;
     }
-    if (conn_from_cni_sim_delete(ctx)) {
-        remove_netns_cookie(ctx);
+    if (check_bypass_process(ctx) || check_bypass_enabled(ctx)) {
         return CGROUP_SOCK_OK;
     }
     int ret = sock4_traffic_control(ctx);

--- a/bpf/kmesh/workload/cgroup_sock.c
+++ b/bpf/kmesh/workload/cgroup_sock.c
@@ -23,90 +23,7 @@
 #include "bpf_log.h"
 #include "ctx/sock_addr.h"
 #include "frontend.h"
-
-static inline void record_netns_cookie(struct bpf_map *map, struct bpf_sock_addr *ctx)
-{
-    int err;
-    int value = 0;
-    __u64 cookie = bpf_get_netns_cookie(ctx);
-    err = bpf_map_update_elem(map, &cookie, &value, BPF_NOEXIST);
-    if (err)
-        BPF_LOG(ERR, KMESH, "record netcookie failed!, err is %d\n", err);
-}
-
-static inline void remove_netns_cookie(struct bpf_map *map, struct bpf_sock_addr *ctx)
-{
-    int err;
-    __u64 cookie = bpf_get_netns_cookie(ctx);
-    err = bpf_map_delete_elem(map, &cookie);
-    if (err && err != -ENOENT)
-        BPF_LOG(ERR, KMESH, "remove netcookie failed!, err is %d\n", err);
-}
-
-void set_netns_cookie_value(struct bpf_sock_addr *ctx, int value)
-{
-    __u64 cookie = bpf_get_netns_cookie(ctx);
-    int *old_value = bpf_map_lookup_elem(&map_of_manager, &cookie);
-    if (!old_value || *old_value == value)
-        return;
-
-    int err = bpf_map_update_elem(&map_of_manager, &cookie, &value, BPF_EXIST);
-    if (err)
-        BPF_LOG(ERR, KMESH, "set netcookie failed!, err is %d\n", err);
-}
-
-void record_kmesh_netns_cookie(struct bpf_sock_addr *ctx)
-{
-    BPF_LOG(DEBUG, KMESH, "record_manager_netns_cookie");
-    record_netns_cookie(&map_of_manager, ctx);
-}
-
-void record_bypass_netns_cookie(struct bpf_sock_addr *ctx)
-{
-    BPF_LOG(DEBUG, KMESH, "record_bypass_netns_cookie");
-    set_netns_cookie_value(ctx, 1);
-}
-
-void remove_kmesh_netns_cookie(struct bpf_sock_addr *ctx)
-{
-    remove_netns_cookie(&map_of_manager, ctx);
-}
-
-void remove_bypass_netns_cookie(struct bpf_sock_addr *ctx)
-{
-    set_netns_cookie_value(ctx, 0);
-}
-
-static inline bool check_kmesh_enabled(struct bpf_sock_addr *ctx)
-{
-    __u64 cookie = bpf_get_netns_cookie(ctx);
-    return bpf_map_lookup_elem(&map_of_manager, &cookie);
-}
-
-static inline bool check_bypass_enabled(struct bpf_sock_addr *ctx)
-{
-    __u64 cookie = bpf_get_netns_cookie(ctx);
-    int *value = bpf_map_lookup_elem(&map_of_manager, &cookie);
-
-    if (!value)
-        return false;
-
-    return (*value == 1);
-}
-
-static inline bool conn_from_bypass_sim_add(struct bpf_sock_addr *ctx)
-{
-    // daemon sim connect 0.0.0.0:931(0x3a3)
-    // 0x3a3 is the specific port handled by the daemon for enable bypass
-    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == 0x3a30000));
-}
-
-static inline bool conn_from_bypass_sim_delete(struct bpf_sock_addr *ctx)
-{
-    // daemon sim connect 0.0.0.1:932(0x3a4)
-    // 0x3a4 is the specific port handled by the daemon for disable bypass
-    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == 0x3a40000));
-}
+#include "bpf_common.h"
 
 static inline int sock4_traffic_control(struct bpf_sock_addr *ctx)
 {
@@ -135,61 +52,19 @@ static inline int sock4_traffic_control(struct bpf_sock_addr *ctx)
     return 0;
 }
 
-static inline bool conn_from_cni_sim_add(struct bpf_sock_addr *ctx)
-{
-    // cni sim connect 0.0.0.0:929(0x3a1)
-    // 0x3a1 is the specific port handled by the cni for enable Kmesh
-    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == 0x3a10000));
-}
-
-static inline bool conn_from_cni_sim_delete(struct bpf_sock_addr *ctx)
-{
-    // cni sim connect 0.0.0.1:930(0x3a2)
-    // 0x3a2 is the specific port handled by the cni for disable Kmesh
-    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == 0x3a20000));
-}
-
-static inline bool check_mgn_process(struct bpf_sock_addr *ctx)
-{
-    if (conn_from_cni_sim_add(ctx)) {
-        record_kmesh_netns_cookie(ctx);
-        // return failed, cni sim connect 0.0.0.1:929(0x3a1)
-        // A normal program will not connect to this IP address
-        return true;
-    }
-
-    if (conn_from_cni_sim_delete(ctx)) {
-        remove_kmesh_netns_cookie(ctx);
-        return true;
-    }
-    return false;
-}
-
-static inline bool check_bypass_process(struct bpf_sock_addr *ctx)
-{
-    if (conn_from_bypass_sim_add(ctx)) {
-        record_bypass_netns_cookie(ctx);
-        // return failed, cni sim connect 0.0.0.1:929(0x3a1)
-        // A normal program will not connect to this IP address
-        return true;
-    }
-    if (conn_from_bypass_sim_delete(ctx)) {
-        remove_bypass_netns_cookie(ctx);
-        return true;
-    }
-    return false;
-}
 SEC("cgroup/connect4")
 int cgroup_connect4_prog(struct bpf_sock_addr *ctx)
 {
-    if (check_mgn_process(ctx) || !check_kmesh_enabled(ctx)) {
+    if (handle_kmesh_manage_process(ctx) || !is_kmesh_enabled(ctx)) {
         return CGROUP_SOCK_OK;
     }
 
-    if (check_bypass_process(ctx) || check_bypass_enabled(ctx)) {
+    if (handle_bypass_process(ctx) || is_bypass_enabled(ctx)) {
         return CGROUP_SOCK_OK;
     }
+
     int ret = sock4_traffic_control(ctx);
+
     return CGROUP_SOCK_OK;
 }
 

--- a/bpf/kmesh/workload/cgroup_sock.c
+++ b/bpf/kmesh/workload/cgroup_sock.c
@@ -23,14 +23,97 @@
 #include "bpf_log.h"
 #include "ctx/sock_addr.h"
 #include "frontend.h"
-#include "bpf_common.h"
+
+static inline void record_netns_cookie(struct bpf_map *map, struct bpf_sock_addr *ctx)
+{
+    int err;
+    int value = 0;
+    __u64 cookie = bpf_get_netns_cookie(ctx);
+    err = bpf_map_update_elem(map, &cookie, &value, BPF_NOEXIST);
+    if (err)
+        BPF_LOG(ERR, KMESH, "record netcookie failed!, err is %d\n", err);
+}
+
+static inline void remove_netns_cookie(struct bpf_map *map, struct bpf_sock_addr *ctx)
+{
+    int err;
+    __u64 cookie = bpf_get_netns_cookie(ctx);
+    err = bpf_map_delete_elem(map, &cookie);
+    if (err && err != -ENOENT)
+        BPF_LOG(ERR, KMESH, "remove netcookie failed!, err is %d\n", err);
+}
+
+void set_netns_cookie_value(struct bpf_sock_addr *ctx, int value)
+{
+    __u64 cookie = bpf_get_netns_cookie(ctx);
+    int *old_value = bpf_map_lookup_elem(&map_of_manager, &cookie);
+    if (!old_value || *old_value == value)
+        return;
+
+    int err = bpf_map_update_elem(&map_of_manager, &cookie, &value, BPF_EXIST);
+    if (err)
+        BPF_LOG(ERR, KMESH, "set netcookie failed!, err is %d\n", err);
+}
+
+void record_kmesh_netns_cookie(struct bpf_sock_addr *ctx)
+{
+    BPF_LOG(DEBUG, KMESH, "record_manager_netns_cookie");
+    record_netns_cookie(&map_of_manager, ctx);
+}
+
+void record_bypass_netns_cookie(struct bpf_sock_addr *ctx)
+{
+    BPF_LOG(DEBUG, KMESH, "record_bypass_netns_cookie");
+    set_netns_cookie_value(ctx, 1);
+}
+
+void remove_kmesh_netns_cookie(struct bpf_sock_addr *ctx)
+{
+    remove_netns_cookie(&map_of_manager, ctx);
+}
+
+void remove_bypass_netns_cookie(struct bpf_sock_addr *ctx)
+{
+    set_netns_cookie_value(ctx, 0);
+}
+
+static inline bool check_kmesh_enabled(struct bpf_sock_addr *ctx)
+{
+    __u64 cookie = bpf_get_netns_cookie(ctx);
+    return bpf_map_lookup_elem(&map_of_manager, &cookie);
+}
+
+static inline bool check_bypass_enabled(struct bpf_sock_addr *ctx)
+{
+    __u64 cookie = bpf_get_netns_cookie(ctx);
+    int *value = bpf_map_lookup_elem(&map_of_manager, &cookie);
+
+    if (!value)
+        return false;
+
+    return (*value == 1);
+}
+
+static inline bool conn_from_bypass_sim_add(struct bpf_sock_addr *ctx)
+{
+    // daemon sim connect 0.0.0.0:931(0x3a3)
+    // 0x3a3 is the specific port handled by the daemon for enable bypass
+    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == 0x3a30000));
+}
+
+static inline bool conn_from_bypass_sim_delete(struct bpf_sock_addr *ctx)
+{
+    // daemon sim connect 0.0.0.1:932(0x3a4)
+    // 0x3a4 is the specific port handled by the daemon for disable bypass
+    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == 0x3a40000));
+}
 
 static inline int sock4_traffic_control(struct bpf_sock_addr *ctx)
 {
     int ret;
     frontend_value *frontend_v = NULL;
 
-    if (!check_kmesh_enabled(ctx) || ctx->protocol != IPPROTO_TCP)
+    if (ctx->protocol != IPPROTO_TCP)
         return 0;
 
     DECLARE_FRONTEND_KEY(ctx, frontend_k);
@@ -52,17 +135,58 @@ static inline int sock4_traffic_control(struct bpf_sock_addr *ctx)
     return 0;
 }
 
+static inline bool conn_from_cni_sim_add(struct bpf_sock_addr *ctx)
+{
+    // cni sim connect 0.0.0.0:929(0x3a1)
+    // 0x3a1 is the specific port handled by the cni for enable Kmesh
+    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == 0x3a10000));
+}
+
+static inline bool conn_from_cni_sim_delete(struct bpf_sock_addr *ctx)
+{
+    // cni sim connect 0.0.0.1:930(0x3a2)
+    // 0x3a2 is the specific port handled by the cni for disable Kmesh
+    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == 0x3a20000));
+}
+
+static inline bool check_mgn_process(struct bpf_sock_addr *ctx)
+{
+    if (conn_from_cni_sim_add(ctx)) {
+        record_kmesh_netns_cookie(ctx);
+        // return failed, cni sim connect 0.0.0.1:929(0x3a1)
+        // A normal program will not connect to this IP address
+        return true;
+    }
+
+    if (conn_from_cni_sim_delete(ctx)) {
+        remove_kmesh_netns_cookie(ctx);
+        return true;
+    }
+    return false;
+}
+
+static inline bool check_bypass_process(struct bpf_sock_addr *ctx)
+{
+    if (conn_from_bypass_sim_add(ctx)) {
+        record_bypass_netns_cookie(ctx);
+        // return failed, cni sim connect 0.0.0.1:929(0x3a1)
+        // A normal program will not connect to this IP address
+        return true;
+    }
+    if (conn_from_bypass_sim_delete(ctx)) {
+        remove_bypass_netns_cookie(ctx);
+        return true;
+    }
+    return false;
+}
 SEC("cgroup/connect4")
 int cgroup_connect4_prog(struct bpf_sock_addr *ctx)
 {
-    if (conn_from_cni_sim_add(ctx)) {
-        record_netns_cookie(ctx);
-        // return failed, cni sim connect 0.0.0.1:929(0x3a1)
-        // A normal program will not connect to this IP address
+    if (check_mgn_process(ctx) || !check_kmesh_enabled(ctx)) {
         return CGROUP_SOCK_OK;
     }
-    if (conn_from_cni_sim_delete(ctx)) {
-        remove_netns_cookie(ctx);
+
+    if (check_bypass_process(ctx) || check_bypass_enabled(ctx)) {
         return CGROUP_SOCK_OK;
     }
     int ret = sock4_traffic_control(ctx);


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind feature

-->

**What this PR does / why we need it**:

This PR introduces the implementation of the bypass kmesh function and reuses the map_of_manager table.
If the map contains pod data and the value of the corresponding record is 0, the traffic of the current pod is managed by kmesh.
If the map contains pod data and the value of the corresponding record is 1, the traffic of the current pod is bypassed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

# Self-verification report
## ads module
```shell
root@ubuntu-1:~# kubectl get pods -A -owide
NAMESPACE            NAME                                            READY   STATUS    RESTARTS   AGE     IP            NODE                    NOMINATED NODE   READINESS GATES
default              fortio-client-deployment-6966bf9488-h8wmz       1/1     Running   0          22s     10.244.1.14   ambient-worker          <none>           <none>
default              fortio-server-deployment-97cf895fc-k8z57        1/1     Running   0          22s     10.244.1.15   ambient-worker          <none>           <none>
default              fortio-server-deployment-97cf895fc-s2c6t        1/1     Running   0          22s     10.244.1.13   ambient-worker          <none>           <none>
istio-system         istio-cni-node-gtdg8                            1/1     Running   0          4h46m   172.18.0.3    ambient-control-plane   <none>           <none>
istio-system         istio-cni-node-vd6mv                            1/1     Running   0          4h46m   172.18.0.2    ambient-worker          <none>           <none>
istio-system         istiod-76c587b7cd-jt778                         1/1     Running   0          4h46m   10.244.1.2    ambient-worker          <none>           <none>
istio-system         ztunnel-8wbkn                                   1/1     Running   0          4h46m   10.244.1.3    ambient-worker          <none>           <none>
istio-system         ztunnel-kjn95                                   1/1     Running   0          4h46m   10.244.0.5    ambient-control-plane   <none>           <none>
kmesh-system         kmesh-n9n78                                     1/1     Running   0          43s     10.244.1.12   ambient-worker          <none>           <none>
kube-system          coredns-565d847f94-7lnc8                        1/1     Running   0          4h48m   10.244.0.3    ambient-control-plane   <none>           <none>
kube-system          coredns-565d847f94-g8x4w                        1/1     Running   0          4h48m   10.244.0.4    ambient-control-plane   <none>           <none>
kube-system          etcd-ambient-control-plane                      1/1     Running   0          4h48m   172.18.0.3    ambient-control-plane   <none>           <none>
```

```shell
##use fortio to test
root@ubuntu-1:~# kubectl exec -it fortio-client-deployment-6966bf9488-h8wmz    -- fortio load -c 1  -t 30s -qps 0 -jitter=true 10.96.5.66

##Open a new window and enter netns in fortio-client.
root@ambient-worker:/# ss -t
State                Recv-Q                Send-Q                                Local Address:Port                                  Peer Address:Port                    Process
ESTAB                0                     74                                      10.244.1.14:43974                                  10.244.1.13:http-alt


```

### enable bypass control

```shell
root@ubuntu-1:~# kubectl label pod fortio-client-deployment-6966bf9488-h8wmz  kmesh.net/bypass=enabled
pod/fortio-client-deployment-6966bf9488-h8wmz labeled

##use fortio to test
root@ubuntu-1:~# kubectl exec -it fortio-client-deployment-6966bf9488-h8wmz    -- fortio load -c 1  -t 30s -qps 0 -jitter=true 10.96.5.66

##Open a new window and enter netns in fortio-client.
root@ambient-worker:/# ss -t
State                   Recv-Q                Send-Q                                 Local Address:Port                                  Peer Address:Port                Process
ESTAB                   0                     74                                       10.244.1.14:44956                                   10.96.5.66:http
SYN-SENT                0                     1                                        10.244.1.14:60300                                      0.0.0.1:931

```

### disable bypass control

```shell
root@ubuntu-1:~# kubectl label pod fortio-client-deployment-6966bf9488-h8wmz  kmesh.net/bypass-
pod/fortio-client-deployment-6966bf9488-h8wmz unlabeled

##Open a new window and enter netns in fortio-client.
root@ubuntu-1:~# kubectl exec -it fortio-client-deployment-6966bf9488-h8wmz    -- fortio load -c 1  -t 30s -qps 0 -jitter=true 10.96.5.66

root@ambient-worker:/# ss -t
State                   Recv-Q                Send-Q                               Local Address:Port                                Peer Address:Port                    Process
SYN-SENT                0                     1                                      10.244.1.14:32894                                    0.0.0.1:932
ESTAB                   0                     74                                     10.244.1.14:35880                                10.244.1.13:http-alt
SYN-SENT                0                     1                                      10.244.1.14:60300                                    0.0.0.1:931

```

## workload module

```shell
root@ubuntu-1:~# kubectl get pods -A -owide
NAMESPACE            NAME                                            READY   STATUS    RESTARTS   AGE     IP            NODE                    NOMINATED NODE   READINESS GATES
default              fortio-client-deployment-6966bf9488-k5qpd       1/1     Running   0          4h15m   10.244.1.9    ambient-worker          <none>           <none>
default              fortio-server-deployment-97cf895fc-5qj64        1/1     Running   0          4h15m   10.244.1.8    ambient-worker          <none>           <none>
default              fortio-server-deployment-97cf895fc-c7jz9        1/1     Running   0          4h15m   10.244.1.10   ambient-worker          <none>           <none>
istio-system         istio-cni-node-gtdg8                            1/1     Running   0          4h40m   172.18.0.3    ambient-control-plane   <none>           <none>
istio-system         istio-cni-node-vd6mv                            1/1     Running   0          4h40m   172.18.0.2    ambient-worker          <none>           <none>
istio-system         istiod-76c587b7cd-jt778                         1/1     Running   0          4h40m   10.244.1.2    ambient-worker          <none>           <none>
istio-system         ztunnel-8wbkn                                   1/1     Running   0          4h40m   10.244.1.3    ambient-worker          <none>           <none>
istio-system         ztunnel-kjn95                                   1/1     Running   0          4h40m   10.244.0.5    ambient-control-plane   <none>           <none>
kmesh-system         kmesh-x7t8t                                     1/1     Running   0          4h21m   10.244.1.4    ambient-worker          <none>           <none>
kube-system          coredns-565d847f94-7lnc8                        1/1     Running   0          4h42m   10.244.0.3    ambient-control-plane   <none>           <none>

```

```shell
##get svc ip
root@ubuntu-1:~# kubectl get svc
NAME            TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)   AGE
fortio-server   ClusterIP   10.96.5.66   <none>        80/TCP    4h20m
kubernetes      ClusterIP   10.96.0.1    <none>        443/TCP   4h43m

##use fortio to test
root@ubuntu-1:~/lw/kmesh# kubectl exec -it fortio-client-deployment-6966bf9488-k5qpd    -- fortio load -c 1  -t 30s -qps 0 -jitter=true 10.96.5.66

##Open a new window and enter netns in fortio-client.
root@ambient-worker:/# ss -t
State                Recv-Q                Send-Q                                Local Address:Port                                  Peer Address:Port                    Process
ESTAB                0                     74                                       10.244.1.9:44012                                  10.244.1.10:http-alt

```

### enable bypass control

```shell
root@ubuntu-1:~# kubectl label pod fortio-client-deployment-6966bf9488-k5qpd  kmesh.net/bypass=enabled
pod/fortio-client-deployment-6966bf9488-k5qpd labeled

##Open a new window and enter netns in fortio-client.
root@ambient-worker:/# ss -t
State                   Recv-Q                Send-Q                                 Local Address:Port                                  Peer Address:Port                Process
SYN-SENT                0                     1                                         10.244.1.9:49046                                      0.0.0.1:931
ESTAB                   0                     74                                        10.244.1.9:51946                                   10.96.5.66:http
```

### disable bypass control

```shell
root@ubuntu-1:~/lw/kmesh# kubectl label pod fortio-client-deployment-6966bf9488-k5qpd  kmesh.net/bypass-
pod/fortio-client-deployment-6966bf9488-k5qpd unlabeled

##Open a new window and enter netns in fortio-client.
root@ambient-worker:/# ss -t
State                   Recv-Q                Send-Q                               Local Address:Port                                Peer Address:Port                    Process
SYN-SENT                0                     1                                       10.244.1.9:49046                                    0.0.0.1:931
SYN-SENT                0                     1                                       10.244.1.9:36504                                    0.0.0.1:932
ESTAB                   0                     74                                      10.244.1.9:58812                                10.244.1.10:http-alt
```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
