### PR TITLE
Kmesh eBPF log user space dumping

### DIFF
--- a/bpf/include/bpf_log.h
+++ b/bpf/include/bpf_log.h
@@ -39,23 +39,32 @@ struct {
     __uint(max_entries, 1);
     __type(key, int);
     __type(value, struct log_event);
-} heap SEC(".maps");
+} tmp_log_buf SEC(".maps");
 
-#define BPF_LOG(l, t, f, ...)                                                                                          \
-    do {                                                                                                               \
-        int loglevel = BPF_MIN((int)BPF_LOG_LEVEL, ((int)BPF_LOG_DEBUG + (int)(BPF_LOGTYPE_##t)));                     \
-        if ((int)(BPF_LOG_##l) <= loglevel) {                                                                          \
-            char fmt[] = "[" #t "] " #l ": " f "";                                                                     \
-            bpf_trace_printk(fmt, sizeof(fmt), ##__VA_ARGS__);                                                         \
-        }                                                                                                              \
-    } while (0)
+struct {
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(max_entries, 1);
+    __uint(key_size, sizeof(__u32));
+    __uint(value_size, sizeof(__u32));
+} bpf_log_level SEC(".maps");
 
 /* Add this macro to get ip addr from ctx variable, include bpf_sock_addr or bpf_sock_ops, weird
-reason is direct access would not be print ipaddr when pass `&ctx->remote_ipv4` to bpf_trace_printk */
+reason is that would not be print ipaddr, when directly pass `&ctx->remote_ipv4` to bpf_trace_printk, maybe ctx pass in
+to printk would be changed*/
 #define DECLARE_VAR_IPV4(ctx_ip, name)                                                                                 \
     __u32 name = 0;                                                                                                    \
     name = ctx_ip;
 
+#define DECLARE_VAR_IPV6(ctx_ip, name)                                                                                 \
+    __u32 name[4] = {0};                                                                                               \
+    name[0] = ctx_ip[0];                                                                                               \
+    name[1] = ctx_ip[1];                                                                                               \
+    name[2] = ctx_ip[2];                                                                                               \
+    name[3] = ctx_ip[3];
+
+/* Add KERNEL_VERSION_HIGHER_5_13_0 to resolve problem, which kernel version lower than 5.13, or linux distribution
+lower than 22.09, compile would report an error of bpf_snprintf dont exist */
+#if KERNEL_VERSION_HIGHER_5_13_0
 #define Kmesh_BPF_SNPRINTF(out, out_size, fmt, args...)                                                                \
     ({                                                                                                                 \
         unsigned long long ___param[___bpf_narg(args)];                                                                \
@@ -67,22 +76,44 @@ reason is direct access would not be print ipaddr when pass `&ctx->remote_ipv4` 
             bpf_snprintf(out, out_size, fmt, ___param, sizeof(___param));                                              \
     })
 
-#define BPF_LOG_U(l, t, f, args...)                                                                                    \
+#define BPF_LOG_U(fmt, args...)                                                                                        \
+    ({                                                                                                                 \
+        struct log_event *e;                                                                                           \
+        __u32 ret = 0;                                                                                                 \
+        int zero = 0;                                                                                                  \
+        e = bpf_map_lookup_elem(&tmp_log_buf, &zero);                                                                  \
+        if (!e)                                                                                                        \
+            break;                                                                                                     \
+        ret = Kmesh_BPF_SNPRINTF(e->msg, sizeof(e->msg), fmt, args);                                                   \
+        e->ret = ret;                                                                                                  \
+        if (ret < 0)                                                                                                   \
+            break;                                                                                                     \
+        bpf_ringbuf_output(&kmesh_events, e, sizeof(*e), 0);                                                           \
+    })
+#else
+#define BPF_LOG_U(fmt, args...)
+#endif
+
+static inline int map_lookup_log_level()
+{
+    int zero = 0;
+    int *value = NULL;
+    value = kmesh_map_lookup_elem(&bpf_log_level, &zero);
+    if (!value)
+        return 0;
+    return *value;
+}
+
+#define BPF_LOG(l, t, f, ...)                                                                                          \
     do {                                                                                                               \
-        int loglevel = BPF_MIN((int)BPF_LOG_LEVEL, ((int)BPF_LOG_DEBUG + (int)(BPF_LOGTYPE_##t)));                     \
+        int level = map_lookup_log_level();                                                                            \
+        int loglevel = BPF_MIN((int)level, ((int)BPF_LOG_DEBUG + (int)(BPF_LOGTYPE_##t)));                             \
         if ((int)(BPF_LOG_##l) <= loglevel) {                                                                          \
             static const char fmt[] = "[" #t "] " #l ": " f "";                                                        \
-            struct log_event *e;                                                                                       \
-            __u32 ret = 0;                                                                                             \
-            int zero = 0;                                                                                              \
-            e = bpf_map_lookup_elem(&heap, &zero);                                                                     \
-            if (!e)                                                                                                    \
-                break;                                                                                                 \
-            ret = Kmesh_BPF_SNPRINTF(e->msg, sizeof(e->msg), fmt, args);                                               \
-            e->ret = ret;                                                                                              \
-            if (ret < 0)                                                                                               \
-                break;                                                                                                 \
-            bpf_ringbuf_output(&kmesh_events, e, sizeof(*e), 0);                                                       \
+            if (!KERNEL_VERSION_HIGHER_5_13_0)                                                                         \
+                bpf_trace_printk(fmt, sizeof(fmt), ##__VA_ARGS__);                                                     \
+            else                                                                                                       \
+                BPF_LOG_U(fmt, ##__VA_ARGS__);                                                                         \
         }                                                                                                              \
     } while (0)
 

--- a/bpf/include/bpf_log.h
+++ b/bpf/include/bpf_log.h
@@ -16,12 +16,30 @@
 #define BPF_LOGTYPE_SOCKOPS BPF_DEBUG_OFF
 #define BPF_LOGTYPE_XDP     BPF_DEBUG_OFF
 #define BPF_LOGTYPE_SENDMSG BPF_DEBUG_OFF
+#define MAX_MSG_LEN         255
+
 enum bpf_loglevel {
     BPF_LOG_ERR = 0,
     BPF_LOG_WARN,
     BPF_LOG_INFO,
     BPF_LOG_DEBUG,
 };
+
+struct log_event {
+    __u32 ret;
+    char msg[MAX_MSG_LEN];
+};
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(max_entries, 256 * 1024 /* 256 KB */);
+} kmesh_events SEC(".maps");
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, int);
+    __type(value, struct log_event);
+} heap SEC(".maps");
 
 #define BPF_LOG(l, t, f, ...)                                                                                          \
     do {                                                                                                               \
@@ -37,5 +55,35 @@ reason is direct access would not be print ipaddr when pass `&ctx->remote_ipv4` 
 #define DECLARE_VAR_IPV4(ctx_ip, name)                                                                                 \
     __u32 name = 0;                                                                                                    \
     name = ctx_ip;
+
+#define Kmesh_BPF_SNPRINTF(out, out_size, fmt, args...)                                                                \
+    ({                                                                                                                 \
+        unsigned long long ___param[___bpf_narg(args)];                                                                \
+                                                                                                                       \
+        _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wint-conversion\"")                          \
+            ___bpf_fill(___param, args);                                                                               \
+        _Pragma("GCC diagnostic pop")                                                                                  \
+                                                                                                                       \
+            bpf_snprintf(out, out_size, fmt, ___param, sizeof(___param));                                              \
+    })
+
+#define BPF_LOG_U(l, t, f, args...)                                                                                    \
+    do {                                                                                                               \
+        int loglevel = BPF_MIN((int)BPF_LOG_LEVEL, ((int)BPF_LOG_DEBUG + (int)(BPF_LOGTYPE_##t)));                     \
+        if ((int)(BPF_LOG_##l) <= loglevel) {                                                                          \
+            static const char fmt[] = "[" #t "] " #l ": " f "";                                                        \
+            struct log_event *e;                                                                                       \
+            __u32 ret = 0;                                                                                             \
+            int zero = 0;                                                                                              \
+            e = bpf_map_lookup_elem(&heap, &zero);                                                                     \
+            if (!e)                                                                                                    \
+                break;                                                                                                 \
+            ret = Kmesh_BPF_SNPRINTF(e->msg, sizeof(e->msg), fmt, args);                                               \
+            e->ret = ret;                                                                                              \
+            if (ret < 0)                                                                                               \
+                break;                                                                                                 \
+            bpf_ringbuf_output(&kmesh_events, e, sizeof(*e), 0);                                                       \
+        }                                                                                                              \
+    } while (0)
 
 #endif // _BPF_LOG_H_

--- a/bpf/include/common.h
+++ b/bpf/include/common.h
@@ -91,19 +91,6 @@ static inline int kmesh_map_update_elem(void *map, const void *key, const void *
 #define MAX_IP4_LEN 16
 #define MAX_IP6_LEN 40
 
-#ifndef u8
-#define u8 __u8
-#endif
-#ifndef u16
-#define u16 __u16
-#endif
-#ifndef u32
-#define u32 __u32
-#endif
-#ifndef u64
-#define u64 __u64
-#endif
-
 struct buf {
     char data[MAX_IP6_LEN];
 };
@@ -115,20 +102,20 @@ struct {
 } tmp_buf SEC(".maps");
 
 #if KERNEL_VERSION_HIGHER_5_13_0
-static inline int convert_v4(char *data, u32 *ip)
+static inline int convert_v4(char *data, __u32 *ip)
 {
     int ret = 0;
     ret = BPF_SNPRINTF(data, MAX_IP4_LEN, "%pI4h", ip);
     return ret;
 }
 #else
-static inline int convert_v4(char *data, u32 *ip_ptr)
+static inline int convert_v4(char *data, __u32 *ip_ptr)
 {
-    u32 ip = *ip_ptr;
-    u8 ip1 = (ip >> 24) & 0xFF;
-    u8 ip2 = (ip >> 16) & 0xFF;
-    u8 ip3 = (ip >> 8) & 0xFF;
-    u8 ip4 = (ip >> 0) & 0xFF;
+    __u32 ip = *ip_ptr;
+    __u8 ip1 = (ip >> 24) & 0xFF;
+    __u8 ip2 = (ip >> 16) & 0xFF;
+    __u8 ip3 = (ip >> 8) & 0xFF;
+    __u8 ip4 = (ip >> 0) & 0xFF;
 
     char tmp[MAX_IP4_LEN];
     tmp[2] = '0' + (ip1 % 10);
@@ -180,7 +167,7 @@ static inline int convert_v4(char *data, u32 *ip_ptr)
 #endif
 
 #if KERNEL_VERSION_HIGHER_5_13_0
-static inline int convert_v6(char *data, u32 *ip6)
+static inline int convert_v6(char *data, __u32 *ip6)
 {
     int ret = 0;
     ret = BPF_SNPRINTF(data, MAX_IP6_LEN, "%pI6", ip6);
@@ -188,17 +175,17 @@ static inline int convert_v6(char *data, u32 *ip6)
 }
 #else
 static const char hex_digits[16] = "0123456789abcdef";
-static inline int convert_v6(char *data, u32 *ip6)
+static inline int convert_v6(char *data, __u32 *ip6)
 {
 #pragma clang loop unroll(full)
     for (int i = 0; i < 4; i++) {
-        u32 ip = *(ip6 + i);
-        u16 ip_1 = (ip >> 0) & 0xFFFF;
-        u16 ip_2 = (ip >> 16) & 0xFFFF;
+        __u32 ip = *(ip6 + i);
+        __u16 ip_1 = (ip >> 0) & 0xFFFF;
+        __u16 ip_2 = (ip >> 16) & 0xFFFF;
         for (int j = 0; j < 2; j++) {
-            u16 ip_1 = (ip)&0xFFFF;
-            u8 h_1 = (ip_1 >> 0) & 0xFF;
-            u8 h_2 = (ip_1 >> 8) & 0xFF;
+            __u16 ip_1 = (ip)&0xFFFF;
+            __u8 h_1 = (ip_1 >> 0) & 0xFF;
+            __u8 h_2 = (ip_1 >> 8) & 0xFF;
             *data++ = hex_digits[(h_1 >> 4) & 0xF];
             *data++ = hex_digits[(h_1 >> 0) & 0xF];
             *data++ = hex_digits[(h_2 >> 4) & 0xF];
@@ -215,7 +202,7 @@ static inline int convert_v6(char *data, u32 *ip6)
 
 /* 2001:0db8:3333:4444:CCCC:DDDD:EEEE:FFFF */
 /* 192.168.000.001 */
-static inline char *ip2str(u32 *ip_ptr, bool v4)
+static inline char *ip2str(__u32 *ip_ptr, bool v4)
 {
     struct buf *buf;
     int zero = 0;

--- a/bpf/include/common.h
+++ b/bpf/include/common.h
@@ -87,4 +87,150 @@ static inline int kmesh_map_update_elem(void *map, const void *key, const void *
 
 #define GET_SKOPS_LOCAL_PORT(sk_ops) (__u16)((sk_ops)->local_port)
 
-#endif  // _COMMON_H_
+#define MAX_BUF_LEN 100
+#define MAX_IP4_LEN 16
+#define MAX_IP6_LEN 40
+
+#ifndef u8
+#define u8 __u8
+#endif
+#ifndef u16
+#define u16 __u16
+#endif
+#ifndef u32
+#define u32 __u32
+#endif
+#ifndef u64
+#define u64 __u64
+#endif
+
+struct buf {
+    char data[MAX_IP6_LEN];
+};
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, int);
+    __type(value, struct buf);
+} tmp_buf SEC(".maps");
+
+#if KERNEL_VERSION_HIGHER_5_13_0
+static inline int convert_v4(char *data, u32 *ip)
+{
+    int ret = 0;
+    ret = BPF_SNPRINTF(data, MAX_IP4_LEN, "%pI4h", ip);
+    return ret;
+}
+#else
+static inline int convert_v4(char *data, u32 *ip_ptr)
+{
+    u32 ip = *ip_ptr;
+    u8 ip1 = (ip >> 24) & 0xFF;
+    u8 ip2 = (ip >> 16) & 0xFF;
+    u8 ip3 = (ip >> 8) & 0xFF;
+    u8 ip4 = (ip >> 0) & 0xFF;
+
+    char tmp[MAX_IP4_LEN];
+    tmp[2] = '0' + (ip1 % 10);
+    ip1 /= 10;
+    tmp[1] = '0' + (ip1 % 10);
+    ip1 /= 10;
+    tmp[0] = '0' + (ip1 % 10);
+    tmp[3] = '.';
+
+    tmp[6] = '0' + (ip2 % 10);
+    ip2 /= 10;
+    tmp[5] = '0' + (ip2 % 10);
+    ip2 /= 10;
+    tmp[4] = '0' + (ip2 % 10);
+    tmp[7] = '.';
+
+    tmp[10] = '0' + (ip3 % 10);
+    ip3 /= 10;
+    tmp[9] = '0' + (ip3 % 10);
+    ip3 /= 10;
+    tmp[8] = '0' + (ip3 % 10);
+    tmp[11] = '.';
+
+    tmp[14] = '0' + (ip4 % 10);
+    ip4 /= 10;
+    tmp[13] = '0' + (ip4 % 10);
+    ip4 /= 10;
+    tmp[12] = '0' + (ip4 % 10);
+
+    *data++ = tmp[12];
+    *data++ = tmp[13];
+    *data++ = tmp[14];
+    *data++ = tmp[11];
+    *data++ = tmp[8];
+    *data++ = tmp[9];
+    *data++ = tmp[10];
+    *data++ = tmp[7];
+    *data++ = tmp[4];
+    *data++ = tmp[5];
+    *data++ = tmp[6];
+    *data++ = tmp[3];
+    *data++ = tmp[0];
+    *data++ = tmp[1];
+    *data++ = tmp[2];
+
+    *data = '\0';
+    return MAX_IP4_LEN;
+}
+#endif
+
+#if KERNEL_VERSION_HIGHER_5_13_0
+static inline int convert_v6(char *data, u32 *ip6)
+{
+    int ret = 0;
+    ret = BPF_SNPRINTF(data, MAX_IP6_LEN, "%pI6", ip6);
+    return ret;
+}
+#else
+static const char hex_digits[16] = "0123456789abcdef";
+static inline int convert_v6(char *data, u32 *ip6)
+{
+#pragma clang loop unroll(full)
+    for (int i = 0; i < 4; i++) {
+        u32 ip = *(ip6 + i);
+        u16 ip_1 = (ip >> 0) & 0xFFFF;
+        u16 ip_2 = (ip >> 16) & 0xFFFF;
+        for (int j = 0; j < 2; j++) {
+            u16 ip_1 = (ip)&0xFFFF;
+            u8 h_1 = (ip_1 >> 0) & 0xFF;
+            u8 h_2 = (ip_1 >> 8) & 0xFF;
+            *data++ = hex_digits[(h_1 >> 4) & 0xF];
+            *data++ = hex_digits[(h_1 >> 0) & 0xF];
+            *data++ = hex_digits[(h_2 >> 4) & 0xF];
+            *data++ = hex_digits[(h_2 >> 0) & 0xF];
+            *data++ = ':';
+            ip = ip >> 16;
+        }
+    }
+    data--;
+    *data = '\0';
+    return MAX_IP6_LEN;
+}
+#endif
+
+/* 2001:0db8:3333:4444:CCCC:DDDD:EEEE:FFFF */
+/* 192.168.000.001 */
+static inline char *ip2str(u32 *ip_ptr, bool v4)
+{
+    struct buf *buf;
+    int zero = 0;
+    int ret;
+    buf = bpf_map_lookup_elem(&tmp_buf, &zero);
+    if (!buf)
+        return NULL;
+    if (v4) {
+        ret = convert_v4(buf->data, ip_ptr);
+    } else {
+        ret = convert_v6(buf->data, ip_ptr);
+    }
+    if (ret < 0)
+        return NULL;
+    return buf->data;
+}
+
+#endif // _COMMON_H_

--- a/bpf/kmesh/ads/cgroup_sock.c
+++ b/bpf/kmesh/ads/cgroup_sock.c
@@ -36,7 +36,7 @@ static inline int sock4_traffic_control(struct bpf_sock_addr *ctx)
             return -ENOENT;
     }
     DECLARE_VAR_IPV4(ctx->user_ip4, ip);
-    BPF_LOG(DEBUG, KMESH, "bpf find listener addr=[%pI4h:%u]\n", &ip, bpf_ntohs(ctx->user_port));
+    BPF_LOG(DEBUG, KMESH, "bpf find listener addr=[%s:%u]\n", ip2str(&ip, 1), bpf_ntohs(ctx->user_port));
 
 #if ENHANCED_KERNEL
     // todo build when kernel support http parse and route

--- a/bpf/kmesh/ads/include/cluster.h
+++ b/bpf/kmesh/ads/include/cluster.h
@@ -288,9 +288,9 @@ static inline int cluster_handle_loadbalance(Cluster__Cluster *cluster, address_
     BPF_LOG(
         INFO,
         CLUSTER,
-        "cluster=\"%s\", loadbalance to addr=[%pI4h:%u]\n",
+        "cluster=\"%s\", loadbalance to addr=[%s:%u]\n",
         name,
-        &sock_addr->ipv4,
+        ip2str(&sock_addr->ipv4, 1),
         bpf_ntohs(sock_addr->port));
     SET_CTX_ADDRESS(ctx, sock_addr);
     return 0;

--- a/bpf/kmesh/ads/include/cluster.h
+++ b/bpf/kmesh/ads/include/cluster.h
@@ -275,7 +275,7 @@ static inline int cluster_handle_loadbalance(Cluster__Cluster *cluster, address_
 
     ep_identity = cluster_get_ep_identity_by_lb_policy(eps, cluster->lb_policy);
     if (!ep_identity) {
-        BPF_LOG(ERR, CLUSTER, "cluster=\"%s\" handle lb failed, %u\n", name);
+        BPF_LOG(ERR, CLUSTER, "cluster=\"%s\" handle lb failed\n", name);
         return -EAGAIN;
     }
 

--- a/bpf/kmesh/ads/include/filter.h
+++ b/bpf/kmesh/ads/include/filter.h
@@ -184,7 +184,7 @@ int filter_chain_manager(ctx_buff_t *ctx)
     /* filter match */
     ret = filter_chain_filter_match(filter_chain, &addr, ctx, &filter, &filter_idx);
     if (ret != 0) {
-        BPF_LOG(ERR, FILTERCHAIN, "no match filter, addr=%pI4h\n", &addr.ipv4);
+        BPF_LOG(ERR, FILTERCHAIN, "no match filter, addr=%s\n", ip2str(&addr.ipv4, 1));
         return KMESH_TAIL_CALL_RET(-1);
     }
 

--- a/bpf/kmesh/ads/include/listener.h
+++ b/bpf/kmesh/ads/include/listener.h
@@ -103,7 +103,12 @@ static inline int listener_manager(ctx_buff_t *ctx, Listener__Listener *listener
     /* filter chain match */
     ret = listener_filter_chain_match(listener, &addr, ctx, &filter_chain, &filter_chain_idx);
     if (ret != 0) {
-        BPF_LOG(WARN, LISTENER, "filterchain mismatch, unsupport addr=%pI4h:%u\n", &addr.ipv4, bpf_ntohs(addr.port));
+        BPF_LOG(
+            WARN,
+            LISTENER,
+            "filterchain mismatch, unsupport addr=%s:%u\n",
+            ip2str(&addr.ipv4, 1),
+            bpf_ntohs(addr.port));
         return -1;
     }
 

--- a/bpf/kmesh/ads/include/route_config.h
+++ b/bpf/kmesh/ads/include/route_config.h
@@ -362,13 +362,13 @@ int route_config_manager(ctx_buff_t *ctx)
 
     virt_host = virtual_host_match(route_config, &addr, ctx);
     if (!virt_host) {
-        BPF_LOG(ERR, ROUTER_CONFIG, "failed to match virtual host, addr=%pI4h\n", &addr.ipv4);
+        BPF_LOG(ERR, ROUTER_CONFIG, "failed to match virtual host, addr=%s\n", ip2str(&addr.ipv4, 1));
         return KMESH_TAIL_CALL_RET(-1);
     }
 
     route = virtual_host_route_match(virt_host, &addr, ctx, (struct bpf_mem_ptr *)ctx_val->msg);
     if (!route) {
-        BPF_LOG(ERR, ROUTER_CONFIG, "failed to match route action, addr=%pI4h\n", &addr.ipv4);
+        BPF_LOG(ERR, ROUTER_CONFIG, "failed to match route action, addr=%s\n", ip2str(&addr.ipv4, 1));
         return KMESH_TAIL_CALL_RET(-1);
     }
 

--- a/bpf/kmesh/ads/sockops.c
+++ b/bpf/kmesh/ads/sockops.c
@@ -35,9 +35,9 @@ static int sockops_traffic_control(struct bpf_sock_ops *skops, struct bpf_mem_pt
     BPF_LOG(
         DEBUG,
         SOCKOPS,
-        "sockops_traffic_control listener=\"%s\", addr=[%pI4h:%u]\n",
+        "sockops_traffic_control listener=\"%s\", addr=[%s:%u]\n",
         (char *)kmesh_get_ptr_val(listener->name),
-        &ip,
+        ip2str(&ip, 1),
         bpf_ntohs(skops->remote_port));
     return listener_manager(skops, listener, msg);
 }

--- a/bpf/kmesh/workload/cgroup_sock.c
+++ b/bpf/kmesh/workload/cgroup_sock.c
@@ -29,7 +29,7 @@ static inline int sock4_traffic_control(struct kmesh_context *kmesh_ctx)
     }
 
     BPF_LOG(DEBUG, KMESH, "bpf find frontend addr=[%s:%u]\n", ip2str(&ip, 1), bpf_ntohs(ctx->user_port));
-    ret = frontend_manager(ctx, frontend_v);
+    ret = frontend_manager(kmesh_ctx, frontend_v);
     if (ret != 0) {
         if (ret != -ENOENT)
             BPF_LOG(ERR, KMESH, "frontend_manager failed, ret:%d\n", ret);

--- a/bpf/kmesh/workload/cgroup_sock.c
+++ b/bpf/kmesh/workload/cgroup_sock.c
@@ -22,14 +22,14 @@ static inline int sock4_traffic_control(struct kmesh_context *kmesh_ctx)
     DECLARE_FRONTEND_KEY(ctx, &kmesh_ctx->orig_dst_addr, frontend_k);
 
     DECLARE_VAR_IPV4(ctx->user_ip4, ip);
-    BPF_LOG(DEBUG, KMESH, "origin addr=[%pI4h:%u]\n", &ip, bpf_ntohs(ctx->user_port));
+    BPF_LOG(DEBUG, KMESH, "origin addr=[%s:%u]\n", ip2str(&ip, 1), bpf_ntohs(ctx->user_port));
     frontend_v = map_lookup_frontend(&frontend_k);
     if (!frontend_v) {
         return -ENOENT;
     }
 
-    BPF_LOG(DEBUG, KMESH, "bpf find frontend addr=[%pI4h:%u]\n", &ip, bpf_ntohs(ctx->user_port));
-    ret = frontend_manager(kmesh_ctx, frontend_v);
+    BPF_LOG(DEBUG, KMESH, "bpf find frontend addr=[%s:%u]\n", ip2str(&ip, 1), bpf_ntohs(ctx->user_port));
+    ret = frontend_manager(ctx, frontend_v);
     if (ret != 0) {
         if (ret != -ENOENT)
             BPF_LOG(ERR, KMESH, "frontend_manager failed, ret:%d\n", ret);

--- a/bpf/kmesh/workload/include/backend.h
+++ b/bpf/kmesh/workload/include/backend.h
@@ -59,8 +59,8 @@ backend_manager(struct kmesh_context *kmesh_ctx, backend_value *backend_v, __u32
         BPF_LOG(
             DEBUG,
             BACKEND,
-            "find waypoint addr=[%pI4h:%u]",
-            &backend_v->wp_addr.ip4,
+            "find waypoint addr=[%s:%u]\n",
+            ip2str(&backend_v->waypoint_addr, 1),
             bpf_ntohs(backend_v->waypoint_port));
         ret = waypoint_manager(kmesh_ctx, &backend_v->wp_addr, backend_v->waypoint_port);
         if (ret != 0) {
@@ -89,9 +89,9 @@ backend_manager(struct kmesh_context *kmesh_ctx, backend_value *backend_v, __u32
                     BPF_LOG(
                         DEBUG,
                         BACKEND,
-                        "get the backend addr=[%pI4h:%u]",
-                        &kmesh_ctx->dnat_ip.ip4,
-                        bpf_ntohs(kmesh_ctx->dnat_port));
+                        "get the backend addr=[%s:%u]\n",
+                        ip2str(&target_addr.ipv4, 1),
+                        bpf_ntohs(target_addr.port));
                     return 0;
                 }
             }

--- a/bpf/kmesh/workload/include/backend.h
+++ b/bpf/kmesh/workload/include/backend.h
@@ -60,7 +60,7 @@ backend_manager(struct kmesh_context *kmesh_ctx, backend_value *backend_v, __u32
             DEBUG,
             BACKEND,
             "find waypoint addr=[%s:%u]\n",
-            ip2str(&backend_v->waypoint_addr, 1),
+            ip2str(&backend_v->wp_addr.ip4, 1),
             bpf_ntohs(backend_v->waypoint_port));
         ret = waypoint_manager(kmesh_ctx, &backend_v->wp_addr, backend_v->waypoint_port);
         if (ret != 0) {
@@ -90,8 +90,8 @@ backend_manager(struct kmesh_context *kmesh_ctx, backend_value *backend_v, __u32
                         DEBUG,
                         BACKEND,
                         "get the backend addr=[%s:%u]\n",
-                        ip2str(&target_addr.ipv4, 1),
-                        bpf_ntohs(target_addr.port));
+                        ip2str(&backend_v->addr.ip4, 1),
+                        bpf_ntohs(service_v->target_port[j]));
                     return 0;
                 }
             }

--- a/bpf/kmesh/workload/include/backend.h
+++ b/bpf/kmesh/workload/include/backend.h
@@ -90,7 +90,7 @@ backend_manager(struct kmesh_context *kmesh_ctx, backend_value *backend_v, __u32
                         DEBUG,
                         BACKEND,
                         "get the backend addr=[%s:%u]\n",
-                        ip2str(&backend_v->addr.ip4, 1),
+                        ip2str(&kmesh_ctx->dnat_ip.ip4, 1),
                         bpf_ntohs(service_v->target_port[j]));
                     return 0;
                 }

--- a/bpf/kmesh/workload/include/frontend.h
+++ b/bpf/kmesh/workload/include/frontend.h
@@ -41,7 +41,7 @@ static inline int frontend_manager(struct kmesh_context *kmesh_ctx, frontend_val
                 DEBUG,
                 FRONTEND,
                 "find waypoint addr=[%s:%u]\n",
-                ip2str(&backend_v->waypoint_addr, 1),
+                ip2str(&backend_v->wp_addr.ip4, 1),
                 bpf_ntohs(backend_v->waypoint_port));
             ret = waypoint_manager(kmesh_ctx, &backend_v->wp_addr, backend_v->waypoint_port);
             if (ret != 0) {

--- a/bpf/kmesh/workload/include/frontend.h
+++ b/bpf/kmesh/workload/include/frontend.h
@@ -40,8 +40,8 @@ static inline int frontend_manager(struct kmesh_context *kmesh_ctx, frontend_val
             BPF_LOG(
                 DEBUG,
                 FRONTEND,
-                "find waypoint addr=[%pI4h:%u]",
-                &backend_v->wp_addr.ip4,
+                "find waypoint addr=[%s:%u]\n",
+                ip2str(&backend_v->waypoint_addr, 1),
                 bpf_ntohs(backend_v->waypoint_port));
             ret = waypoint_manager(kmesh_ctx, &backend_v->wp_addr, backend_v->waypoint_port);
             if (ret != 0) {

--- a/bpf/kmesh/workload/include/service.h
+++ b/bpf/kmesh/workload/include/service.h
@@ -55,7 +55,7 @@ static inline int service_manager(struct kmesh_context *kmesh_ctx, __u32 service
         return ret;
     }
 
-    BPF_LOG(DEBUG, SERVICE, "load balance type:%u", service_v->lb_policy);
+    BPF_LOG(DEBUG, SERVICE, "load balance type:%u\n", service_v->lb_policy);
     switch (service_v->lb_policy) {
     case LB_POLICY_RANDOM:
         ret = lb_random_handle(kmesh_ctx, service_id, service_v);

--- a/bpf/kmesh/workload/include/service.h
+++ b/bpf/kmesh/workload/include/service.h
@@ -45,8 +45,8 @@ static inline int service_manager(struct kmesh_context *kmesh_ctx, __u32 service
         BPF_LOG(
             DEBUG,
             SERVICE,
-            "find waypoint addr=[%pI4h:%u]",
-            &service_v->wp_addr.ip4,
+            "find waypoint addr=[%s:%u]\n",
+            ip2str(&service_v->waypoint_addr, 1),
             bpf_ntohs(service_v->waypoint_port));
         ret = waypoint_manager(kmesh_ctx, &service_v->wp_addr, service_v->waypoint_port);
         if (ret != 0) {

--- a/bpf/kmesh/workload/include/service.h
+++ b/bpf/kmesh/workload/include/service.h
@@ -46,7 +46,7 @@ static inline int service_manager(struct kmesh_context *kmesh_ctx, __u32 service
             DEBUG,
             SERVICE,
             "find waypoint addr=[%s:%u]\n",
-            ip2str(&service_v->waypoint_addr, 1),
+            ip2str(&service_v->wp_addr.ip4, 1),
             bpf_ntohs(service_v->waypoint_port));
         ret = waypoint_manager(kmesh_ctx, &service_v->wp_addr, service_v->waypoint_port);
         if (ret != 0) {

--- a/bpf/kmesh/workload/xdp.c
+++ b/bpf/kmesh/workload/xdp.c
@@ -83,8 +83,8 @@ static inline int should_shutdown(struct bpf_sock_tuple *tuple_info)
         BPF_LOG(
             INFO,
             XDP,
-            "auth denied, src ip: %pI4h, port: %u\n",
-            &tuple_info->ipv4.saddr,
+            "auth denied, src ip: %s, port: %u\n",
+            ip2str(&tuple_info->ipv4.saddr, 1),
             bpf_ntohs(tuple_info->ipv4.sport));
         bpf_map_delete_elem(&map_of_auth, tuple_info);
         return AUTH_FORBID;

--- a/config/kmesh_marcos_def.h
+++ b/config/kmesh_marcos_def.h
@@ -81,3 +81,8 @@
  * is enabled accordingly.
  * */
 #define LIBBPF_HIGHER_0_6_0_VERSION 0
+
+/*
+
+ */
+#define KERNEL_VERSION_HIGHER_5_13_0 0

--- a/daemon/manager/manager.go
+++ b/daemon/manager/manager.go
@@ -85,7 +85,7 @@ func Execute(configs *options.BootstrapConfigs) error {
 	log.Info("controller Start successful")
 	defer c.Stop()
 
-	statusServer := status.NewServer(c.GetXdsClient(), configs)
+	statusServer := status.NewServer(c.GetXdsClient(), configs, bpfLoader.GetBpfKmeshWorkload())
 	statusServer.StartServer()
 	defer func() {
 		_ = statusServer.StopServer()

--- a/daemon/manager/manager.go
+++ b/daemon/manager/manager.go
@@ -78,7 +78,7 @@ func Execute(configs *options.BootstrapConfigs) error {
 	log.Info("bpf Start successful")
 	defer bpfLoader.Stop()
 
-	c := controller.NewController(configs, bpfLoader.GetBpfKmeshWorkload())
+	c := controller.NewController(configs, bpfLoader.GetBpfKmeshWorkload(), configs.BpfConfig.BpfFsPath, configs.BpfConfig.EnableBpfLog)
 	if err := c.Start(); err != nil {
 		return err
 	}

--- a/daemon/options/bpf.go
+++ b/daemon/options/bpf.go
@@ -32,6 +32,7 @@ type BpfConfig struct {
 	Cgroup2Path      string
 	EnableMda        bool
 	BpfVerifyLogSize int
+	EnableBpfLog     bool
 }
 
 func (c *BpfConfig) AttachFlags(cmd *cobra.Command) {
@@ -39,6 +40,7 @@ func (c *BpfConfig) AttachFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&c.Cgroup2Path, "cgroup2-path", "/mnt/kmesh_cgroup2", "cgroup2 path")
 	cmd.PersistentFlags().StringVar(&c.Mode, "mode", "workload", "controller plane mode, valid values are [ads, workload]")
 	cmd.PersistentFlags().BoolVar(&c.EnableMda, "enable-mda", false, "enable mda")
+	cmd.PersistentFlags().BoolVar(&c.EnableBpfLog, "enable-bpf-log", false, "enable ebpf log in daemon process")
 }
 
 func (c *BpfConfig) ParseConfig() error {

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -8,7 +8,7 @@ deploy:
       tag: latest
     imagePullPolicy: IfNotPresent
     containers:
-      kmeshDaemonArgs: "--mode=workload --enable-bypass=false"
+      kmeshDaemonArgs: "--mode=workload --enable-bypass=false --enable-bpf-log=true"
     resources:
       limits:
         cpu: "1"

--- a/kmesh_macros_env.sh
+++ b/kmesh_macros_env.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
   
 VERSION=$(uname -r | cut -d '.' -f 1)
+KERNEL_VERSION=$(uname -r | cut -d '-' -f 1)
 
 function set_config() {
     sed -i -r -e "s/($1)([ \t]*)([0-9]+)/\1\2$2/" config/kmesh_marcos_def.h
@@ -59,4 +60,10 @@ if [[ "$LIBBPF_VERSION" < "0.6.0" ]]; then
 	set_config LIBBPF_HIGHER_0_6_0_VERSION 0
 else
 	set_config LIBBPF_HIGHER_0_6_0_VERSION 1
+fi
+
+if [[ "$KERNEL_VERSION" < "5.13.0" ]]; then
+	set_config KERNEL_VERSION_HIGHER_5_13_0 0
+else
+	set_config KERNEL_VERSION_HIGHER_5_13_0 1
 fi

--- a/pkg/bpf/bpf_kmesh.go
+++ b/pkg/bpf/bpf_kmesh.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
+
 	"kmesh.net/kmesh/bpf/kmesh/bpf2go"
 	"kmesh.net/kmesh/daemon/options"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -28,4 +28,7 @@ const (
 	XDP_PROG_NAME = "xdp_shutdown"
 
 	RootCertPath = "/var/run/secrets/istio/root-cert.pem"
+
+	BPF_LOG_ERR   = 0
+	BPF_LOG_DEBUG = 3
 )

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -41,8 +41,8 @@ type Controller struct {
 	client              *XdsClient
 	enableByPass        bool
 	enableSecretManager bool
-	bpfFsPath      string
-	enableBpfLog   bool
+	bpfFsPath           string
+	enableBpfLog        bool
 }
 
 func NewController(opts *options.BootstrapConfigs, bpfWorkloadObj *bpf.BpfKmeshWorkload, bpfFsPath string, enableBpfLog bool) *Controller {
@@ -51,8 +51,8 @@ func NewController(opts *options.BootstrapConfigs, bpfWorkloadObj *bpf.BpfKmeshW
 		enableByPass:        opts.ByPassConfig.EnableByPass,
 		bpfWorkloadObj:      bpfWorkloadObj,
 		enableSecretManager: opts.SecretManagerConfig.Enable,
-		bpfFsPath:      bpfFsPath,
-		enableBpfLog:   enableBpfLog,
+		bpfFsPath:           bpfFsPath,
+		enableBpfLog:        enableBpfLog,
 	}
 }
 
@@ -75,11 +75,11 @@ func (c *Controller) Start() error {
 		return nil
 	}
 
-if c.enableBpfLog {
-	if err := logger.StartRingBufReader(ctx, c.mode, c.bpfFsPath); err != nil {
-		return fmt.Errorf("fail to start ringbuf reader: %v", err)
+	if c.enableBpfLog {
+		if err := logger.StartRingBufReader(ctx, c.mode, c.bpfFsPath); err != nil {
+			return fmt.Errorf("fail to start ringbuf reader: %v", err)
+		}
 	}
-}
 	c.client = NewXdsClient(c.mode, c.bpfWorkloadObj)
 	if c.client.WorkloadController != nil {
 		if c.enableSecretManager {

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -140,7 +140,7 @@ func handleLogEvents(ctx context.Context, rbMap *ebpf.Map) {
 			if err != nil {
 				log.Errorf("ringbuf decode data failed:%v", err)
 			}
-			log.Infof("ebpf_log:%v", le.Msg)
+			log.Infof("%v", le.Msg)
 		}
 	}
 }

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -33,6 +33,7 @@ import (
 	"kmesh.net/kmesh/api/v2/workloadapi/security"
 	"kmesh.net/kmesh/daemon/options"
 	"kmesh.net/kmesh/pkg/bpf"
+	"kmesh.net/kmesh/pkg/constants"
 	"kmesh.net/kmesh/pkg/controller"
 	"kmesh.net/kmesh/pkg/controller/ads"
 	"kmesh.net/kmesh/pkg/logger"
@@ -205,7 +206,7 @@ func (s *Server) bpfLogLevel(w http.ResponseWriter, r *http.Request) {
 	matches := pattern.FindStringSubmatch(r.URL.Path)
 	if len(matches) > 1 {
 		level, err := strconv.Atoi(matches[1])
-		if err != nil || (level < 0 || level > 3) {
+		if err != nil || (level < constants.BPF_LOG_ERR || level > constants.BPF_LOG_DEBUG) {
 			http.Error(w, "Invalid log level", http.StatusBadRequest)
 			return
 		}

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -21,14 +21,18 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/pprof"
+	"regexp"
+	"strconv"
 	"time"
 
 	// nolint
+	"github.com/cilium/ebpf"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	adminv2 "kmesh.net/kmesh/api/v2/admin"
 	"kmesh.net/kmesh/api/v2/workloadapi/security"
 	"kmesh.net/kmesh/daemon/options"
+	"kmesh.net/kmesh/pkg/bpf"
 	"kmesh.net/kmesh/pkg/controller"
 	"kmesh.net/kmesh/pkg/controller/ads"
 	"kmesh.net/kmesh/pkg/logger"
@@ -46,26 +50,29 @@ const (
 	patternConfigDumpAds      = configDumpPrefix + "/ads"
 	patternConfigDumpWorkload = configDumpPrefix + "/workload"
 	patternReadyProbe         = "/debug/ready"
+	patternBpfLogLevel        = "/debug/bpfLogLevel/"
 
 	httpTimeout = time.Second * 20
 )
 
 type Server struct {
-	config    *options.BootstrapConfigs
-	xdsClient *controller.XdsClient
-	mux       *http.ServeMux
-	server    *http.Server
+	config         *options.BootstrapConfigs
+	xdsClient      *controller.XdsClient
+	mux            *http.ServeMux
+	server         *http.Server
+	bpfWorkloadObj *bpf.BpfKmeshWorkload
 }
 
 func GetConfigDumpAddr(mode string) string {
 	return "http://" + adminAddr + configDumpPrefix + "/" + mode
 }
 
-func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs) *Server {
+func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs, bpfWorkloadObj *bpf.BpfKmeshWorkload) *Server {
 	s := &Server{
-		config:    configs,
-		xdsClient: c,
-		mux:       http.NewServeMux(),
+		config:         configs,
+		xdsClient:      c,
+		mux:            http.NewServeMux(),
+		bpfWorkloadObj: bpfWorkloadObj,
 	}
 	s.server = &http.Server{
 		Addr:         adminAddr,
@@ -79,6 +86,7 @@ func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs) *Serv
 	s.mux.HandleFunc(patternBpfAdsMaps, s.bpfAdsMaps)
 	s.mux.HandleFunc(patternConfigDumpAds, s.configDumpAds)
 	s.mux.HandleFunc(patternConfigDumpWorkload, s.configDumpWorkload)
+	s.mux.HandleFunc(patternBpfLogLevel, s.bpfLogLevel)
 
 	// TODO: add dump certificate, authorizationPolicies and services
 	s.mux.HandleFunc(patternReadyProbe, s.readyProbe)
@@ -190,6 +198,27 @@ func (s *Server) readyProbe(w http.ResponseWriter, r *http.Request) {
 	// TODO: Add some components check
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("OK"))
+}
+
+func (s *Server) bpfLogLevel(w http.ResponseWriter, r *http.Request) {
+	pattern := regexp.MustCompile(`^/debug/bpfLogLevel/(\d+)$`)
+	matches := pattern.FindStringSubmatch(r.URL.Path)
+	if len(matches) > 1 {
+		level, err := strconv.Atoi(matches[1])
+		if err != nil || (level < 0 || level > 3) {
+			http.Error(w, "Invalid log level", http.StatusBadRequest)
+			return
+		}
+		key := uint32(0)
+		levelPtr := uint32(level)
+		if err := s.bpfWorkloadObj.SockConn.BpfLogLevel.Update(&key, &levelPtr, ebpf.UpdateAny); err != nil {
+			http.Error(w, fmt.Errorf("update log level error:%v", err).Error(), http.StatusBadRequest)
+			return
+		}
+		fmt.Fprintf(w, "BPF Log Level: %d\n", level)
+	} else {
+		http.NotFound(w, r)
+	}
 }
 
 func (s *Server) StartServer() {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/kind enhancement
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

1. Kmesh eBPF log user space dumping.
version > 5.13 dump bpf log to userspace, otherwise print log in trace pipe.

2. Support dynamic bpf log level.
 `k exec ds/kmesh -n kmesh-system -- curl -s localhost:15200/debug/bpfLogLevel/3`

**Which issue(s) this PR fixes**:
Fixes [388](https://github.com/kmesh-net/kmesh/issues/388)

**Special notes for your reviewer**:
![bpf_log_3](https://github.com/kmesh-net/kmesh/assets/39798612/4ead1822-5dc8-47f9-97a4-52fb9f73f1ae)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
When print bpf log to kmesh daemon process or user space,  just use BPF_LOG_U instead of BPF_LOG, the args which input is same as BPF_LOG.
```release-note

```
