### PR TITLE
Kmesh: repair kmesh manager not effect in sockops on oe 23.03

### DIFF
--- a/bpf/kmesh/workload/sockops_tuple.c
+++ b/bpf/kmesh/workload/sockops_tuple.c
@@ -161,7 +161,7 @@ static inline bool conn_from_cni_sim_add(struct bpf_sock_ops *skops)
 			(bpf_ntohl(skops->remote_port) == 0x3a1));
 #else
 	return ((bpf_ntohl(skops->remote_ip4) == 1) &&
-			(bpf_ntohl(skops->remote_port) == 0xa1030000));
+			(bpf_ntohl(skops->remote_port) == 0x3a10000));
 #endif
 }
 
@@ -169,8 +169,13 @@ static inline bool conn_from_cni_sim_delete(struct bpf_sock_ops *skops)
 {
 	// cni sim connect 0.0.0.1:930(0x3a2)
 	// 0x3a2 is the specific port handled by the cni for disable Kmesh
+#if !OE_23_03
 	return ((bpf_ntohl(skops->remote_ip4) == 1) &&
 			(bpf_ntohl(skops->remote_port) == 0x3a2));
+#else
+	return ((bpf_ntohl(skops->remote_ip4) == 1) &&
+			(bpf_ntohl(skops->remote_port) == 0x3a20000));
+#endif
 }
 
 static inline bool ipv4_mapped_addr(__u32 ip6[4])


### PR DESCRIPTION
sockops port is not same as other linux vendor. We need to adapt oe 23.03.

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->
/kind bug
**What this PR does / why we need it**:
repair issue #298 
**Which issue(s) this PR fixes**:
Fixes #
https://github.com/kmesh-net/kmesh/issues/298
**Special notes for your reviewer**:
NA
**Does this PR introduce a user-facing change?**:
NA
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NA
```
