### PR TITLE
fix flaky e2e test

### DIFF
--- a/test/e2e/baseline_test.go
+++ b/test/e2e/baseline_test.go
@@ -4,6 +4,7 @@
 package kmesh
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -84,6 +85,16 @@ spec:
 			opt = opt.DeepCopy()
 			opt.Count = 5
 			opt.Timeout = time.Second * 10
+			opt.Check = check.And(
+				check.OK(),
+				func(result echo.CallResult, _ error) error {
+					for _, r := range result.Responses {
+						if r.Version != "v1" {
+							return fmt.Errorf("expected service version %q, got %q", "v1", r.Version)
+						}
+					}
+					return nil
+				})
 			src.CallOrFail(t, opt)
 		})
 
@@ -94,6 +105,17 @@ spec:
 			if opt.HTTP.Headers == nil {
 				opt.HTTP.Headers = map[string][]string{}
 			}
+			opt.HTTP.Headers.Set("user", "istio-custom-user")
+			opt.Check = check.And(
+				check.OK(),
+				func(result echo.CallResult, _ error) error {
+					for _, r := range result.Responses {
+						if r.Version != "v2" {
+							return fmt.Errorf("expected service version %q, got %q", "v2", r.Version)
+						}
+					}
+					return nil
+				})
 			opt.HTTP.Headers.Set("user", "istio-custom-user")
 			src.CallOrFail(t, opt)
 		})


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

E2E test case `TestTrafficSplit` was previously incomplete as it was found to be unstable during test.

Now find reason is that if the test application is deployed before Kmesh Ready, it will not managed by Kmesh.

The solution is to ensure Kmesh runs successfully before proceeding with the subsequent steps.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
