### PR TITLE
Modify observe connection shutdown probe log

### DIFF
--- a/bpf/kmesh/probes/probe.h
+++ b/bpf/kmesh/probes/probe.h
@@ -61,8 +61,7 @@ static inline void observe_on_close(struct bpf_sock *sk)
 
     storage = bpf_sk_storage_get(&map_of_sock_storage, sk, 0, 0);
     if (!storage) {
-        BPF_LOG(ERR, PROBE, "close bpf_sk_storage_get failed\n");
-        return;
+        BPF_LOG(INFO, PROBE, "TCP Connection closed or map_of_sock_storage cleaned up\n");
     }
 
     tcp_report(sk, tcp_sock, storage, BPF_TCP_CLOSE);


### PR DESCRIPTION
For the bpf_sk_storage_get function, for an sk that may have been closed to get the storage associated with it, it usually returns NULL, and this part of the judgement log level should be changed to INFO, and the subsequent `tcp_report(sk, tcp_sock, storage, BPF_TCP_ CLOSE)` also reports on this connection closure.


