### PR TITLE
Fix bug when delete waypoint, dont update bpf kmesh_service map

### DIFF
--- a/bpf/kmesh/workload/include/endpoint.h
+++ b/bpf/kmesh/workload/include/endpoint.h
@@ -22,7 +22,7 @@ endpoint_manager(ctx_buff_t *ctx, endpoint_value *endpoint_v, __u32 service_id, 
     backend_k.backend_uid = endpoint_v->backend_uid;
     backend_v = map_lookup_backend(&backend_k);
     if (!backend_v) {
-        BPF_LOG(WARN, ENDPOINT, "find backend failed");
+        BPF_LOG(WARN, ENDPOINT, "find backend %u failed", backend_k.backend_uid);
         return -ENOENT;
     }
 

--- a/bpf/kmesh/workload/include/service.h
+++ b/bpf/kmesh/workload/include/service.h
@@ -23,7 +23,7 @@ static inline int lb_random_handle(ctx_buff_t *ctx, __u32 service_id, service_va
 
     endpoint_v = map_lookup_endpoint(&endpoint_k);
     if (!endpoint_v) {
-        BPF_LOG(WARN, SERVICE, "find endpoint failed");
+        BPF_LOG(WARN, SERVICE, "find endpoint [%u/%u] failed", service_id, endpoint_k.backend_index);
         return -ENOENT;
     }
 

--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -390,8 +390,7 @@ func (p *Processor) handleDataWithService(workload *workloadapi.Workload) error 
 		return err
 	}
 
-	for serviceName, _ := range workload.GetServices() {
-		p.storeServiceEndpoint(workload.GetUid(), serviceName)
+	for serviceName := range workload.GetServices() {
 		bk.BackendUid = backend_uid
 		// for update sense, if the backend is exist, just need update it
 		if err = p.bpf.BackendLookup(&bk, &bv); err != nil {
@@ -402,6 +401,8 @@ func (p *Processor) handleDataWithService(workload *workloadapi.Workload) error 
 					log.Errorf("storeEndpointWithService failed, err:%s", err)
 					return err
 				}
+			} else {
+				p.storeServiceEndpoint(workload.GetUid(), serviceName)
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
In istio 1.22.1, when delete a waypoint, which proxy for a certain k8s service, the workload_processor don't update kmesh_service bpf map, end up to still route to the old waypoint.

**Which issue(s) this PR fixes**:
Fixes #406

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
