### PR TITLE
passthrough go test flag

### DIFF
--- a/test/e2e/run_test.sh
+++ b/test/e2e/run_test.sh
@@ -204,7 +204,7 @@ function cleanup_docker_registry() {
     docker rm "${KIND_REGISTRY_NAME}" || echo "Failed to remove or no such registry '${KIND_REGISTRY_NAME}'."
 }
 
-PARAMS=""
+PARAMS=()
 
 while (( "$#" )); do
     case "$1" in
@@ -235,13 +235,9 @@ while (( "$#" )); do
       CLEANUP_REGISTRY=true
       shift
     ;;
-    --select-cases)
-      PARAMS+="-test.run \"$2\""
-      shift 2
-    ;;
-    --skip-cases)
-      PARAMS+="-test.skip \"$2\""
-      shift 2
+    *)
+      PARAMS+=("$1")
+      shift
     ;;
     esac
 done
@@ -265,7 +261,7 @@ if [[ -z "${SKIP_SETUP:-}" ]]; then
     setup_kmesh
 fi
 
-cmd="go test -v -tags=integ $ROOT_DIR/test/e2e/... -count=1 $PARAMS"
+cmd="go test -v -tags=integ $ROOT_DIR/test/e2e/... ${PARAMS[*]}"
 
 bash -c "$cmd"
 


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement


**What this PR does / why we need it**:

The E2E test will eventually call the `go test` command, which has a variety of flags for adjusting the test.

Obviously, it's very tedious to encapsulate each flag. Therefore we adopt the direct passthrough unknown flags to make full use of existing capabilities of `go test`.

Although it's not very robust, I think it's ok for running test cases.

For example, now we could directly run the follow command:

```bash
./test/e2e/run_test.sh --only-run-tests -run "TestKmeshRestart"  -count 10 -timeout 30m
``` 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
