### PR TITLE
use peer_metadata to get pod metadata info from istiod

### DIFF
--- a/deploy/helm/templates/l7-envoyfilter.yaml
+++ b/deploy/helm/templates/l7-envoyfilter.yaml
@@ -20,11 +20,33 @@ spec:
             port_value: 15019
         filter_chains:
         - filters:
-          - name: "envoy.filters.network.tcp_proxy"
+          - name: envoy.filters.network.http_connection_manager
             typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-              stat_prefix: main_interval
-              cluster: main_internal
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: kmesh
+              route_config:
+                name: default
+                virtual_hosts:
+                - name: default
+                  domains:
+                  - '*'
+                  routes:
+                  - match:
+                      prefix: "/"
+                    route:
+                      cluster: main_internal
+              http_filters:
+              - name: waypoint_downstream_peer_metadata
+                typed_config:
+                  "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+                  type_url: type.googleapis.com/io.istio.http.peer_metadata.Config
+                  value:
+                    downstream_discovery:
+                    - workload_discovery: {}
+                    shared_with_upstream: true
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
         listener_filters:
         - name: "envoy.listener.kmesh_tlv"
           typed_config:

--- a/deploy/yaml/l7-envoyfilter.yaml
+++ b/deploy/yaml/l7-envoyfilter.yaml
@@ -20,11 +20,33 @@ spec:
             port_value: 15019
         filter_chains:
         - filters:
-          - name: "envoy.filters.network.tcp_proxy"
+          - name: envoy.filters.network.http_connection_manager
             typed_config:
-              "@type": type.googleapis.com/envoy.extensions.filters.network.tcp_proxy.v3.TcpProxy
-              stat_prefix: main_interval
-              cluster: main_internal
+              "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+              stat_prefix: kmesh
+              route_config:
+                name: default
+                virtual_hosts:
+                - name: default
+                  domains:
+                  - '*'
+                  routes:
+                  - match:
+                      prefix: "/"
+                    route:
+                      cluster: main_internal
+              http_filters:
+              - name: waypoint_downstream_peer_metadata
+                typed_config:
+                  "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+                  type_url: type.googleapis.com/io.istio.http.peer_metadata.Config
+                  value:
+                    downstream_discovery:
+                    - workload_discovery: {}
+                    shared_with_upstream: true
+              - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
         listener_filters:
         - name: "envoy.listener.kmesh_tlv"
           typed_config:


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

use `peer_metadata` http filter to get pod metadata from istiod

**What this PR does / why we need it**:

So we could get necessary fields to fill observability information

**Before this modification, the metric is :**

istio_requests_total{reporter="destination",source_workload="unknown",source_canonical_service="unknown",source_canonical_revision="latest",source_workload_namespace="unknown",source_principal="unknown",source_app="unknown",source_version="unknown",source_cluster="unknown",destination_workload="reviews-v1",destination_workload_namespace="default",destination_principal="unknown",destination_app="unknown",destination_version="unknown",destination_service="reviews.default.svc.cluster.local",destination_canonical_service="reviews",destination_canonical_revision="v1",destination_service_name="reviews",destination_service_namespace="default",destination_cluster="Kubernetes",request_protocol="http",response_code="200",grpc_response_status="",response_flags="-",connection_security_policy="none"} 93

**After this modification:**

istio_requests_total{reporter="destination",source_workload="productpage-v1",source_canonical_service="productpage",source_canonical_revision="v1",source_workload_namespace="default",source_principal="unknown",source_app="productpage",source_version="v1",source_cluster="Kubernetes",destination_workload="reviews-v1",destination_workload_namespace="default",destination_principal="unknown",destination_app="unknown",destination_version="unknown",destination_service="reviews.default.svc.cluster.local",destination_canonical_service="reviews",destination_canonical_revision="v1",destination_service_name="reviews",destination_service_namespace="default",destination_cluster="Kubernetes",request_protocol="http",response_code="200",grpc_response_status="",response_flags="-",connection_security_policy="none"} 1

**And the metric from waypoint in ambient mesh:**

istio_requests_total{reporter="destination",source_workload="productpage-v1",source_canonical_service="productpage",source_canonical_revision="v1",source_workload_namespace="default",source_principal="spiffe://cluster.local/ns/default/sa/bookinfo-productpage",source_app="productpage",source_version="v1",source_cluster="Kubernetes",destination_workload="reviews-v1",destination_workload_namespace="default",destination_principal="spiffe://cluster.local/ns/default/sa/bookinfo-reviews-istio-waypoint",destination_app="unknown",destination_version="unknown",destination_service="reviews.default.svc.cluster.local",destination_canonical_service="reviews",destination_canonical_revision="v1",destination_service_name="reviews",destination_service_namespace="default",destination_cluster="Kubernetes",request_protocol="http",response_code="200",grpc_response_status="",response_flags="-",connection_security_policy="mutual_tls"} 34


We have basically filled in all the fields, compared with ambient.

**Which issue(s) this PR fixes**:
Fixes part of #320

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
