### PR TITLE
use latest waypoint image to run e2e

### DIFF
--- a/test/e2e/run_test.sh
+++ b/test/e2e/run_test.sh
@@ -12,7 +12,7 @@ DEFAULT_KIND_IMAGE="kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba
 # support testing multiple istio version in the future.
 ISTIO_VERSION=1.22.0
 
-export KMESH_WAYPOINT_IMAGE="ghcr.io/kmesh-net/waypoint-x86:v0.3.0"
+export KMESH_WAYPOINT_IMAGE="ghcr.io/kmesh-net/waypoint:latest"
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement


**What this PR does / why we need it**:

Now we maintain the latest image of waypoint and also support mulit arch.

So no longer need to include version and arch info.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
