### PR TITLE
Clean kmesh build docker container in make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,3 +170,7 @@ clean:
 	$(QUIET) make clean -C bpf/deserialization_to_bpf_map
 	$(call printlog, CLEAN, "kernel")
 	$(QUIET) make clean -C kernel/ko_src
+
+	$(QUIET) if docker ps -a -q -f name=kmesh-build | grep -q .; then \
+		docker rm -f kmesh-build; \
+	fi


### PR DESCRIPTION
**What type of PR is this?**
enhancement
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
Sometimes user may interrupt the `make build`(or `make docker`) process, during which a temp docker container named "kmesh-build" will be created. The next time the user `make build`, it will raise an error like 'container kmesh-build already exists'. 

Users should be able to remove `kmesh-build` docker container using `make clean`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
