### PR TITLE
add some secure compilation options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ LDFLAGS := "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=w
 			-X kmesh.net/kmesh/pkg/version.gitCommit=$(GIT_COMMIT_HASH) \
 			-X kmesh.net/kmesh/pkg/version.gitTreeState=$(GIT_TREESTATE) \
 			-X kmesh.net/kmesh/pkg/version.buildDate=$(BUILD_DATE)"
+EXTLDFLAGS := '-fPIE -pie -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack'
 
 # target
 APPS1 := kmesh-daemon
@@ -79,7 +80,7 @@ all:
 	
 	$(call printlog, BUILD, $(APPS1))
 	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-		$(GO) build -ldflags $(LDFLAGS) -tags $(ENHANCED_KERNEL) -o $(APPS1) $(GOFLAGS) ./daemon/main.go)
+		$(GO) build -ldflags $(LDFLAGS) -ldflags "-linkmode=external -extldflags $(EXTLDFLAGS)" -tags $(ENHANCED_KERNEL) -o $(APPS1) $(GOFLAGS) ./daemon/main.go)
 	
 	$(call printlog, BUILD, "kernel")
 	$(QUIET) make -C kernel/ko_src
@@ -89,7 +90,7 @@ all:
 
 	$(call printlog, BUILD, $(APPS3))
 	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-		$(GO) build -ldflags $(LDFLAGS) -tags $(ENHANCED_KERNEL) -o $(APPS3) $(GOFLAGS) ./cniplugin/main.go)
+		$(GO) build -ldflags $(LDFLAGS) -ldflags "-linkmode=external -extldflags $(EXTLDFLAGS)" -tags $(ENHANCED_KERNEL) -o $(APPS3) $(GOFLAGS) ./cniplugin/main.go)
 
 .PHONY: gen-proto
 gen-proto:

--- a/api/v2-c/Makefile
+++ b/api/v2-c/Makefile
@@ -24,9 +24,11 @@ INCLUDES = -I./
 
 # compiler flags
 LDFLAGS := -lprotobuf-c
+LDFLAGS += -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack
 CFLAGS := $(EXTRA_CFLAGS) $(EXTRA_CDEFINE)
-CFLAGS += -fstack-protector -fPIC
+CFLAGS += -fstack-protector-strong -fPIC
 CFLAGS += -Wall -Werror
+CFLAGS += -D_FORTIFY_SOURCE=2 -O2
 
 SOURCES = $(wildcard */*.c)
 OBJECTS = $(subst .c,.o,$(SOURCES))

--- a/bpf/deserialization_to_bpf_map/Makefile
+++ b/bpf/deserialization_to_bpf_map/Makefile
@@ -10,9 +10,11 @@ INCLUDES =
 
 # compiler flags
 LDFLAGS := -lbpf -lboundscheck
+LDFLAGS += -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack
 CFLAGS := $(EXTRA_CFLAGS) $(EXTRA_CDEFINE)
-CFLAGS += -fstack-protector -fPIC
+CFLAGS += -fstack-protector-strong -fPIC
 CFLAGS += -Wall -Werror
+CFLAGS += -D_FORTIFY_SOURCE=2 -O2
 
 SOURCES = $(wildcard *.c)
 OBJECTS = $(subst .c,.o,$(SOURCES))


### PR DESCRIPTION
**What type of PR is this?**

Currently, the binary programs provided by Kmesh lack some necessary secure compilation options during the compilation process. Adding these secure compilation options can effectively prevent some security issues.

<!--
Add one of the following kinds:
/kind security

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@nlgwcy @hzxuzhonghu 
**Does this PR introduce a user-facing change?**:
NA
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
