### PR TITLE
preclude pod with host network to be managed by kmesh

### DIFF
--- a/pkg/utils/enroll.go
+++ b/pkg/utils/enroll.go
@@ -42,6 +42,11 @@ func ShouldEnroll(pod *corev1.Pod, ns *corev1.Namespace) bool {
 		return false
 	}
 
+	// exclude pod with host network set, otherwise it will cause other pods with host network to be managed by kmesh
+	if pod.Spec.HostNetwork {
+		return false
+	}
+
 	// If it is a Pod of waypoint, it should not be managed by Kmesh
 	// Exclude istio managed gateway
 	if gateway, ok := pod.Labels["gateway.istio.io/managed"]; ok {

--- a/pkg/utils/enroll_test.go
+++ b/pkg/utils/enroll_test.go
@@ -70,6 +70,37 @@ func TestShouldEnroll(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "pod with hostnetwork",
+			args: args{
+				namespace: &corev1.Namespace{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Namespace",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "ut-test",
+					},
+				},
+				pod: &corev1.Pod{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "Pod",
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "ut-test",
+						Name:      "ut-pod",
+						Labels: map[string]string{
+							constants.DataPlaneModeLabel: constants.DataPlaneModeKmesh,
+						},
+					},
+					Spec: corev1.PodSpec{
+						HostNetwork: true,
+					},
+				},
+			},
+			want: false,
+		},
+		{
 			name: "sidecar misconfigured label",
 			args: args{
 				namespace: &corev1.Namespace{


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

/kind enhancement


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/kmesh-net/kmesh/issues/630

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
