### PR TITLE
unified handing logic for skops->remote_port/local_port

### DIFF
--- a/bpf/include/bpf_common.h
+++ b/bpf/include/bpf_common.h
@@ -16,14 +16,14 @@
 
 #define map_of_manager      kmesh_manage
 #define MAP_SIZE_OF_MANAGER 8192
-/*0x3a10000 is the specific port handled by the cni to enable kmesh*/
-#define ENABLE_KMESH_PORT 0x3a10000
-/*0x3a20000 is the specific port handled by the cni to enable kmesh*/
-#define DISABLE_KMESH_PORT 0x3a20000
-/*0x3a30000 is the specific port handled by the daemon to enable bypass*/
-#define ENABLE_BYPASS_PORT 0x3a30000
-/*0x3a40000 is the specific port handled by the daemon to enable bypass*/
-#define DISABLE_BYPASS_PORT 0x3a40000
+/*0x3a1(929) is the specific port handled by the cni to enable kmesh*/
+#define ENABLE_KMESH_PORT 0x3a1
+/*0x3a2(930) is the specific port handled by the cni to enable kmesh*/
+#define DISABLE_KMESH_PORT 0x3a2
+/*0x3a3(931) is the specific port handled by the daemon to enable bypass*/
+#define ENABLE_BYPASS_PORT 0x3a3
+/*0x3a4(932) is the specific port handled by the daemon to enable bypass*/
+#define DISABLE_BYPASS_PORT 0x3a4
 
 typedef struct {
     __u32 is_bypassed;
@@ -104,28 +104,28 @@ static inline bool conn_from_bypass_sim_add(struct bpf_sock_addr *ctx)
 {
     // daemon sim connect 0.0.0.0:931(0x3a3)
     // 0x3a3 is the specific port handled by the daemon to enable bypass
-    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == ENABLE_BYPASS_PORT));
+    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohs(ctx->user_port) == ENABLE_BYPASS_PORT));
 }
 
 static inline bool conn_from_bypass_sim_delete(struct bpf_sock_addr *ctx)
 {
     // daemon sim connect 0.0.0.1:932(0x3a4)
     // 0x3a4 is the specific port handled by the daemon to disable bypass
-    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == DISABLE_BYPASS_PORT));
+    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohs(ctx->user_port) == DISABLE_BYPASS_PORT));
 }
 
 static inline bool conn_from_cni_sim_add(struct bpf_sock_addr *ctx)
 {
     // cni sim connect 0.0.0.0:929(0x3a1)
     // 0x3a1 is the specific port handled by the cni to enable Kmesh
-    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == ENABLE_KMESH_PORT));
+    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohs(ctx->user_port) == ENABLE_KMESH_PORT));
 }
 
 static inline bool conn_from_cni_sim_delete(struct bpf_sock_addr *ctx)
 {
     // cni sim connect 0.0.0.1:930(0x3a2)
     // 0x3a2 is the specific port handled by the cni to disable Kmesh
-    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohl(ctx->user_port) == DISABLE_KMESH_PORT));
+    return ((bpf_ntohl(ctx->user_ip4) == 1) && (bpf_ntohs(ctx->user_port) == DISABLE_KMESH_PORT));
 }
 
 /* This function is used to store and delete cookie

--- a/bpf/include/common.h
+++ b/bpf/include/common.h
@@ -69,7 +69,12 @@ static inline int kmesh_map_update_elem(void *map, const void *key, const void *
 }
 
 #if OE_23_03
-#define bpf__strncmp bpf_strncmp
+#define bpf__strncmp                  bpf_strncmp
+#define GET_SKOPS_REMOTE_PORT(sk_ops) (__u16)((sk_ops)->remote_port)
+#else
+#define GET_SKOPS_REMOTE_PORT(sk_ops) (__u16)((sk_ops)->remote_port >> 16)
 #endif
+
+#define GET_SKOPS_LOCAL_PORT(sk_ops) (__u16)((sk_ops)->local_port)
 
 #endif // _COMMON_H_

--- a/bpf/kmesh/ads/sockops.c
+++ b/bpf/kmesh/ads/sockops.c
@@ -33,9 +33,8 @@ static int sockops_traffic_control(struct bpf_sock_ops *skops, struct bpf_mem_pt
     int ret;
     /* 1 lookup listener */
     DECLARE_VAR_ADDRESS(skops, addr);
-#if !OE_23_03
-    addr.port = addr.port >> 16;
-#endif
+    addr.port = GET_SKOPS_REMOTE_PORT(skops);
+
     Listener__Listener *listener = map_lookup_listener(&addr);
 
     if (!listener) {

--- a/bpf/kmesh/workload/include/backend.h
+++ b/bpf/kmesh/workload/include/backend.h
@@ -82,7 +82,7 @@ static inline int backend_manager(ctx_buff_t *ctx, backend_value *backend_v, __u
             return -EINVAL;
         }
         if (service_id == backend_v->service[i]) {
-            BPF_LOG(DEBUG, BACKEND, "access the backend by service:%d\n", service_id);
+            BPF_LOG(DEBUG, BACKEND, "access the backend by service:%u\n", service_id);
 #pragma unroll
             for (__u32 j = 0; j < MAX_PORT_COUNT; j++) {
                 if (user_port == service_v->service_port[j]) {

--- a/oncn-mda/include/mesh_accelerate.h
+++ b/oncn-mda/include/mesh_accelerate.h
@@ -37,6 +37,14 @@ enum bpf_loglevel {
 
 #define BPF_LOGLEVEL BPF_LOG_ERROR
 
+#if OE_23_03
+#define GET_SKOPS_REMOTE_PORT(sk_ops) (__u16)((sk_ops)->remote_port)
+#else
+#define GET_SKOPS_REMOTE_PORT(sk_ops) (__u16)((sk_ops)->remote_port >> 16)
+#endif
+
+#define GET_SKOPS_LOCAL_PORT(sk_ops) (__u16)((sk_ops)->local_port)
+
 #ifndef bpf_printk
 #define bpf_printk(fmt, ...)                                                                                           \
     ({                                                                                                                 \


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:
Current Situation:

bpf_sock_addr:user_port is stored in u16 network order.
bpf_sock_ops:local_port is stored in u32 host order.
bpf_sock_ops:remote_port oe23.03 is stored in u16 network order, while non-oe23.03 is stored in u32 network order.
Currently, the port conversion is scattered throughout the code and not handled consistently.

Proposed Solution:

Treat all ports as u16.
Maintain the byte order as defined originally.
Provide dedicated macros to retrieve the remote_port and local_port of skops.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kmesh-net/kmesh/issues/374

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
