### PR TITLE
Support ns manage after kmesh restart

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -24,6 +24,8 @@ const (
 	DataPlaneModeLabel = "istio.io/dataplane-mode"
 	// DataPlaneModeKmesh is the value of the label to indicate the data plane mode is kmesh
 	DataPlaneModeKmesh = "kmesh"
+	// This annotation is used to indicate traffic redirection settings specific to Kmesh
+	KmeshRedirectionAnnotation = "kmesh.net/redirection"
 
 	XDP_PROG_NAME = "xdp_shutdown"
 

--- a/pkg/controller/manage/kmesh_manage.go
+++ b/pkg/controller/manage/kmesh_manage.go
@@ -42,21 +42,20 @@ var (
 	log                = logger.NewLoggerField("manage_controller")
 	annotationDelPatch = []byte(fmt.Sprintf(
 		`{"metadata":{"annotations":{"%s":null}}}`,
-		KmeshRedirectionAnnotation,
+		constants.KmeshRedirectionAnnotation,
 	))
 	annotationAddPatch = []byte(fmt.Sprintf(
 		`{"metadata":{"annotations":{"%s":"%s"}}}`,
-		KmeshRedirectionAnnotation,
+		constants.KmeshRedirectionAnnotation,
 		"enabled",
 	))
 )
 
 const (
-	DefaultInformerSyncPeriod  = 30 * time.Second
-	MaxRetries                 = 5
-	KmeshRedirectionAnnotation = "kmesh.net/redirection"
-	ActionAddAnnotation        = "add"
-	ActionDeleteAnnotation     = "delete"
+	DefaultInformerSyncPeriod = 30 * time.Second
+	MaxRetries                = 5
+	ActionAddAnnotation       = "add"
+	ActionDeleteAnnotation    = "delete"
 )
 
 type QueueItem struct {
@@ -214,7 +213,7 @@ func shouldEnroll(client kubernetes.Interface, pod *corev1.Pod) bool {
 	if strings.EqualFold(pod.Labels[constants.DataPlaneModeLabel], constants.DataPlaneModeKmesh) {
 		return true
 	}
-	if pod.Annotations[KmeshRedirectionAnnotation] == "enabled" {
+	if pod.Annotations[constants.KmeshRedirectionAnnotation] == "enabled" {
 		return true
 	}
 
@@ -231,8 +230,8 @@ func shouldEnroll(client kubernetes.Interface, pod *corev1.Pod) bool {
 }
 
 func addKmeshAnnotation(client kubernetes.Interface, pod *corev1.Pod) error {
-	if value, exists := pod.Annotations[KmeshRedirectionAnnotation]; exists && value == "enabled" {
-		log.Debugf("Pod %s in namespace %s already has annotation %s with value %s", pod.Name, pod.Namespace, KmeshRedirectionAnnotation, value)
+	if value, exists := pod.Annotations[constants.KmeshRedirectionAnnotation]; exists && value == "enabled" {
+		log.Debugf("Pod %s in namespace %s already has annotation %s with value %s", pod.Name, pod.Namespace, constants.KmeshRedirectionAnnotation, value)
 		return nil
 	}
 	_, err := client.CoreV1().Pods(pod.Namespace).Patch(
@@ -246,8 +245,8 @@ func addKmeshAnnotation(client kubernetes.Interface, pod *corev1.Pod) error {
 }
 
 func delKmeshAnnotation(client kubernetes.Interface, pod *corev1.Pod) error {
-	if _, exists := pod.Annotations[KmeshRedirectionAnnotation]; !exists {
-		log.Debugf("Pod %s in namespace %s does not have annotation %s", pod.Name, pod.Namespace, KmeshRedirectionAnnotation)
+	if _, exists := pod.Annotations[constants.KmeshRedirectionAnnotation]; !exists {
+		log.Debugf("Pod %s in namespace %s does not have annotation %s", pod.Name, pod.Namespace, constants.KmeshRedirectionAnnotation)
 		return nil
 	}
 	_, err := client.CoreV1().Pods(pod.Namespace).Patch(


### PR DESCRIPTION
**What type of PR is this?**
Support ns manage after kmesh restart
<!--
Add one of the following kinds:

/kind enhancement

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
Managing Pods in namespace level

```shell
kubectl label ns default istio.io/dataplane-mode=Kmesh
kubectl delete pods --all -n default
kubectl get pods -A -owide
NAMESPACE            NAME                                            READY   STATUS    RESTARTS      AGE     IP            NODE                    NOMINATED NODE   READINESS GATES
default              fortio-client-deployment-7d7f58785b-s4cwc       1/1     Running   0             88m     10.244.1.30   ambient-worker          <none>           <none>
default              fortio-server-deployment-dfd5cdd4c-rdmtl        1/1     Running   0             88m     10.244.1.33   ambient-worker          <none>           <none>
default              fortio-server-deployment-dfd5cdd4c-scjh7        1/1     Running   0             88m     10.244.1.32   ambient-worker          <none>           <none>
istio-system         istio-cni-node-xk2pb                            1/1     Running   3 (25h ago)   2d22h   172.18.0.3    ambient-worker          <none>           <none>
istio-system         istio-cni-node-zl4t5                            1/1     Running   3 (25h ago)   2d22h   172.18.0.2    ambient-control-plane   <none>           <none>
istio-system         istiod-686fb897f8-7snpv                         1/1     Running   3 (25h ago)   2d22h   10.244.1.5    ambient-worker          <none>           <none>
istio-system         ztunnel-l9v76                                   1/1     Running   3 (25h ago)   2d22h   10.244.1.7    ambient-worker          <none>           <none>
istio-system         ztunnel-t5wbw                                   1/1     Running   3 (25h ago)   2d22h   10.244.0.5    ambient-control-plane   <none>           <none>
kmesh-system         kmesh-2phlv                                     1/1     Running   0             71s     10.244.1.41   ambient-worker          <none>           <none>
kmesh-system         kmesh-6n2fr                                     1/1     Running   0             69s     10.244.0.10   ambient-control-plane   <none>           <none>
kube-system          coredns-565d847f94-5l5jp                        1/1     Running   3 (25h ago)   2d22h   10.244.0.4    ambient-control-plane   <none>           <none>
```

Delete kmesh pod

```shell
kubectl delete pod -n kmesh-system kmesh
```

Check the logs after the kmesh is restarted.

```shell
kubectl logs -f -n kmesh-system kmesh-fvf8v
time="2024-07-09T06:08:48Z" level=info msg="controller Start successful" subsys=manager
time="2024-07-09T06:08:48Z" level=info msg="start write CNI config\n" subsys="cni installer"
time="2024-07-09T06:08:48Z" level=info msg="kmesh cni use chained\n" subsys="cni installer"
time="2024-07-09T06:08:48Z" level=info msg="default/fortio-server-deployment-dfd5cdd4c-rdmtl: enable Kmesh manage" subsys=manage_controller
time="2024-07-09T06:08:48Z" level=info msg="default/fortio-server-deployment-dfd5cdd4c-scjh7: enable Kmesh manage" subsys=manage_controller
time="2024-07-09T06:08:48Z" level=info msg="default/fortio-client-deployment-7d7f58785b-s4cwc: enable Kmesh manage" subsys=manage_controller
time="2024-07-09T06:08:49Z" level=info msg="Copied /usr/bin/kmesh-cni to /opt/cni/bin." subsys="cni installer"
time="2024-07-09T06:08:49Z" level=info msg="kubeconfig either does not exist or is out of date, writing a new one" subsys="cni installer"
time="2024-07-09T06:08:49Z" level=info msg="wrote kubeconfig file /etc/cni/net.d/kmesh-cni-kubeconfig" subsys="cni installer"
time="2024-07-09T06:08:49Z" level=info msg="cni config file: /etc/cni/net.d/10-kindnet.conflist" subsys="cni installer"
time="2024-07-09T06:08:49Z" level=info msg="command Start cni successful" subsys=manager
```

Check the elements in map kmesh_manage

```shell
bpftool map dump name kmesh_manage
[{
        "id": 16964,
        "type": "hash",
        "name": "kmesh_manage",
        "flags": 0,
        "elements": []
    },{
        "id": 16987,
        "type": "hash",
        "name": "kmesh_manage",
        "flags": 0,
        "elements": [{
                "key": {
                    "": {
                        "netns_cookie": 536998922,
                        "addr": {
                            "": {
                                "ip4": 536998922,
                                "ip6": [536998922,0,0,0
                                ]
                            }
                        }
                    }
                },
                "value": {
                    "is_bypassed": 0
                }
            },{
                "key": {
                    "": {
                        "netns_cookie": 553776138,
                        "addr": {
                            "": {
                                "ip4": 553776138,
                                "ip6": [553776138,0,0,0
                                ]
                            }
                        }
                    }
                },
                "value": {
                    "is_bypassed": 0
                }
            },{
                "key": {
                    "": {
                        "netns_cookie": 53250,
                        "addr": {
                            "": {
                                "ip4": 53250,
                                "ip6": [53250,0,0,0
                                ]
                            }
                        }
                    }
                },
                "value": {
                    "is_bypassed": 0
                }
            },{
                "key": {
                    "": {
                        "netns_cookie": 12293,
                        "addr": {
                            "": {
                                "ip4": 12293,
                                "ip6": [12293,0,0,0
                                ]
                            }
                        }
                    }
                },
                "value": {
                    "is_bypassed": 0
                }
            },{
                "key": {
                    "": {
                        "netns_cookie": 503444490,
                        "addr": {
                            "": {
                                "ip4": 503444490,
                                "ip6": [503444490,0,0,0
                                ]
                            }
                        }
                    }
                },
                "value": {
                    "is_bypassed": 0
                }
            },{
                "key": {
                    "": {
                        "netns_cookie": 40968,
                        "addr": {
                            "": {
                                "ip4": 40968,
                                "ip6": [40968,0,0,0
                                ]
                            }
                        }
                    }
                },
                "value": {
                    "is_bypassed": 0
                }
            }
        ]
    }
]

```

