### PR TITLE
FIX: go test timeout after running benchmark test

### DIFF
--- a/pkg/controller/workload/workload_controller_test.go
+++ b/pkg/controller/workload/workload_controller_test.go
@@ -187,6 +187,9 @@ func TestWorkloadStreamCreateAndSend(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("workloadStream.WorklaodStreamCreateAndSend() error = %v, wantErr %v", err, tt.wantErr)
 			}
+			if workloadController.Processor != nil {
+				workloadController.Processor.hashName.Reset()
+			}
 			tt.afterFunc()
 		})
 	}

--- a/pkg/controller/workload/workload_hash.go
+++ b/pkg/controller/workload/workload_hash.go
@@ -18,15 +18,12 @@ package workload
 
 import (
 	"fmt"
+	"hash"
 	"hash/fnv"
 	"math"
 	"os"
 
 	"gopkg.in/yaml.v3"
-)
-
-var (
-	hash = fnv.New32a()
 )
 
 const (
@@ -37,11 +34,13 @@ const (
 type HashName struct {
 	numToStr map[uint32]string
 	strToNum map[string]uint32
+	hash     hash.Hash32
 }
 
 func NewHashName() *HashName {
 	hashName := &HashName{
 		strToNum: make(map[string]uint32),
+		hash:     fnv.New32a(),
 	}
 	// if read failed, initialize with an empty map
 	if err := hashName.readFromPersistFile(); err != nil {
@@ -94,15 +93,14 @@ func (h *HashName) flushDelta(str string, num uint32) error {
 func (h *HashName) StrToNum(str string) uint32 {
 	var num uint32
 
-	hash.Reset()
-	hash.Write([]byte(str))
-
 	if num, exists := h.strToNum[str]; exists {
 		return num
 	}
 
+	h.hash.Reset()
+	h.hash.Write([]byte(str))
 	// Using linear probing to solve hash conflicts
-	for num = hash.Sum32(); num < math.MaxUint32; num++ {
+	for num = h.hash.Sum32(); num < math.MaxUint32; num++ {
 		// Create a new item if we find an empty slot
 		if _, exists := h.numToStr[num]; !exists {
 			h.numToStr[num] = str
@@ -136,4 +134,9 @@ func (h *HashName) Delete(str string) {
 			log.Errorf("error flushing when calling Delete: %v", err)
 		}
 	}
+}
+
+// Should only be used by test
+func (h *HashName) Reset() {
+	os.Remove(persistPath)
 }

--- a/pkg/controller/workload/workload_hash_test.go
+++ b/pkg/controller/workload/workload_hash_test.go
@@ -41,6 +41,7 @@ func cleanPersistFile() {
 func TestWorkloadHash_Basic(t *testing.T) {
 	cleanPersistFile()
 	hashName := NewHashName()
+	defer hashName.Reset()
 
 	// "foo" does not collide with "bar"
 	// while "costarring" collides with "liquid"
@@ -110,4 +111,6 @@ func TestWorkloadHash_StrToNumAfterDelete(t *testing.T) {
 			return
 		}
 	}
+
+	hashName.Reset()
 }

--- a/pkg/controller/workload/workload_processor_test.go
+++ b/pkg/controller/workload/workload_processor_test.go
@@ -158,6 +158,7 @@ func BenchmarkHandleDataWithService(b *testing.B) {
 		err := workloadController.Processor.handleDataWithService(workload)
 		assert.NoError(t, err)
 	}
+	workloadController.Processor.hashName.Reset()
 }
 
 func createTestWorkloadWithService() *workloadapi.Workload {
@@ -312,4 +313,5 @@ func hashNameClean(p *Processor) {
 		}
 		p.hashName.Delete(str)
 	}
+	p.hashName.Reset()
 }


### PR DESCRIPTION
…timeout

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

Without cleaning up hash file, test will fail with timeout error.  By default vs plugin set 30s timeout.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
