### PR TITLE
fix clang format tool not install

### DIFF
--- a/hack/format.sh
+++ b/hack/format.sh
@@ -19,4 +19,6 @@ function install_clang_format () {
     fi
 }
 
+install_clang_format
+
 find ./ -path "./api/v2-c" -prune -o -name "*.[ch]" -exec clang-format -i {} \;


### PR DESCRIPTION
**What this PR does / why we need it**:
fix clang format tool not install

