### PR TITLE
Check codecov but not fail github checks

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,11 +1,12 @@
 coverage:
   status:
-    project: #add everything under here, more options at https://docs.codecov.com/docs/commit-status
+    project: off
+    # https://docs.codecov.com/docs/commit-status#patch-status
+    patch:
       default:
-        # basic
-        target: auto #default
-        base: auto 
+        target: 80%
+        informational: false
+        if_ci_failed: error
 comment:                  # this is a top-level key
   layout: "header, files, footer" # remove "new" from "header" and "footer"
   hide_project_coverage: false # set to false
-github_checks: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,3 +8,4 @@ coverage:
 comment:                  # this is a top-level key
   layout: "header, files, footer" # remove "new" from "header" and "footer"
   hide_project_coverage: false # set to false
+github_checks: false


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

Just want codcov to give use a hint, not to block PR merging. Not sure if this works.

Also investigated on prow bot to ignore the codecov, but not found how to congure it



**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
