### PR TITLE
Fix the Enhanced Compilation Failure Issue

### DIFF
--- a/pkg/bpf/bpf_kmesh.go
+++ b/pkg/bpf/bpf_kmesh.go
@@ -80,10 +80,10 @@ func (sc *BpfSockOps) NewBpf(cfg *options.BpfConfig) error {
 	return nil
 }
 
-func NewBpfKmesh(cfg *options.BpfConfig) (BpfKmesh, error) {
+func NewBpfKmesh(cfg *options.BpfConfig) (*BpfKmesh, error) {
 	var err error
 
-	sc := BpfKmesh{}
+	sc := &BpfKmesh{}
 
 	sc.TracePoint.NewBpf(cfg)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug



**What this PR does / why we need it**:
Fix the Enhanced Compilation Failure Issue

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
#309 
For enhanced kernel, without changing `BpfKmesh` to pointer type, would report an error `pkg/bpf/bpf.go:58:18: cannot use NewBpfKmesh(l.config) (value of type BpfKmesh) as *BpfKmesh value in assignment` at kmesh-daemon compile time.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
