### PR TITLE
Rm coverage threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,7 +4,6 @@ coverage:
       default:
         # basic
         target: auto #default
-        threshold: 50%
         base: auto 
 comment:                  # this is a top-level key
   layout: "header, files, footer" # remove "new" from "header" and "footer"


### PR DESCRIPTION
With the hard limit, may even prevent developer from fixing typo, which is not covered before.