### PR TITLE
fix dns cannot remove domain bug

### DIFF
--- a/pkg/controller/ads/ads_processor.go
+++ b/pkg/controller/ads/ads_processor.go
@@ -167,10 +167,8 @@ func (p *processor) handleCdsResponse(resp *service_discovery_v3.DiscoveryRespon
 		}
 	}
 
-	if len(dnsClusters) > 0 {
-		// send dns clusters to dns resolver
-		p.DnsResolverChan <- dnsClusters
-	}
+	// send dns clusters to dns resolver
+	p.DnsResolverChan <- dnsClusters
 	removed := p.Cache.ClusterCache.GetResourceNames().Difference(current)
 	for key := range removed {
 		p.Cache.UpdateApiClusterStatus(key, core_v2.ApiStatus_DELETE)

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -424,7 +424,6 @@ func TestGetPendingResolveDomain(t *testing.T) {
 
 func TestRemoveUnwatchedCluster(t *testing.T) {
 	fakeDNSServer := newFakeDNSServer()
-
 	testDNSResolver, err := NewDNSResolver(ads.NewAdsCache())
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
![image](https://github.com/user-attachments/assets/fd187519-d204-4bbe-bef2-0c4a62ed7ad2)

`Stow` solution. should send dnsClusters to DNS resolver even if it is empty so that the resolver could remove unwatched domains.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
