### PR TITLE
Improve security manager

### DIFF
--- a/daemon/manager/manager.go
+++ b/daemon/manager/manager.go
@@ -76,7 +76,7 @@ func Execute(configs *options.BootstrapConfigs) error {
 	log.Info("bpf Start successful")
 	defer bpfLoader.Stop()
 
-	c := controller.NewController(configs.BpfConfig.Mode, configs.ByPassConfig.EnableByPass, bpfLoader.GetBpfKmeshWorkload())
+	c := controller.NewController(configs, bpfLoader.GetBpfKmeshWorkload())
 	if err := c.Start(); err != nil {
 		return err
 	}

--- a/daemon/options/options.go
+++ b/daemon/options/options.go
@@ -25,16 +25,18 @@ import (
 )
 
 type BootstrapConfigs struct {
-	BpfConfig    *BpfConfig
-	CniConfig    *cniConfig
-	ByPassConfig *byPassConfig
+	BpfConfig           *BpfConfig
+	CniConfig           *cniConfig
+	ByPassConfig        *byPassConfig
+	SecretManagerConfig *secretConfig
 }
 
 func NewBootstrapConfigs() *BootstrapConfigs {
 	return &BootstrapConfigs{
-		BpfConfig:    &BpfConfig{},
-		CniConfig:    &cniConfig{},
-		ByPassConfig: &byPassConfig{},
+		BpfConfig:           &BpfConfig{},
+		CniConfig:           &cniConfig{},
+		ByPassConfig:        &byPassConfig{},
+		SecretManagerConfig: &secretConfig{},
 	}
 }
 
@@ -51,6 +53,7 @@ func (c *BootstrapConfigs) AttachFlags(cmd *cobra.Command) {
 	c.BpfConfig.AttachFlags(cmd)
 	c.CniConfig.AttachFlags(cmd)
 	c.ByPassConfig.AttachFlags(cmd)
+	c.SecretManagerConfig.AttachFlags(cmd)
 }
 
 func (c *BootstrapConfigs) ParseConfigs() error {

--- a/daemon/options/secret_manager.go
+++ b/daemon/options/secret_manager.go
@@ -1,0 +1,28 @@
+/* Copyright 2024 The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type secretConfig struct {
+	Enable bool
+}
+
+func (c *secretConfig) AttachFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().BoolVar(&c.Enable, "enable-secret-manager", false, "whether to start secret manager or not, default to false")
+}

--- a/pkg/controller/security/caclient.go
+++ b/pkg/controller/security/caclient.go
@@ -158,20 +158,6 @@ func (c *caClient) fetchCert(identity string) (*security.SecretItem, error) {
 	}, nil
 }
 
-func (c *caClient) reconnect() error {
-	if err := c.conn.Close(); err != nil {
-		return fmt.Errorf("failed to close connection: %v", err)
-	}
-
-	conn, err := nets.GrpcConnect(caAddress)
-	if err != nil {
-		return err
-	}
-	c.conn = conn
-	c.client = pb.NewIstioCertificateServiceClient(conn)
-	return nil
-}
-
 func (c *caClient) close() error {
 	return c.conn.Close()
 }

--- a/pkg/controller/security/caclient.go
+++ b/pkg/controller/security/caclient.go
@@ -58,7 +58,7 @@ func newCaClient(opts *security.Options, tlsOpts *tlsOptions) (*caClient, error)
 		opts:    opts,
 	}
 
-	conn, err := nets.GrpcConnect(CSRSignAddress)
+	conn, err := nets.GrpcConnect(caAddress)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create grpcconnect : %v", err)
 	}
@@ -91,14 +91,7 @@ func (c *caClient) csrSend(csrPEM []byte, certValidsec int64, identity string) (
 	// when certificate acquisition fails. If it still fails, return an error.
 	resp, err := c.client.CreateCertificate(ctx, req)
 	if err != nil {
-		log.Errorf("create certificate failed: %v reconnect...", err)
-		if err := c.reconnect(); err != nil {
-			return nil, fmt.Errorf("reconnect error: %v", err)
-		}
-		resp, err = c.client.CreateCertificate(ctx, req)
-		if err != nil {
-			return nil, fmt.Errorf("create certificate: %v", err)
-		}
+		return nil, fmt.Errorf("create certificate failed: %v", err)
 	}
 
 	if len(resp.CertChain) <= 1 {
@@ -170,7 +163,7 @@ func (c *caClient) reconnect() error {
 		return fmt.Errorf("failed to close connection: %v", err)
 	}
 
-	conn, err := nets.GrpcConnect(CSRSignAddress)
+	conn, err := nets.GrpcConnect(caAddress)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/security/caclient.go
+++ b/pkg/controller/security/caclient.go
@@ -91,7 +91,7 @@ func (c *caClient) csrSend(csrPEM []byte, certValidsec int64, identity string) (
 	// when certificate acquisition fails. If it still fails, return an error.
 	resp, err := c.client.CreateCertificate(ctx, req)
 	if err != nil {
-		log.Errorf("create certificate: %v reconnect...", err)
+		log.Errorf("create certificate failed: %v reconnect...", err)
 		if err := c.reconnect(); err != nil {
 			return nil, fmt.Errorf("reconnect error: %v", err)
 		}
@@ -141,7 +141,7 @@ func (c *caClient) fetchCert(identity string) (*security.SecretItem, error) {
 	}
 	certChainPEM, err := c.csrSend(csrPEM, int64(c.opts.SecretTTL.Seconds()), identity)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get certChainPEM: %v", err)
+		return nil, err
 	}
 
 	certChain := standardCerts(certChainPEM)
@@ -154,7 +154,7 @@ func (c *caClient) fetchCert(identity string) (*security.SecretItem, error) {
 
 	rootCertPEM = []byte(certChainPEM[len(certChainPEM)-1])
 
-	log.Debugf("cert for %v ExpireTime :%v", identity, expireTime)
+	log.Debugf("cert for %v expireTime :%v", identity, expireTime)
 	return &security.SecretItem{
 		CertificateChain: certChain,
 		PrivateKey:       keyPEM,

--- a/pkg/controller/security/manager.go
+++ b/pkg/controller/security/manager.go
@@ -185,7 +185,7 @@ func (s *SecretManager) rotateCerts() {
 func (s *SecretManager) fetchCert(identity string) {
 	newCert, err := s.caClient.fetchCert(identity)
 	if err != nil {
-		log.Errorf("fetcheCert %v error: %v", identity, err)
+		log.Errorf("fetchCert for [%v] error: %v", identity, err)
 		// TODO: backoff retry
 		time.AfterFunc(time.Second, func() {
 			s.SendCertRequest(identity, RETRY)

--- a/pkg/controller/security/manager.go
+++ b/pkg/controller/security/manager.go
@@ -184,8 +184,6 @@ func (s *SecretManager) addCert(identity string) {
 	newCert, err := s.caClient.fetchCert(identity)
 	if err != nil {
 		log.Errorf("fetcheCert %v error: %v", identity, err)
-		// in case fetchCert failed, retry
-		s.certRequestChan <- certRequest{Identity: identity, Operation: ADD}
 		return
 	}
 

--- a/pkg/controller/security/option.go
+++ b/pkg/controller/security/option.go
@@ -26,6 +26,7 @@ import (
 const (
 	ADD = iota
 	DELETE
+	RETRY
 	Rotate
 
 	maxConcurrentCSR = 128 // max concurrent CSR
@@ -42,8 +43,8 @@ func NewSecurityOptions() *security.Options {
 }
 
 var (
-	CSRSignAddress = env.Register("CA_CONTROLLER", "istiod.istio-system.svc:15012", "").Get()
-	secretTTLEnv   = env.Register("SECRET_TTL", 24*time.Hour,
+	caAddress    = env.Register("CA_ADDRESS", "istiod.istio-system.svc:15012", "").Get()
+	secretTTLEnv = env.Register("SECRET_TTL", 24*time.Hour,
 		"The cert lifetime requested by kmesh CA agent").Get()
 
 	workloadRSAKeySizeEnv = env.Register("WORKLOAD_RSA_KEY_SIZE", 2048,

--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -52,7 +52,7 @@ type Processor struct {
 	// endpoint indexer, svc key -> workload id -> endpoint
 	endpointsByService map[string]map[string]Endpoint
 	bpf                *bpf.Cache
-	Sm                 *kmeshsecurity.SecretManager
+	SecretManager      *kmeshsecurity.SecretManager
 	nodeName           string
 	WorkloadCache      cache.WorkloadCache
 	ServiceCache       cache.ServiceCache
@@ -183,13 +183,15 @@ func (p *Processor) removeWorkloadResource(removedResources []string) error {
 	)
 
 	for _, uid := range removedResources {
-		exist := p.WorkloadCache.GetWorkloadByUid(uid)
-		if exist != nil && p.isManagedWorkload(exist) {
-			Identity := p.getIdentityByUid(uid)
-			p.Sm.SendCertRequest(Identity, kmeshsecurity.DELETE)
+		if p.SecretManager != nil {
+			exist := p.WorkloadCache.GetWorkloadByUid(uid)
+			if exist != nil && p.isManagedWorkload(exist) {
+				Identity := p.getIdentityByUid(uid)
+				p.SecretManager.SendCertRequest(Identity, kmeshsecurity.DELETE)
+			}
 		}
-		p.WorkloadCache.DeleteWorkload(uid)
 
+		p.WorkloadCache.DeleteWorkload(uid)
 		backendUid := p.hashName.StrToNum(uid)
 		// for Pod to Pod access, Pod info stored in frontend map, when Pod offline, we need delete the related records
 		if err = p.deletePodFrontendData(backendUid); err != nil {
@@ -466,7 +468,7 @@ func (p *Processor) handleDataWithoutService(workload *workloadapi.Workload) err
 
 func (p *Processor) handleWorkload(workload *workloadapi.Workload) error {
 	log.Debugf("handle workload: %s", workload.Uid)
-	if p.isManagedWorkload(workload) {
+	if p.SecretManager != nil && p.isManagedWorkload(workload) {
 		wl := p.WorkloadCache.GetWorkloadByUid(workload.Uid)
 		// only send cert request for a workload once
 		// because workload identity can be updated
@@ -477,7 +479,7 @@ func (p *Processor) handleWorkload(workload *workloadapi.Workload) error {
 				ServiceAccount: workload.ServiceAccount,
 			}.String()
 			// This is the case workload added first time
-			p.Sm.SendCertRequest(identity, kmeshsecurity.ADD)
+			p.SecretManager.SendCertRequest(identity, kmeshsecurity.ADD)
 		}
 	}
 

--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -467,15 +467,17 @@ func (p *Processor) handleDataWithoutService(workload *workloadapi.Workload) err
 func (p *Processor) handleWorkload(workload *workloadapi.Workload) error {
 	log.Debugf("handle workload: %s", workload.Uid)
 	if p.isManagedWorkload(workload) {
-		oldIdentity := p.getIdentityByUid(workload.Uid)
-		if oldIdentity == "" {
-			newIdentity := spiffe.Identity{
+		wl := p.WorkloadCache.GetWorkloadByUid(workload.Uid)
+		// only send cert request for a workload once
+		// because workload identity can be updated
+		if wl == nil {
+			identity := spiffe.Identity{
 				TrustDomain:    workload.TrustDomain,
 				Namespace:      workload.Namespace,
 				ServiceAccount: workload.ServiceAccount,
 			}.String()
 			// This is the case workload added first time
-			p.Sm.SendCertRequest(newIdentity, kmeshsecurity.ADD)
+			p.Sm.SendCertRequest(identity, kmeshsecurity.ADD)
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

It does many enhancements:

1. added a flag `enable-secret-manager` to allow turn off secret manager
2. Add a separate `retry` fetching cert
3. Removed reconnect, actually grpc connection can be reconnected automatically when the underlying connection closed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
