### PR TITLE
Fix bpfloglevel update error bug in Ads mode.

### DIFF
--- a/daemon/manager/manager.go
+++ b/daemon/manager/manager.go
@@ -87,7 +87,7 @@ func Execute(configs *options.BootstrapConfigs) error {
 	log.Info("controller Start successful")
 	defer c.Stop()
 
-	statusServer := status.NewServer(c.GetXdsClient(), configs, bpfLoader.GetBpfKmeshWorkload())
+	statusServer := status.NewServer(c.GetXdsClient(), configs, bpfLoader.GetBpfLogLevel())
 	statusServer.StartServer()
 	defer func() {
 		_ = statusServer.StopServer()

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -49,6 +49,7 @@ type BpfLoader struct {
 
 	obj         *BpfKmesh
 	workloadObj *BpfKmeshWorkload
+	bpfLogLevel *ebpf.Map
 }
 
 func NewBpfLoader(config *options.BpfConfig) *BpfLoader {
@@ -80,6 +81,7 @@ func (l *BpfLoader) StartAdsMode() (err error) {
 		return fmt.Errorf("api env config failed, %s", err)
 	}
 
+	l.bpfLogLevel = l.obj.SockConn.BpfLogLevel
 	ret := C.deserial_init()
 	if ret != 0 {
 		l.Stop()
@@ -131,6 +133,13 @@ func (l *BpfLoader) GetBpfKmeshWorkload() *BpfKmeshWorkload {
 		return nil
 	}
 	return l.workloadObj
+}
+
+func (l *BpfLoader) GetBpfLogLevel() *ebpf.Map {
+	if l == nil {
+		return nil
+	}
+	return l.bpfLogLevel
 }
 
 func StopMda() error {

--- a/pkg/bpf/bpf_kmesh_l4_workload.go
+++ b/pkg/bpf/bpf_kmesh_l4_workload.go
@@ -68,7 +68,7 @@ func (l *BpfLoader) StartWorkloadMode() error {
 		l.Stop()
 		return fmt.Errorf("bpf Attach failed, %s", err)
 	}
-
+	l.bpfLogLevel = l.workloadObj.SockConn.BpfLogLevel
 	return nil
 }
 

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -34,7 +34,6 @@ import (
 	adminv2 "kmesh.net/kmesh/api/v2/admin"
 	"kmesh.net/kmesh/api/v2/workloadapi/security"
 	"kmesh.net/kmesh/daemon/options"
-	"kmesh.net/kmesh/pkg/bpf"
 	"kmesh.net/kmesh/pkg/constants"
 	"kmesh.net/kmesh/pkg/controller"
 	"kmesh.net/kmesh/pkg/controller/ads"
@@ -64,7 +63,7 @@ type Server struct {
 	xdsClient      *controller.XdsClient
 	mux            *http.ServeMux
 	server         *http.Server
-	bpfWorkloadObj *bpf.BpfKmeshWorkload
+	bpfLogLevelMap *ebpf.Map
 }
 
 func GetConfigDumpAddr(mode string) string {
@@ -75,12 +74,12 @@ func GetLoggerURL() string {
 	return "http://" + adminAddr + patternLoggers
 }
 
-func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs, bpfWorkloadObj *bpf.BpfKmeshWorkload) *Server {
+func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs, bpfLogLevel *ebpf.Map) *Server {
 	s := &Server{
 		config:         configs,
 		xdsClient:      c,
 		mux:            http.NewServeMux(),
-		bpfWorkloadObj: bpfWorkloadObj,
+		bpfLogLevelMap: bpfLogLevel,
 	}
 	s.server = &http.Server{
 		Addr:         adminAddr,
@@ -295,7 +294,7 @@ func (s *Server) bpfLogLevel(w http.ResponseWriter, r *http.Request) {
 		}
 		key := uint32(0)
 		levelPtr := uint32(level)
-		if err := s.bpfWorkloadObj.SockConn.BpfLogLevel.Update(&key, &levelPtr, ebpf.UpdateAny); err != nil {
+		if err := s.bpfLogLevelMap.Update(&key, &levelPtr, ebpf.UpdateAny); err != nil {
 			http.Error(w, fmt.Errorf("update log level error:%v", err).Error(), http.StatusBadRequest)
 			return
 		}

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -294,6 +294,10 @@ func (s *Server) bpfLogLevel(w http.ResponseWriter, r *http.Request) {
 		}
 		key := uint32(0)
 		levelPtr := uint32(level)
+		if s.bpfLogLevelMap == nil {
+			http.Error(w, fmt.Errorf("update log level error:%v", "bpfLogLevelMap is nil").Error(), http.StatusBadRequest)
+			return
+		}
 		if err := s.bpfLogLevelMap.Update(&key, &levelPtr, ebpf.UpdateAny); err != nil {
 			http.Error(w, fmt.Errorf("update log level error:%v", err).Error(), http.StatusBadRequest)
 			return


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/kmesh-net/kmesh/issues/477

**Special notes for your reviewer**:
```
[root@master ~]#  kubectl exec -it nettool -- curl helloworld-d.default.svc.cluster.local:5000/hello
Hello version: v2, instance: helloworld-v2-654d97458-pmxk6
```

```
time="2024-07-03T12:44:55Z" level=info msg="[KMESH] DEBUG: bpf find listener addr=[10.104.111.255:5000]\n" subsys=ebpf
time="2024-07-03T12:44:55Z" level=info msg="[CLUSTER] INFO: cluster=\"outbound|5000||helloworld.default.svc.cluster.local\", loadbalance to addr=[172.16.219.112:5000]\n" subsys=ebpf
```
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
