### PR TITLE
Improve cni uninstall

### DIFF
--- a/build/docker/start_kmesh.sh
+++ b/build/docker/start_kmesh.sh
@@ -51,4 +51,6 @@ while kill -0 $pid 2>/dev/null; do
   sleep 1
 done
 
+kmesh-daemon uninstall $@
+
 cleanup

--- a/daemon/manager/manager.go
+++ b/daemon/manager/manager.go
@@ -29,6 +29,7 @@ import (
 
 	"kmesh.net/kmesh/daemon/manager/dump"
 	logcmd "kmesh.net/kmesh/daemon/manager/log"
+	"kmesh.net/kmesh/daemon/manager/uninstall"
 	"kmesh.net/kmesh/daemon/manager/version"
 	"kmesh.net/kmesh/daemon/options"
 	"kmesh.net/kmesh/pkg/bpf"
@@ -68,6 +69,7 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(version.NewCmd())
 	cmd.AddCommand(dump.NewCmd())
 	cmd.AddCommand(logcmd.NewCmd())
+	cmd.AddCommand(uninstall.NewUninstallCmd())
 
 	return cmd
 }

--- a/daemon/manager/manager.go
+++ b/daemon/manager/manager.go
@@ -80,14 +80,10 @@ func Execute(configs *options.BootstrapConfigs) error {
 	}
 
 	bpfLoader := bpf.NewBpfLoader(configs.BpfConfig)
-<<<<<<< HEAD
-	if err = bpfLoader.Start(configs.BpfConfig); err != nil {
-=======
-	defer bpfLoader.Stop()
 	if err := bpfLoader.Start(configs.BpfConfig); err != nil {
->>>>>>> e6e5bf1 (Improve cni uninstall)
 		return err
 	}
+	defer bpfLoader.Stop()
 	log.Info("bpf loader start successfully")
 
 	stopCh := make(chan struct{})
@@ -108,11 +104,10 @@ func Execute(configs *options.BootstrapConfigs) error {
 
 	cniInstaller := cni.NewInstaller(configs.BpfConfig.Mode,
 		configs.CniConfig.CniMountNetEtcDIR, configs.CniConfig.CniConfigName, configs.CniConfig.CniConfigChained)
-	// even though Start failed, we should run Stop to clean up
-	defer cniInstaller.Stop()
 	if err := cniInstaller.Start(); err != nil {
 		return err
 	}
+	defer cniInstaller.Stop()
 	log.Info("start cni successfully")
 
 	setupSignalHandler()

--- a/daemon/manager/manager.go
+++ b/daemon/manager/manager.go
@@ -69,7 +69,7 @@ func NewCommand() *cobra.Command {
 	cmd.AddCommand(version.NewCmd())
 	cmd.AddCommand(dump.NewCmd())
 	cmd.AddCommand(logcmd.NewCmd())
-	cmd.AddCommand(uninstall.NewUninstallCmd())
+	cmd.AddCommand(uninstall.NewCmd())
 
 	return cmd
 }

--- a/daemon/manager/uninstall/uninstall.go
+++ b/daemon/manager/uninstall/uninstall.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Kmesh Authors.
+ * Copyright The Kmesh Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import (
 	"kmesh.net/kmesh/pkg/cni"
 )
 
-func NewUninstallCmd() *cobra.Command {
+func NewCmd() *cobra.Command {
 	configs := options.NewBootstrapConfigs()
 	cmd := &cobra.Command{
 		Use:   "uninstall",

--- a/daemon/manager/uninstall/uninstall.go
+++ b/daemon/manager/uninstall/uninstall.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uninstall
+
+import (
+	"flag"
+
+	"github.com/spf13/cobra"
+
+	"kmesh.net/kmesh/daemon/options"
+	"kmesh.net/kmesh/pkg/cni"
+)
+
+func NewUninstallCmd() *cobra.Command {
+	configs := options.NewBootstrapConfigs()
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Uninstall kmesh-cni",
+		Example: `Uninstall kmesh-cni configs before exit:
+		kmesh-daemon uninstall`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := configs.ParseConfigs(); err != nil {
+				return err
+			}
+			cniInstaller := cni.NewInstaller(configs.BpfConfig.Mode,
+				configs.CniConfig.CniMountNetEtcDIR, configs.CniConfig.CniConfigName, configs.CniConfig.CniConfigChained)
+			cniInstaller.Stop()
+			return nil
+		},
+	}
+
+	bindCmdlineFlags(configs, cmd)
+
+	return cmd
+}
+
+func bindCmdlineFlags(configs *options.BootstrapConfigs, cmd *cobra.Command) {
+	configs.AttachFlags(cmd)
+	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+}

--- a/pkg/cni/chained.go
+++ b/pkg/cni/chained.go
@@ -37,8 +37,6 @@ const (
 	MountedCNIBinDir   = "/opt/cni/bin"
 )
 
-var cniConfigFilePath string
-
 func (i *Installer) getCniConfigPath() (string, error) {
 	var confFile string
 	if len(i.CniConfigName) != 0 {
@@ -205,7 +203,7 @@ func (i *Installer) chainedKmeshCniPlugin(mode string, cniMountNetEtcDIR string)
 		return fmt.Errorf("write kubeconfig: %v", err)
 	}
 
-	cniConfigFilePath, err = i.getCniConfigPath()
+	cniConfigFilePath, err := i.getCniConfigPath()
 	if err != nil {
 		return err
 	}
@@ -251,6 +249,10 @@ func (i *Installer) chainedKmeshCniPlugin(mode string, cniMountNetEtcDIR string)
 func (i *Installer) removeChainedKmeshCniPlugin() error {
 	var err error
 	var newCNIConfig []byte
+	cniConfigFilePath, err := i.getCniConfigPath()
+	if err != nil {
+		return err
+	}
 	existCNIConfig, err := os.ReadFile(cniConfigFilePath)
 	if err != nil {
 		err = fmt.Errorf("failed to read cni config file %v : %v", cniConfigFilePath, err)

--- a/pkg/cni/install.go
+++ b/pkg/cni/install.go
@@ -70,7 +70,7 @@ func NewInstaller(mode string,
 
 func (i *Installer) Start() error {
 	if i.Mode == constants.AdsMode || i.Mode == constants.WorkloadMode {
-		log.Info("start write CNI config\n")
+		log.Info("start write CNI config")
 		return i.addCniConfig()
 	}
 	return nil
@@ -78,9 +78,10 @@ func (i *Installer) Start() error {
 
 func (i *Installer) Stop() {
 	if i.Mode == constants.AdsMode || i.Mode == constants.WorkloadMode {
-		log.Info("start remove CNI config\n")
+		log.Info("start remove CNI config")
 		if err := i.removeCniConfig(); err != nil {
 			log.Errorf("remove CNI config failed: %v, please remove manually", err)
 		}
+		log.Info("remove CNI config done")
 	}
 }

--- a/pkg/cni/install.go
+++ b/pkg/cni/install.go
@@ -71,7 +71,11 @@ func NewInstaller(mode string,
 func (i *Installer) Start() error {
 	if i.Mode == constants.AdsMode || i.Mode == constants.WorkloadMode {
 		log.Info("start write CNI config")
-		return i.addCniConfig()
+		err := i.addCniConfig()
+		if err != nil {
+			i.Stop()
+			return err
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

Fix option 1 of https://github.com/kmesh-net/kmesh/issues/730

> Do clean up the cni config at the end of https://github.com/kmesh-net/kmesh/blob/main/build/docker/start_kmesh.sh#L54

This may cleanup cni configs twice, but doesnot matter.

If without this, and kmesh crashed unexpected, the k8s cluster will be influenced, the blast radius is very large

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
