### PR TITLE
Support ads bpf map lookup all

### DIFF
--- a/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.c
+++ b/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.c
@@ -19,36 +19,42 @@
 #include "deserialization_to_bpf_map.h"
 #include "../../config/kmesh_marcos_def.h"
 
-#define LOG_ERR(fmt, args...)  printf(fmt, ##args)
-#define LOG_WARN(fmt, args...) printf(fmt, ##args)
-#define LOG_INFO(fmt, args...) printf(fmt, ##args)
+#define PRINTF(fmt, args...) \
+    do {                     \
+        printf(fmt, ##args); \
+        fflush(stdout);      \
+    } while (0)
+
+#define LOG_ERR(fmt, args...) PRINTF(fmt, ##args)
+#define LOG_WARN(fmt, args...) PRINTF(fmt, ##args)
+#define LOG_INFO(fmt, args...) PRINTF(fmt, ##args)
 
 struct op_context {
-    void *key;
-    void *value;
+    void* key;
+    void* value;
     int outter_fd;
     int map_fd;
     int curr_fd;
-    struct bpf_map_info *outter_info;
-    struct bpf_map_info *inner_info;
-    struct bpf_map_info *info;
-    struct bpf_map_info *curr_info;
-    char *inner_map_object;
-    const ProtobufCMessageDescriptor *desc;
+    struct bpf_map_info* outter_info;
+    struct bpf_map_info* inner_info;
+    struct bpf_map_info* info;
+    struct bpf_map_info* curr_info;
+    char* inner_map_object;
+    const ProtobufCMessageDescriptor* desc;
 };
 
-#define init_op_context(context, key, val, desc, o_fd, fd, o_info, i_info, m_info)                                     \
-    do {                                                                                                               \
-        (context).key = (key);                                                                                         \
-        (context).value = (val);                                                                                       \
-        (context).desc = (desc);                                                                                       \
-        (context).outter_fd = (o_fd);                                                                                  \
-        (context).map_fd = (fd);                                                                                       \
-        (context).outter_info = (o_info);                                                                              \
-        (context).inner_info = (i_info);                                                                               \
-        (context).info = (m_info);                                                                                     \
-        (context).curr_info = (m_info);                                                                                \
-        (context).curr_fd = (fd);                                                                                      \
+#define init_op_context(context, k, v, desc, o_fd, fd, o_info, i_info, m_info) \
+    do {                                                                       \
+        (context).key = (k);                                                   \
+        (context).value = (v);                                                 \
+        (context).desc = (desc);                                               \
+        (context).outter_fd = (o_fd);                                          \
+        (context).map_fd = (fd);                                               \
+        (context).outter_info = (o_info);                                      \
+        (context).inner_info = (i_info);                                       \
+        (context).info = (m_info);                                             \
+        (context).curr_info = (m_info);                                        \
+        (context).curr_fd = (fd);                                              \
     } while (0)
 
 #define TASK_SIZE (100)
@@ -72,13 +78,14 @@ struct task_contex {
 
 struct inner_map_mng g_inner_map_mng = {0};
 
-static int update_bpf_map(struct op_context *ctx);
-static void *create_struct(struct op_context *ctx, int *err);
-static int del_bpf_map(struct op_context *ctx, int is_inner);
-static int free_outter_map_entry(struct op_context *ctx, void *outter_key);
+static int update_bpf_map(struct op_context* ctx);
+static void* create_struct(struct op_context* ctx, int* err);
+static int del_bpf_map(struct op_context* ctx, int is_inner);
+static int free_outter_map_entry(struct op_context* ctx, void* outter_key);
 
-static int normalize_key(struct op_context *ctx, void *key, const char *map_name)
-{
+static int normalize_key(struct op_context* ctx,
+                         void* key,
+                         const char* map_name) {
     ctx->key = calloc(1, ctx->curr_info->key_size);
     if (!ctx->key)
         return -errno;
@@ -87,16 +94,17 @@ static int normalize_key(struct op_context *ctx, void *key, const char *map_name
         return -errno;
 
     if (!strncmp(map_name, "Listener", strlen(map_name)))
-        memcpy_s(ctx->key, ctx->curr_info->key_size, key, ctx->curr_info->key_size);
+        memcpy_s(ctx->key, ctx->curr_info->key_size, key,
+                 ctx->curr_info->key_size);
     else
         strncpy(ctx->key, key, ctx->curr_info->key_size);
 
     return 0;
 }
 
-static inline int selected_oneof_field(void *value, const ProtobufCFieldDescriptor *field)
-{
-    uint32_t n = *(uint32_t *)((char *)value + field->quantifier_offset);
+static inline int selected_oneof_field(void* value,
+                                       const ProtobufCFieldDescriptor* field) {
+    uint32_t n = *(uint32_t*)((char*)value + field->quantifier_offset);
 
     if ((field->flags & PROTOBUF_C_FIELD_FLAG_ONEOF) && field->id != n)
         return 0;
@@ -104,84 +112,81 @@ static inline int selected_oneof_field(void *value, const ProtobufCFieldDescript
     return 1;
 }
 
-static inline int valid_field_value(void *value, const ProtobufCFieldDescriptor *field)
-{
-    uint32_t val = *(uint32_t *)((char *)value + field->offset);
+static inline int valid_field_value(void* value,
+                                    const ProtobufCFieldDescriptor* field) {
+    uint32_t val = *(uint32_t*)((char*)value + field->offset);
 
     if (val == 0) {
         switch (field->type) {
-        case PROTOBUF_C_TYPE_MESSAGE:
-        case PROTOBUF_C_TYPE_STRING:
-            return 0;
-        default:
-            break;
+            case PROTOBUF_C_TYPE_MESSAGE:
+            case PROTOBUF_C_TYPE_STRING:
+                return 0;
+            default:
+                break;
         }
 
         switch (field->label) {
-        case PROTOBUF_C_LABEL_REPEATED:
-            return 0;
-        default:
-            break;
+            case PROTOBUF_C_LABEL_REPEATED:
+                return 0;
+            default:
+                break;
         }
     }
 
     return 1;
 }
 
-static inline size_t sizeof_elt_in_repeated_array(ProtobufCType type)
-{
+static inline size_t sizeof_elt_in_repeated_array(ProtobufCType type) {
     switch (type) {
-    case PROTOBUF_C_TYPE_SINT32:
-    case PROTOBUF_C_TYPE_INT32:
-    case PROTOBUF_C_TYPE_UINT32:
-    case PROTOBUF_C_TYPE_SFIXED32:
-    case PROTOBUF_C_TYPE_FIXED32:
-    case PROTOBUF_C_TYPE_FLOAT:
-    case PROTOBUF_C_TYPE_ENUM:
-        return 4;
-    case PROTOBUF_C_TYPE_SINT64:
-    case PROTOBUF_C_TYPE_INT64:
-    case PROTOBUF_C_TYPE_UINT64:
-    case PROTOBUF_C_TYPE_SFIXED64:
-    case PROTOBUF_C_TYPE_FIXED64:
-    case PROTOBUF_C_TYPE_DOUBLE:
-        return 8;
-    case PROTOBUF_C_TYPE_BOOL:
-        return sizeof(protobuf_c_boolean);
-    case PROTOBUF_C_TYPE_STRING:
-    case PROTOBUF_C_TYPE_MESSAGE:
-        return sizeof(void *);
-    case PROTOBUF_C_TYPE_BYTES:
-        return sizeof(ProtobufCBinaryData);
-    default:
-        break;
+        case PROTOBUF_C_TYPE_SINT32:
+        case PROTOBUF_C_TYPE_INT32:
+        case PROTOBUF_C_TYPE_UINT32:
+        case PROTOBUF_C_TYPE_SFIXED32:
+        case PROTOBUF_C_TYPE_FIXED32:
+        case PROTOBUF_C_TYPE_FLOAT:
+        case PROTOBUF_C_TYPE_ENUM:
+            return 4;
+        case PROTOBUF_C_TYPE_SINT64:
+        case PROTOBUF_C_TYPE_INT64:
+        case PROTOBUF_C_TYPE_UINT64:
+        case PROTOBUF_C_TYPE_SFIXED64:
+        case PROTOBUF_C_TYPE_FIXED64:
+        case PROTOBUF_C_TYPE_DOUBLE:
+            return 8;
+        case PROTOBUF_C_TYPE_BOOL:
+            return sizeof(protobuf_c_boolean);
+        case PROTOBUF_C_TYPE_STRING:
+        case PROTOBUF_C_TYPE_MESSAGE:
+            return sizeof(void*);
+        case PROTOBUF_C_TYPE_BYTES:
+            return sizeof(ProtobufCBinaryData);
+        default:
+            break;
     }
 
     return 0;
 }
 
-static inline int valid_outter_key(struct op_context *ctx, unsigned int outter_key)
-{
+static inline int valid_outter_key(struct op_context* ctx,
+                                   unsigned int outter_key) {
     if (outter_key < 0 || outter_key >= MAX_OUTTER_MAP_ENTRIES)
         return 0;
 
     return 1;
 }
 
-static void free_elem(void *ptr)
-{
+static void free_elem(void* ptr) {
     if ((uintptr_t)ptr < MAX_OUTTER_MAP_ENTRIES)
         return;
 
     free(ptr);
 }
 
-static void free_keys(struct op_context *ctx, void *keys, int n)
-{
+static void free_keys(struct op_context* ctx, void* keys, int n) {
     int i;
     unsigned int key;
     for (i = 0; i < n; i++) {
-        key = *((uintptr_t *)keys + i);
+        key = *((uintptr_t*)keys + i);
         if (!key)
             return;
 
@@ -189,19 +194,20 @@ static void free_keys(struct op_context *ctx, void *keys, int n)
     }
 }
 
-static unsigned int get_map_id(const char *name)
-{
-    char *ptr = NULL;
-    char *map_id = getenv(name);
+static unsigned int get_map_id(const char* name) {
+    char* ptr = NULL;
+    char* map_id = getenv(name);
     if (!map_id)
         return 0;
     return (unsigned int)strtol(map_id, &ptr, 10);
 }
 
-static int get_map_ids(const char *name, unsigned int *id, unsigned int *outter_id, unsigned int *inner_id)
-{
-    char *ptr = NULL;
-    char *map_id;
+static int get_map_ids(const char* name,
+                       unsigned int* id,
+                       unsigned int* outter_id,
+                       unsigned int* inner_id) {
+    char* ptr = NULL;
+    char* map_id;
 
     map_id = (name == NULL) ? getenv("MAP_ID") : getenv(name);
     if (!map_id) {
@@ -228,8 +234,9 @@ static int get_map_ids(const char *name, unsigned int *id, unsigned int *outter_
     return -errno;
 }
 
-static int get_map_fd_info(unsigned int id, int *map_fd, struct bpf_map_info *info)
-{
+static int get_map_fd_info(unsigned int id,
+                           int* map_fd,
+                           struct bpf_map_info* info) {
     int ret;
     __u32 map_info_len;
 
@@ -242,9 +249,8 @@ static int get_map_fd_info(unsigned int id, int *map_fd, struct bpf_map_info *in
     return ret;
 }
 
-static int free_outter_map_entry(struct op_context *ctx, void *outter_key)
-{
-    int key = *(int *)outter_key;
+static int free_outter_map_entry(struct op_context* ctx, void* outter_key) {
+    int key = *(int*)outter_key;
     if (key <= 0 || key >= MAX_OUTTER_MAP_ENTRIES)
         return -1;
 
@@ -255,11 +261,12 @@ static int free_outter_map_entry(struct op_context *ctx, void *outter_key)
     return 0;
 }
 
-static int alloc_outter_map_entry(struct op_context *ctx)
-{
+static int alloc_outter_map_entry(struct op_context* ctx) {
     int i;
-    if (!g_inner_map_mng.init || g_inner_map_mng.used_cnt >= MAX_OUTTER_MAP_ENTRIES) {
-        LOG_ERR("[%d %d]alloc_outter_map_entry failed\n", g_inner_map_mng.init, g_inner_map_mng.used_cnt);
+    if (!g_inner_map_mng.init ||
+        g_inner_map_mng.used_cnt >= MAX_OUTTER_MAP_ENTRIES) {
+        LOG_ERR("[%d %d]alloc_outter_map_entry failed\n", g_inner_map_mng.init,
+                g_inner_map_mng.used_cnt);
         return -1;
     }
 
@@ -275,22 +282,22 @@ static int alloc_outter_map_entry(struct op_context *ctx)
     return -1;
 }
 
-static int outter_key_to_inner_fd(struct op_context *ctx, unsigned int key)
-{
+static int outter_key_to_inner_fd(struct op_context* ctx, unsigned int key) {
     if (g_inner_map_mng.inner_maps[key].in_outer_map)
         return g_inner_map_mng.inner_maps[key].map_fd;
     return -1;
 }
 
-static int copy_sfield_to_map(struct op_context *ctx, int o_index, const ProtobufCFieldDescriptor *field)
-{
+static int copy_sfield_to_map(struct op_context* ctx,
+                              int o_index,
+                              const ProtobufCFieldDescriptor* field) {
     int ret;
     int key = 0;
     int inner_fd;
-    char **value = (char **)((char *)ctx->value + field->offset);
-    char *save_value = *value;
+    char** value = (char**)((char*)ctx->value + field->offset);
+    char* save_value = *value;
 
-    *(uintptr_t *)value = (size_t)o_index;
+    *(uintptr_t*)value = (size_t)o_index;
     ret = bpf_map_update_elem(ctx->curr_fd, ctx->key, ctx->value, BPF_ANY);
     if (ret) {
         free_outter_map_entry(ctx, &o_index);
@@ -306,17 +313,18 @@ static int copy_sfield_to_map(struct op_context *ctx, int o_index, const Protobu
     return ret;
 }
 
-static int copy_msg_field_to_map(struct op_context *ctx, int o_index, const ProtobufCFieldDescriptor *field)
-{
+static int copy_msg_field_to_map(struct op_context* ctx,
+                                 int o_index,
+                                 const ProtobufCFieldDescriptor* field) {
     int ret;
     int key = 0;
     int inner_fd;
-    void **value = (void **)((char *)ctx->value + field->offset);
-    void *msg = *value;
+    void** value = (void**)((char*)ctx->value + field->offset);
+    void* msg = *value;
     struct op_context new_ctx;
-    const ProtobufCMessageDescriptor *desc;
+    const ProtobufCMessageDescriptor* desc;
 
-    *(uintptr_t *)value = (size_t)o_index;
+    *(uintptr_t*)value = (size_t)o_index;
     ret = bpf_map_update_elem(ctx->curr_fd, ctx->key, ctx->value, BPF_ANY);
     if (ret) {
         free_outter_map_entry(ctx, &o_index);
@@ -330,11 +338,11 @@ static int copy_msg_field_to_map(struct op_context *ctx, int o_index, const Prot
     memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
 
     new_ctx.curr_fd = inner_fd;
-    new_ctx.key = (void *)&key;
+    new_ctx.key = (void*)&key;
     new_ctx.value = msg;
     new_ctx.curr_info = ctx->inner_info;
 
-    desc = ((ProtobufCMessage *)new_ctx.value)->descriptor;
+    desc = ((ProtobufCMessage*)new_ctx.value)->descriptor;
     if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
         return -EINVAL;
     }
@@ -345,91 +353,95 @@ static int copy_msg_field_to_map(struct op_context *ctx, int o_index, const Prot
     return ret;
 }
 
-static int field_handle(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
-{
+static int field_handle(struct op_context* ctx,
+                        const ProtobufCFieldDescriptor* field) {
     int key = 0;
 
-    if (field->type == PROTOBUF_C_TYPE_MESSAGE || field->type == PROTOBUF_C_TYPE_STRING) {
+    if (field->type == PROTOBUF_C_TYPE_MESSAGE ||
+        field->type == PROTOBUF_C_TYPE_STRING) {
         key = alloc_outter_map_entry(ctx);
         if (key < 0)
             return key;
     }
 
     switch (field->type) {
-    case PROTOBUF_C_TYPE_MESSAGE:
-        return copy_msg_field_to_map(ctx, key, field);
-    case PROTOBUF_C_TYPE_STRING:
-        return copy_sfield_to_map(ctx, key, field);
-    default:
-        break;
+        case PROTOBUF_C_TYPE_MESSAGE:
+            return copy_msg_field_to_map(ctx, key, field);
+        case PROTOBUF_C_TYPE_STRING:
+            return copy_sfield_to_map(ctx, key, field);
+        default:
+            break;
     }
 
     return 0;
 }
 
-static int copy_indirect_data_to_map(struct op_context *ctx, int outter_key, void *value, ProtobufCType type)
-{
+static int copy_indirect_data_to_map(struct op_context* ctx,
+                                     int outter_key,
+                                     void* value,
+                                     ProtobufCType type) {
     int ret = 0;
     int inner_fd, key = 0;
     struct op_context new_ctx;
-    const ProtobufCMessageDescriptor *desc;
+    const ProtobufCMessageDescriptor* desc;
 
     inner_fd = outter_key_to_inner_fd(ctx, outter_key);
     if (inner_fd < 0)
         return inner_fd;
 
     switch (type) {
-    case PROTOBUF_C_TYPE_MESSAGE:
-        memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
-        new_ctx.curr_fd = inner_fd;
-        new_ctx.key = (void *)&key;
-        new_ctx.value = value;
-        new_ctx.curr_info = ctx->inner_info;
+        case PROTOBUF_C_TYPE_MESSAGE:
+            memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
+            new_ctx.curr_fd = inner_fd;
+            new_ctx.key = (void*)&key;
+            new_ctx.value = value;
+            new_ctx.curr_info = ctx->inner_info;
 
-        desc = ((ProtobufCMessage *)value)->descriptor;
-        if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
-            return -EINVAL;
-        }
+            desc = ((ProtobufCMessage*)value)->descriptor;
+            if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
+                return -EINVAL;
+            }
 
-        new_ctx.desc = desc;
-        ret = update_bpf_map(&new_ctx);
-        break;
-    case PROTOBUF_C_TYPE_STRING:
-        strcpy_s(ctx->inner_map_object, ctx->inner_info->value_size, (char *)value);
-        ret = bpf_map_update_elem(inner_fd, &key, ctx->inner_map_object, BPF_ANY);
-        break;
-    default:
-        break;
+            new_ctx.desc = desc;
+            ret = update_bpf_map(&new_ctx);
+            break;
+        case PROTOBUF_C_TYPE_STRING:
+            strcpy_s(ctx->inner_map_object, ctx->inner_info->value_size,
+                     (char*)value);
+            ret = bpf_map_update_elem(inner_fd, &key, ctx->inner_map_object,
+                                      BPF_ANY);
+            break;
+        default:
+            break;
     }
 
     return ret;
 }
 
-static bool indirect_data_type(ProtobufCType type)
-{
+static bool indirect_data_type(ProtobufCType type) {
     switch (type) {
-    case PROTOBUF_C_TYPE_MESSAGE:
-    case PROTOBUF_C_TYPE_STRING:
-        return true;
-    default:
-        return false;
+        case PROTOBUF_C_TYPE_MESSAGE:
+        case PROTOBUF_C_TYPE_STRING:
+            return true;
+        default:
+            return false;
     }
 }
 
-static int repeat_field_handle(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
-{
+static int repeat_field_handle(struct op_context* ctx,
+                               const ProtobufCFieldDescriptor* field) {
     int ret, ret1;
     unsigned int i;
     int outter_key, inner_fd, key = 0;
-    void *n = ((char *)ctx->value) + field->quantifier_offset;
-    void ***value = (void ***)((char *)ctx->value + field->offset);
-    void **origin_value = *value;
-    char *inner_map_object;
+    void* n = ((char*)ctx->value) + field->quantifier_offset;
+    void*** value = (void***)((char*)ctx->value + field->offset);
+    void** origin_value = *value;
+    char* inner_map_object;
 
     outter_key = alloc_outter_map_entry(ctx);
     if (outter_key < 0)
         return outter_key;
-    *(uintptr_t *)value = (size_t)outter_key;
+    *(uintptr_t*)value = (size_t)outter_key;
     ret = bpf_map_update_elem(ctx->curr_fd, ctx->key, ctx->value, BPF_ANY);
     if (ret) {
         free_outter_map_entry(ctx, &outter_key);
@@ -446,26 +458,25 @@ static int repeat_field_handle(struct op_context *ctx, const ProtobufCFieldDescr
     }
 
     switch (field->type) {
-    case PROTOBUF_C_TYPE_MESSAGE:
-    case PROTOBUF_C_TYPE_STRING:
-        for (i = 0; i < *(unsigned int *)n; i++) {
-            outter_key = alloc_outter_map_entry(ctx);
-            if (outter_key < 0)
-                goto end;
+        case PROTOBUF_C_TYPE_MESSAGE:
+        case PROTOBUF_C_TYPE_STRING:
+            for (i = 0; i < *(unsigned int*)n; i++) {
+                outter_key = alloc_outter_map_entry(ctx);
+                if (outter_key < 0)
+                    goto end;
 
-            *((uintptr_t *)inner_map_object + i) = (size_t)outter_key;
-            ret = copy_indirect_data_to_map(ctx, outter_key, origin_value[i], field->type);
-            if (ret)
-                goto end;
-        }
-        break;
-    default:
-        memcpy_s(
-            inner_map_object,
-            ctx->inner_info->value_size,
-            (void *)origin_value,
-            *(size_t *)n * sizeof_elt_in_repeated_array(field->type));
-        break;
+                *((uintptr_t*)inner_map_object + i) = (size_t)outter_key;
+                ret = copy_indirect_data_to_map(ctx, outter_key,
+                                                origin_value[i], field->type);
+                if (ret)
+                    goto end;
+            }
+            break;
+        default:
+            memcpy_s(inner_map_object, ctx->inner_info->value_size,
+                     (void*)origin_value,
+                     *(size_t*)n * sizeof_elt_in_repeated_array(field->type));
+            break;
     }
 
 end:
@@ -473,19 +484,18 @@ end:
     if (ret1) {
         ret = ret1;
         if (indirect_data_type(field->type))
-            free_keys(ctx, inner_map_object, *(size_t *)n);
+            free_keys(ctx, inner_map_object, *(size_t*)n);
     }
 
     free(inner_map_object);
     return ret;
 }
 
-static int update_bpf_map(struct op_context *ctx)
-{
+static int update_bpf_map(struct op_context* ctx) {
     int ret;
     unsigned int i;
-    void *temp_val;
-    const ProtobufCMessageDescriptor *desc = ctx->desc;
+    void* temp_val;
+    const ProtobufCMessageDescriptor* desc = ctx->desc;
 
     if (desc->sizeof_message > ctx->curr_info->value_size) {
         LOG_ERR("map entry size is too small\n");
@@ -496,32 +506,29 @@ static int update_bpf_map(struct op_context *ctx)
     if (!temp_val)
         return -ENOMEM;
 
-    memcpy_s(temp_val, ctx->curr_info->value_size, ctx->value, ctx->curr_info->value_size);
+    memcpy_s(temp_val, ctx->curr_info->value_size, ctx->value,
+             ctx->curr_info->value_size);
     ctx->value = temp_val;
 
     for (i = 0; i < desc->n_fields; i++) {
-        const ProtobufCFieldDescriptor *field = desc->fields + i;
+        const ProtobufCFieldDescriptor* field = desc->fields + i;
 
-        if (!selected_oneof_field(ctx->value, field) || !valid_field_value(ctx->value, field))
+        if (!selected_oneof_field(ctx->value, field) ||
+            !valid_field_value(ctx->value, field))
             continue;
 
         switch (field->label) {
-        case PROTOBUF_C_LABEL_REPEATED:
-            ret = repeat_field_handle(ctx, field);
-            break;
-        default:
-            ret = field_handle(ctx, field);
-            break;
+            case PROTOBUF_C_LABEL_REPEATED:
+                ret = repeat_field_handle(ctx, field);
+                break;
+            default:
+                ret = field_handle(ctx, field);
+                break;
         }
 
         if (ret) {
-            LOG_INFO(
-                "desc.name:%s field[%d - %s] handle failed:%d, errno:%d\n",
-                desc->short_name,
-                i,
-                desc->fields[i].name,
-                ret,
-                errno);
+            LOG_INFO("desc.name:%s field[%d - %s] handle failed:%d, errno:%d\n",
+                     desc->short_name, i, desc->fields[i].name, ret, errno);
             free(temp_val);
             return ret;
         }
@@ -532,26 +539,27 @@ static int update_bpf_map(struct op_context *ctx)
     return ret;
 }
 
-static int map_info_check(struct bpf_map_info *outter_info, struct bpf_map_info *inner_info)
-{
+static int map_info_check(struct bpf_map_info* outter_info,
+                          struct bpf_map_info* inner_info) {
     if (outter_info->type != BPF_MAP_TYPE_ARRAY_OF_MAPS) {
         LOG_ERR("outter map type must be BPF_MAP_TYPE_ARRAY_OF_MAPS\n");
         return -EINVAL;
     }
 
-    if (outter_info->max_entries < 2 || outter_info->max_entries > MAX_OUTTER_MAP_ENTRIES) {
-        LOG_ERR("outter map max_entries must be in[2,%d]\n", MAX_OUTTER_MAP_ENTRIES);
+    if (outter_info->max_entries < 2 ||
+        outter_info->max_entries > MAX_OUTTER_MAP_ENTRIES) {
+        LOG_ERR("outter map max_entries must be in[2,%d]\n",
+                MAX_OUTTER_MAP_ENTRIES);
         return -EINVAL;
     }
     return 0;
 }
 
-int deserial_update_elem(void *key, void *value)
-{
+int deserial_update_elem(void* key, void* value) {
     int ret;
-    const char *map_name = NULL;
+    const char* map_name = NULL;
     struct op_context context = {.inner_map_object = NULL};
-    const ProtobufCMessageDescriptor *desc;
+    const ProtobufCMessageDescriptor* desc;
     struct bpf_map_info outter_info = {0}, inner_info = {0}, info = {0};
     int map_fd, outter_fd = 0, inner_fd = 0;
     unsigned int id, outter_id = 0, inner_id = 0;
@@ -559,7 +567,7 @@ int deserial_update_elem(void *key, void *value)
     if (!key || !value)
         return -EINVAL;
 
-    desc = ((ProtobufCMessage *)value)->descriptor;
+    desc = ((ProtobufCMessage*)value)->descriptor;
     if (desc && desc->magic == PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC)
         map_name = desc->short_name;
 
@@ -585,7 +593,8 @@ int deserial_update_elem(void *key, void *value)
 
     deserial_delete_elem(key, desc);
 
-    init_op_context(context, key, value, desc, outter_fd, map_fd, &outter_info, &inner_info, &info);
+    init_op_context(context, key, value, desc, outter_fd, map_fd, &outter_info,
+                    &inner_info, &info);
 
     context.inner_map_object = calloc(1, context.inner_info->value_size);
     if (context.inner_map_object == NULL) {
@@ -613,14 +622,14 @@ end:
     return ret;
 }
 
-static int query_string_field(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
-{
+static int query_string_field(struct op_context* ctx,
+                              const ProtobufCFieldDescriptor* field) {
     int key = 0, ret;
     int inner_fd;
-    void *string;
-    void *outter_key = (void *)((char *)ctx->value + field->offset);
+    void* string;
+    void* outter_key = (void*)((char*)ctx->value + field->offset);
 
-    inner_fd = outter_key_to_inner_fd(ctx, *(int *)outter_key);
+    inner_fd = outter_key_to_inner_fd(ctx, *(int*)outter_key);
     if (inner_fd < 0)
         return inner_fd;
 
@@ -629,21 +638,21 @@ static int query_string_field(struct op_context *ctx, const ProtobufCFieldDescri
         return -ENOMEM;
     }
 
-    (*(uintptr_t *)outter_key) = (uintptr_t)string;
+    (*(uintptr_t*)outter_key) = (uintptr_t)string;
 
     ret = bpf_map_lookup_elem(inner_fd, &key, string);
     return ret;
 }
 
-static int query_message_field(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
-{
+static int query_message_field(struct op_context* ctx,
+                               const ProtobufCFieldDescriptor* field) {
     int ret;
     int key = 0;
     int inner_fd;
-    void *message;
+    void* message;
     struct op_context new_ctx;
-    const ProtobufCMessageDescriptor *desc;
-    uintptr_t *outter_key = (uintptr_t *)((char *)ctx->value + field->offset);
+    const ProtobufCMessageDescriptor* desc;
+    uintptr_t* outter_key = (uintptr_t*)((char*)ctx->value + field->offset);
 
     inner_fd = outter_key_to_inner_fd(ctx, *outter_key);
     if (inner_fd < 0)
@@ -651,10 +660,10 @@ static int query_message_field(struct op_context *ctx, const ProtobufCFieldDescr
 
     memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
     new_ctx.curr_fd = inner_fd;
-    new_ctx.key = (void *)&key;
+    new_ctx.key = (void*)&key;
     new_ctx.curr_info = ctx->inner_info;
 
-    desc = (ProtobufCMessageDescriptor *)field->descriptor;
+    desc = (ProtobufCMessageDescriptor*)field->descriptor;
     if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
         return -EINVAL;
     }
@@ -666,27 +675,28 @@ static int query_message_field(struct op_context *ctx, const ProtobufCFieldDescr
     return ret;
 }
 
-static int field_query(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
-{
+static int field_query(struct op_context* ctx,
+                       const ProtobufCFieldDescriptor* field) {
     switch (field->type) {
-    case PROTOBUF_C_TYPE_MESSAGE:
-        return query_message_field(ctx, field);
-    case PROTOBUF_C_TYPE_STRING:
-        return query_string_field(ctx, field);
-    default:
-        break;
+        case PROTOBUF_C_TYPE_MESSAGE:
+            return query_message_field(ctx, field);
+        case PROTOBUF_C_TYPE_STRING:
+            return query_string_field(ctx, field);
+        default:
+            break;
     }
 
     return 0;
 }
 
-static void *create_indirect_struct(
-    struct op_context *ctx, unsigned long outter_key, const ProtobufCFieldDescriptor *field, int *err)
-{
+static void* create_indirect_struct(struct op_context* ctx,
+                                    unsigned long outter_key,
+                                    const ProtobufCFieldDescriptor* field,
+                                    int* err) {
     int inner_fd, key = 0;
-    void *value;
+    void* value;
     struct op_context new_ctx;
-    const ProtobufCMessageDescriptor *desc;
+    const ProtobufCMessageDescriptor* desc;
 
     inner_fd = outter_key_to_inner_fd(ctx, outter_key);
     if (inner_fd < 0) {
@@ -695,49 +705,49 @@ static void *create_indirect_struct(
     }
 
     switch (field->type) {
-    case PROTOBUF_C_TYPE_MESSAGE:
-        memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
-        new_ctx.curr_fd = inner_fd;
-        new_ctx.key = (void *)&key;
-        new_ctx.curr_info = ctx->inner_info;
+        case PROTOBUF_C_TYPE_MESSAGE:
+            memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
+            new_ctx.curr_fd = inner_fd;
+            new_ctx.key = (void*)&key;
+            new_ctx.curr_info = ctx->inner_info;
 
-        desc = (ProtobufCMessageDescriptor *)field->descriptor;
-        if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
-            *err = -EINVAL;
-            return NULL;
-        }
+            desc = (ProtobufCMessageDescriptor*)field->descriptor;
+            if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
+                *err = -EINVAL;
+                return NULL;
+            }
 
-        new_ctx.desc = desc;
-        value = create_struct(&new_ctx, err);
-        return value;
-    default:
-        value = malloc(ctx->inner_info->value_size);
-        if (!value) {
-            *err = -ENOMEM;
-            return NULL;
-        }
-
-        *err = bpf_map_lookup_elem(inner_fd, &key, value);
-        if (*err < 0) {
+            new_ctx.desc = desc;
+            value = create_struct(&new_ctx, err);
             return value;
-        }
+        default:
+            value = malloc(ctx->inner_info->value_size);
+            if (!value) {
+                *err = -ENOMEM;
+                return NULL;
+            }
 
-        break;
+            *err = bpf_map_lookup_elem(inner_fd, &key, value);
+            if (*err < 0) {
+                return value;
+            }
+
+            break;
     }
 
     *err = 0;
     return value;
 }
 
-static int repeat_field_query(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
-{
+static int repeat_field_query(struct op_context* ctx,
+                              const ProtobufCFieldDescriptor* field) {
     int ret;
     int key = 0;
     int inner_fd;
-    void *array;
+    void* array;
     unsigned int i;
-    void *n = ((char *)ctx->value) + field->quantifier_offset;
-    uintptr_t *outter_key = (uintptr_t *)((char *)ctx->value + field->offset);
+    void* n = ((char*)ctx->value) + field->quantifier_offset;
+    uintptr_t* outter_key = (uintptr_t*)((char*)ctx->value + field->offset);
 
     inner_fd = outter_key_to_inner_fd(ctx, *outter_key);
     if (inner_fd < 0)
@@ -755,28 +765,77 @@ static int repeat_field_query(struct op_context *ctx, const ProtobufCFieldDescri
     }
 
     switch (field->type) {
-    case PROTOBUF_C_TYPE_MESSAGE:
-    case PROTOBUF_C_TYPE_STRING:
-        for (i = 0; i < *(unsigned int *)n; i++) {
-            outter_key = (uintptr_t *)array + i;
-            *outter_key = (uintptr_t)create_indirect_struct(ctx, *outter_key, field, &ret);
-            if (ret)
-                break;
-        }
-        break;
-    default:
-        break;
+        case PROTOBUF_C_TYPE_MESSAGE:
+        case PROTOBUF_C_TYPE_STRING:
+            for (i = 0; i < *(unsigned int*)n; i++) {
+                outter_key = (uintptr_t*)array + i;
+                *outter_key = (uintptr_t)create_indirect_struct(
+                    ctx, *outter_key, field, &ret);
+                if (ret)
+                    break;
+            }
+            break;
+        default:
+            break;
     }
 
     return ret;
 }
 
-static void *create_struct(struct op_context *ctx, int *err)
-{
-    void *value;
+void deserial_free_elem_list(struct element_list_node* head) {
+    while (head != NULL) {
+        struct element_list_node* n = head;
+        deserial_free_elem(n->elem);
+        head = n->next;
+        free(n);
+    }
+}
+
+static void* create_struct_list(struct op_context* ctx, int* err) {
+    void* prev_key = NULL;
+    void* value;
+    struct element_list_node* elem_list_head = NULL;
+    struct element_list_node* curr_elem_list_node = NULL;
+
+    *err = 0;
+    ctx->key = calloc(1, ctx->curr_info->key_size);
+    while (!bpf_map_get_next_key(ctx->curr_fd, prev_key, ctx->key)) {
+        prev_key = ctx->key;
+
+        value = create_struct(ctx, err);
+        if (*err != 0) {
+            LOG_ERR("create_struct failed, err = %d\n", err);
+            deserial_free_elem_list(elem_list_head);
+            value = NULL;
+        }
+
+        if (value == NULL) {
+            continue;
+        }
+
+        struct element_list_node* new_node = (struct element_list_node*)calloc(
+            1, sizeof(struct element_list_node));
+        if (!new_node) {
+            deserial_free_elem_list(elem_list_head);
+            return NULL;
+        }
+        new_node->elem = value;
+        new_node->next = NULL;
+        if (curr_elem_list_node == NULL) {
+            curr_elem_list_node = elem_list_head = new_node;
+        } else {
+            curr_elem_list_node->next = new_node;
+            curr_elem_list_node = new_node;
+        }
+    }
+    return elem_list_head;
+}
+
+static void* create_struct(struct op_context* ctx, int* err) {
+    void* value;
     int ret;
     unsigned int i;
-    const ProtobufCMessageDescriptor *desc = ctx->desc;
+    const ProtobufCMessageDescriptor* desc = ctx->desc;
 
     *err = 0;
 
@@ -797,18 +856,19 @@ static void *create_struct(struct op_context *ctx, int *err)
 
     ctx->value = value;
     for (i = 0; i < desc->n_fields; i++) {
-        const ProtobufCFieldDescriptor *field = desc->fields + i;
+        const ProtobufCFieldDescriptor* field = desc->fields + i;
 
-        if (!selected_oneof_field(ctx->value, field) || !valid_field_value(ctx->value, field))
+        if (!selected_oneof_field(ctx->value, field) ||
+            !valid_field_value(ctx->value, field))
             continue;
 
         switch (field->label) {
-        case PROTOBUF_C_LABEL_REPEATED:
-            ret = repeat_field_query(ctx, field);
-            break;
-        default:
-            ret = field_query(ctx, field);
-            break;
+            case PROTOBUF_C_LABEL_REPEATED:
+                ret = repeat_field_query(ctx, field);
+                break;
+            default:
+                ret = field_query(ctx, field);
+                break;
         }
 
         if (ret) {
@@ -821,21 +881,20 @@ static void *create_struct(struct op_context *ctx, int *err)
     return value;
 }
 
-void *deserial_lookup_elem(void *key, const void *msg_desciptor)
-{
+struct element_list_node* deserial_lookup_all_elems(const void* msg_desciptor) {
     int ret, err;
-    void *value = NULL;
-    const char *map_name = NULL;
+    struct element_list_node* value_list_head = NULL;
+    const char* map_name = NULL;
     struct op_context context = {.inner_map_object = NULL};
-    const ProtobufCMessageDescriptor *desc;
+    const ProtobufCMessageDescriptor* desc;
     struct bpf_map_info outter_info = {0}, inner_info = {0}, info = {0};
     int map_fd, outter_fd = 0, inner_fd = 0;
     unsigned int id, outter_id = 0, inner_id = 0;
 
-    if (msg_desciptor == NULL || key == NULL)
+    if (msg_desciptor == NULL)
         return NULL;
 
-    desc = (ProtobufCMessageDescriptor *)msg_desciptor;
+    desc = (ProtobufCMessageDescriptor*)msg_desciptor;
     if (desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC)
         return NULL;
 
@@ -855,7 +914,63 @@ void *deserial_lookup_elem(void *key, const void *msg_desciptor)
     if (ret < 0 || map_info_check(&outter_info, &inner_info))
         goto end;
 
-    init_op_context(context, key, NULL, desc, outter_fd, map_fd, &outter_info, &inner_info, &info);
+    init_op_context(context, NULL, NULL, desc, outter_fd, map_fd, &outter_info,
+                    &inner_info, &info);
+
+    value_list_head = create_struct_list(&context, &err);
+    if (err != 0) {
+        LOG_ERR("create_struct_list failed, err = %d", err);
+        deserial_free_elem_list(value_list_head);
+        value_list_head = NULL;
+    }
+
+end:
+    if (context.key != NULL)
+        free(context.key);
+    if (map_fd > 0)
+        close(map_fd);
+    if (outter_fd > 0)
+        close(outter_fd);
+    if (inner_fd > 0)
+        close(inner_fd);
+    return value_list_head;
+}
+
+void* deserial_lookup_elem(void* key, const void* msg_desciptor) {
+    int ret, err;
+    void* value = NULL;
+    const char* map_name = NULL;
+    struct op_context context = {.inner_map_object = NULL};
+    const ProtobufCMessageDescriptor* desc;
+    struct bpf_map_info outter_info = {0}, inner_info = {0}, info = {0};
+    int map_fd, outter_fd = 0, inner_fd = 0;
+    unsigned int id, outter_id = 0, inner_id = 0;
+
+    if (msg_desciptor == NULL || key == NULL)
+        return NULL;
+
+    desc = (ProtobufCMessageDescriptor*)msg_desciptor;
+    if (desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC)
+        return NULL;
+
+    map_name = desc->short_name;
+    ret = get_map_ids(map_name, &id, &outter_id, &inner_id);
+    if (ret)
+        return NULL;
+
+    ret = get_map_fd_info(id, &map_fd, &info);
+    if (ret < 0) {
+        LOG_ERR("invalid MAP_ID: %d\n", id);
+        return NULL;
+    }
+
+    ret = get_map_fd_info(inner_id, &inner_fd, &inner_info);
+    ret |= get_map_fd_info(outter_id, &outter_fd, &outter_info);
+    if (ret < 0 || map_info_check(&outter_info, &inner_info))
+        goto end;
+
+    init_op_context(context, key, NULL, desc, outter_fd, map_fd, &outter_info,
+                    &inner_info, &info);
 
     normalize_key(&context, key, map_name);
     value = create_struct(&context, &err);
@@ -876,12 +991,13 @@ end:
     return value;
 }
 
-static int indirect_field_del(struct op_context *ctx, unsigned int outter_key, const ProtobufCFieldDescriptor *field)
-{
-    char *inner_map_object = NULL;
+static int indirect_field_del(struct op_context* ctx,
+                              unsigned int outter_key,
+                              const ProtobufCFieldDescriptor* field) {
+    char* inner_map_object = NULL;
     int inner_fd, key = 0;
     struct op_context new_ctx;
-    const ProtobufCMessageDescriptor *desc;
+    const ProtobufCMessageDescriptor* desc;
 
     if (!valid_outter_key(ctx, outter_key))
         return -EINVAL;
@@ -893,43 +1009,43 @@ static int indirect_field_del(struct op_context *ctx, unsigned int outter_key, c
     free_outter_map_entry(ctx, &outter_key);
 
     switch (field->type) {
-    case PROTOBUF_C_TYPE_MESSAGE:
-        desc = (ProtobufCMessageDescriptor *)field->descriptor;
-        if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
-            return -EINVAL;
-        }
+        case PROTOBUF_C_TYPE_MESSAGE:
+            desc = (ProtobufCMessageDescriptor*)field->descriptor;
+            if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
+                return -EINVAL;
+            }
 
-        inner_map_object = malloc(ctx->inner_info->value_size);
-        if (!inner_map_object) {
-            return -ENOMEM;
-        }
+            inner_map_object = malloc(ctx->inner_info->value_size);
+            if (!inner_map_object) {
+                return -ENOMEM;
+            }
 
-        memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
-        new_ctx.curr_fd = inner_fd;
-        new_ctx.key = (void *)&key;
-        new_ctx.curr_info = ctx->inner_info;
-        new_ctx.value = inner_map_object;
-        new_ctx.desc = desc;
+            memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
+            new_ctx.curr_fd = inner_fd;
+            new_ctx.key = (void*)&key;
+            new_ctx.curr_info = ctx->inner_info;
+            new_ctx.value = inner_map_object;
+            new_ctx.desc = desc;
 
-        (void)del_bpf_map(&new_ctx, 1);
-        free(inner_map_object);
-        break;
+            (void)del_bpf_map(&new_ctx, 1);
+            free(inner_map_object);
+            break;
 
-    default:
-        break;
+        default:
+            break;
     }
 
     return 0;
 }
 
-static int repeat_field_del(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
-{
+static int repeat_field_del(struct op_context* ctx,
+                            const ProtobufCFieldDescriptor* field) {
     int ret;
     unsigned int i;
     int inner_fd, key = 0;
-    void *inner_map_object = NULL;
-    void *n;
-    uintptr_t *outter_key;
+    void* inner_map_object = NULL;
+    void* n;
+    uintptr_t* outter_key;
 
     ret = bpf_map_lookup_elem(ctx->curr_fd, ctx->key, ctx->value);
     if (ret < 0) {
@@ -937,7 +1053,7 @@ static int repeat_field_del(struct op_context *ctx, const ProtobufCFieldDescript
         return ret;
     }
 
-    outter_key = (uintptr_t *)((char *)ctx->value + field->offset);
+    outter_key = (uintptr_t*)((char*)ctx->value + field->offset);
     if (!valid_outter_key(ctx, *outter_key))
         return -EINVAL;
 
@@ -949,28 +1065,28 @@ static int repeat_field_del(struct op_context *ctx, const ProtobufCFieldDescript
     if (ret)
         return ret;
 
-    n = ((char *)ctx->value) + field->quantifier_offset;
+    n = ((char*)ctx->value) + field->quantifier_offset;
 
     switch (field->type) {
-    case PROTOBUF_C_TYPE_MESSAGE:
-        // lint -fallthrough
-    case PROTOBUF_C_TYPE_STRING:
-        inner_map_object = calloc(1, ctx->inner_info->value_size);
-        if (!inner_map_object) {
-            ret = -ENOMEM;
-            goto end;
-        }
+        case PROTOBUF_C_TYPE_MESSAGE:
+            // lint -fallthrough
+        case PROTOBUF_C_TYPE_STRING:
+            inner_map_object = calloc(1, ctx->inner_info->value_size);
+            if (!inner_map_object) {
+                ret = -ENOMEM;
+                goto end;
+            }
 
-        ret = bpf_map_lookup_elem(inner_fd, &key, inner_map_object);
-        if (ret < 0)
-            goto end;
+            ret = bpf_map_lookup_elem(inner_fd, &key, inner_map_object);
+            if (ret < 0)
+                goto end;
 
-        for (i = 0; i < *(size_t *)n; i++) {
-            outter_key = (uintptr_t *)inner_map_object + i;
-            indirect_field_del(ctx, *outter_key, field);
-        }
-    default:
-        break;
+            for (i = 0; i < *(size_t*)n; i++) {
+                outter_key = (uintptr_t*)inner_map_object + i;
+                indirect_field_del(ctx, *outter_key, field);
+            }
+        default:
+            break;
     }
 
 end:
@@ -979,15 +1095,16 @@ end:
     return ret;
 }
 
-static int msg_field_del(struct op_context *ctx, int inner_fd, const ProtobufCFieldDescriptor *field)
-{
+static int msg_field_del(struct op_context* ctx,
+                         int inner_fd,
+                         const ProtobufCFieldDescriptor* field) {
     int key = 0;
     int ret;
-    char *inner_map_object = NULL;
+    char* inner_map_object = NULL;
     struct op_context new_ctx;
-    const ProtobufCMessageDescriptor *desc;
+    const ProtobufCMessageDescriptor* desc;
 
-    desc = (ProtobufCMessageDescriptor *)field->descriptor;
+    desc = (ProtobufCMessageDescriptor*)field->descriptor;
     if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC)
         return -EINVAL;
 
@@ -997,7 +1114,7 @@ static int msg_field_del(struct op_context *ctx, int inner_fd, const ProtobufCFi
 
     memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
     new_ctx.curr_fd = inner_fd;
-    new_ctx.key = (void *)&key;
+    new_ctx.key = (void*)&key;
     new_ctx.curr_info = ctx->inner_info;
     new_ctx.value = inner_map_object;
     new_ctx.desc = desc;
@@ -1007,69 +1124,69 @@ static int msg_field_del(struct op_context *ctx, int inner_fd, const ProtobufCFi
     return ret;
 }
 
-static int field_del(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
-{
+static int field_del(struct op_context* ctx,
+                     const ProtobufCFieldDescriptor* field) {
     int ret;
     int inner_fd;
-    uintptr_t *outter_key;
+    uintptr_t* outter_key;
 
     switch (field->type) {
-    case PROTOBUF_C_TYPE_MESSAGE:
-    case PROTOBUF_C_TYPE_STRING:
-        ret = bpf_map_lookup_elem(ctx->curr_fd, ctx->key, ctx->value);
-        if (ret < 0)
-            return ret;
+        case PROTOBUF_C_TYPE_MESSAGE:
+        case PROTOBUF_C_TYPE_STRING:
+            ret = bpf_map_lookup_elem(ctx->curr_fd, ctx->key, ctx->value);
+            if (ret < 0)
+                return ret;
 
-        outter_key = (uintptr_t *)((char *)ctx->value + field->offset);
-        if (!valid_outter_key(ctx, *outter_key))
-            return -EINVAL;
+            outter_key = (uintptr_t*)((char*)ctx->value + field->offset);
+            if (!valid_outter_key(ctx, *outter_key))
+                return -EINVAL;
 
-        inner_fd = outter_key_to_inner_fd(ctx, *outter_key);
-        if (inner_fd < 0)
-            return inner_fd;
+            inner_fd = outter_key_to_inner_fd(ctx, *outter_key);
+            if (inner_fd < 0)
+                return inner_fd;
 
-        free_outter_map_entry(ctx, outter_key);
+            free_outter_map_entry(ctx, outter_key);
 
-        if (field->type == PROTOBUF_C_TYPE_STRING) {
+            if (field->type == PROTOBUF_C_TYPE_STRING) {
+                break;
+            }
+
+            msg_field_del(ctx, inner_fd, field);
             break;
-        }
-
-        msg_field_del(ctx, inner_fd, field);
-        break;
-    default:
-        break;
+        default:
+            break;
     }
 
     return 0;
 }
 
-static int del_bpf_map(struct op_context *ctx, int is_inner)
-{
+static int del_bpf_map(struct op_context* ctx, int is_inner) {
     int ret;
     unsigned int i;
-    const ProtobufCMessageDescriptor *desc = ctx->desc;
+    const ProtobufCMessageDescriptor* desc = ctx->desc;
 
     ret = bpf_map_lookup_elem(ctx->curr_fd, ctx->key, ctx->value);
     if (ret < 0)
         return ret;
 
     for (i = 0; i < desc->n_fields; i++) {
-        const ProtobufCFieldDescriptor *field = desc->fields + i;
+        const ProtobufCFieldDescriptor* field = desc->fields + i;
 
-        if (!selected_oneof_field(ctx->value, field) || !valid_field_value(ctx->value, field))
+        if (!selected_oneof_field(ctx->value, field) ||
+            !valid_field_value(ctx->value, field))
             continue;
 
         switch (field->label) {
-        case PROTOBUF_C_LABEL_REPEATED:
-            ret = repeat_field_del(ctx, field);
-            if (ret)
-                goto end;
-            break;
-        default:
-            ret = field_del(ctx, field);
-            if (ret)
-                goto end;
-            break;
+            case PROTOBUF_C_LABEL_REPEATED:
+                ret = repeat_field_del(ctx, field);
+                if (ret)
+                    goto end;
+                break;
+            default:
+                ret = field_del(ctx, field);
+                if (ret)
+                    goto end;
+                break;
         }
     }
 
@@ -1077,21 +1194,20 @@ end:
     return (is_inner == 1) ?: bpf_map_delete_elem(ctx->curr_fd, ctx->key);
 }
 
-int deserial_delete_elem(void *key, const void *msg_desciptor)
-{
+int deserial_delete_elem(void* key, const void* msg_desciptor) {
     int ret;
-    const char *map_name = NULL;
+    const char* map_name = NULL;
     struct op_context context = {.inner_map_object = NULL};
-    const ProtobufCMessageDescriptor *desc;
+    const ProtobufCMessageDescriptor* desc;
     struct bpf_map_info outter_info = {0}, inner_info = {0}, info = {0};
     int map_fd, outter_fd = 0, inner_fd = 0;
     unsigned int id, outter_id = 0, inner_id = 0;
-    char *inner_map_object = NULL;
+    char* inner_map_object = NULL;
 
     if (!key || !msg_desciptor)
         return -EINVAL;
 
-    desc = (ProtobufCMessageDescriptor *)msg_desciptor;
+    desc = (ProtobufCMessageDescriptor*)msg_desciptor;
     if (desc->magic == PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC)
         map_name = desc->short_name;
 
@@ -1115,7 +1231,8 @@ int deserial_delete_elem(void *key, const void *msg_desciptor)
     if (ret < 0 || map_info_check(&outter_info, &inner_info))
         goto end;
 
-    init_op_context(context, key, NULL, desc, outter_fd, map_fd, &outter_info, &inner_info, &info);
+    init_op_context(context, key, NULL, desc, outter_fd, map_fd, &outter_info,
+                    &inner_info, &info);
 
     context.inner_map_object = calloc(1, context.inner_info->value_size);
     context.value = calloc(1, context.curr_info->value_size);
@@ -1145,58 +1262,56 @@ end:
     return ret;
 }
 
-static void repeat_field_free(void *value, const ProtobufCFieldDescriptor *field)
-{
+static void repeat_field_free(void* value,
+                              const ProtobufCFieldDescriptor* field) {
     unsigned int i;
-    void *n = ((char *)value) + field->quantifier_offset;
-    uintptr_t *ptr_array = *(uintptr_t **)((char *)value + field->offset);
+    void* n = ((char*)value) + field->quantifier_offset;
+    uintptr_t* ptr_array = *(uintptr_t**)((char*)value + field->offset);
 
     switch (field->type) {
-    case PROTOBUF_C_TYPE_MESSAGE:
-    case PROTOBUF_C_TYPE_STRING:
-        for (i = 0; i < *(unsigned int *)n; i++) {
-            if (field->type == PROTOBUF_C_TYPE_STRING)
-                free_elem((void *)ptr_array[i]);
-            else
-                deserial_free_elem((void *)ptr_array[i]);
-        }
-        break;
-    default:
-        free_elem((void *)ptr_array);
-        break;
+        case PROTOBUF_C_TYPE_MESSAGE:
+        case PROTOBUF_C_TYPE_STRING:
+            for (i = 0; i < *(unsigned int*)n; i++) {
+                if (field->type == PROTOBUF_C_TYPE_STRING)
+                    free_elem((void*)ptr_array[i]);
+                else
+                    deserial_free_elem((void*)ptr_array[i]);
+            }
+            break;
+        default:
+            free_elem((void*)ptr_array);
+            break;
     }
 
     return;
 }
 
-static void field_free(void *value, const ProtobufCFieldDescriptor *field)
-{
-    uintptr_t *tobe_free = (uintptr_t *)((char *)value + field->offset);
+static void field_free(void* value, const ProtobufCFieldDescriptor* field) {
+    uintptr_t* tobe_free = (uintptr_t*)((char*)value + field->offset);
 
     switch (field->type) {
-    case PROTOBUF_C_TYPE_MESSAGE:
-        deserial_free_elem((void *)(*tobe_free));
-        break;
-    case PROTOBUF_C_TYPE_STRING:
-        free_elem((void *)*tobe_free);
-        break;
-    default:
-        break;
+        case PROTOBUF_C_TYPE_MESSAGE:
+            deserial_free_elem((void*)(*tobe_free));
+            break;
+        case PROTOBUF_C_TYPE_STRING:
+            free_elem((void*)*tobe_free);
+            break;
+        default:
+            break;
     }
 
     return;
 }
 
-void deserial_free_elem(void *value)
-{
+void deserial_free_elem(void* value) {
     unsigned int i;
-    const char *map_name = NULL;
-    const ProtobufCMessageDescriptor *desc;
+    const char* map_name = NULL;
+    const ProtobufCMessageDescriptor* desc;
 
     if (!value || (uintptr_t)value < MAX_OUTTER_MAP_ENTRIES)
         return;
 
-    desc = ((ProtobufCMessage *)value)->descriptor;
+    desc = ((ProtobufCMessage*)value)->descriptor;
     if (desc && desc->magic == PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC)
         map_name = desc->short_name;
 
@@ -1207,18 +1322,19 @@ void deserial_free_elem(void *value)
     }
 
     for (i = 0; i < desc->n_fields; i++) {
-        const ProtobufCFieldDescriptor *field = desc->fields + i;
+        const ProtobufCFieldDescriptor* field = desc->fields + i;
 
-        if (!selected_oneof_field(value, field) || !valid_field_value(value, field))
+        if (!selected_oneof_field(value, field) ||
+            !valid_field_value(value, field))
             continue;
 
         switch (field->label) {
-        case PROTOBUF_C_LABEL_REPEATED:
-            repeat_field_free(value, field);
-            break;
-        default:
-            field_free(value, field);
-            break;
+            case PROTOBUF_C_LABEL_REPEATED:
+                repeat_field_free(value, field);
+                break;
+            default:
+                field_free(value, field);
+                break;
         }
     }
 
@@ -1226,9 +1342,10 @@ void deserial_free_elem(void *value)
     return;
 }
 
-int get_outer_inner_map_infos(
-    int *inner_fd, struct bpf_map_info *inner_info, int *outter_fd, struct bpf_map_info *outter_info)
-{
+int get_outer_inner_map_infos(int* inner_fd,
+                              struct bpf_map_info* inner_info,
+                              int* outter_fd,
+                              struct bpf_map_info* outter_info) {
     int ret;
     unsigned int outter_id, inner_id;
 
@@ -1244,22 +1361,23 @@ int get_outer_inner_map_infos(
     return 0;
 }
 
-void *outter_map_update_task(void *arg)
-{
+void* outter_map_update_task(void* arg) {
     int i, end, ret = 0;
     pthread_t tid = pthread_self();
-    struct task_contex *ctx = (struct task_contex *)arg;
+    struct task_contex* ctx = (struct task_contex*)arg;
     if (!ctx)
         return NULL;
 
-    i = (ctx->task_id * TASK_SIZE) ? (ctx->task_id * TASK_SIZE) : 1;
-    end = ((i + TASK_SIZE) < MAX_OUTTER_MAP_ENTRIES) ? (i + TASK_SIZE) : MAX_OUTTER_MAP_ENTRIES;
+    i = ctx->task_id * TASK_SIZE;
+    end = ((i + TASK_SIZE) < MAX_OUTTER_MAP_ENTRIES) ? (i + TASK_SIZE)
+                                                     : MAX_OUTTER_MAP_ENTRIES;
     for (; i < end; i++) {
         if (!g_inner_map_mng.inner_maps[i].map_fd) {
             continue;
         }
 
-        ret = bpf_map_update_elem(ctx->outter_fd, &i, &g_inner_map_mng.inner_maps[i].map_fd, BPF_ANY);
+        ret = bpf_map_update_elem(
+            ctx->outter_fd, &i, &g_inner_map_mng.inner_maps[i].map_fd, BPF_ANY);
         if (ret)
             break;
         g_inner_map_mng.inner_maps[i].in_outer_map = 1;
@@ -1272,19 +1390,17 @@ void *outter_map_update_task(void *arg)
     return NULL;
 }
 
-void wait_sem_value(sem_t *sem, int wait_value)
-{
+void wait_sem_value(sem_t* sem, int wait_value) {
     int sem_val;
     do {
         sem_getvalue(sem, &sem_val);
     } while (sem_val < wait_value);
 }
 
-int outter_map_update(int outter_fd)
-{
+int outter_map_update(int outter_fd) {
     int i, ret = 0;
     pthread_t tid;
-    struct task_contex *task_ctx = NULL;
+    struct task_contex* task_ctx = NULL;
     int threads = MAX_OUTTER_MAP_ENTRIES / TASK_SIZE + 1;
 
     ret = sem_init(&g_inner_map_mng.fin_tasks, 0, 0);
@@ -1294,7 +1410,7 @@ int outter_map_update(int outter_fd)
     }
 
     for (i = 0; i < threads; i++) {
-        task_ctx = (struct task_contex *)malloc(sizeof(struct task_contex));
+        task_ctx = (struct task_contex*)malloc(sizeof(struct task_contex));
         if (!task_ctx)
             break;
 
@@ -1310,28 +1426,22 @@ int outter_map_update(int outter_fd)
     return ret;
 }
 
-int inner_map_create(struct bpf_map_info *inner_info)
-{
+int inner_map_create(struct bpf_map_info* inner_info) {
     int fd;
 #if LIBBPF_HIGHER_0_6_0_VERSION
     LIBBPF_OPTS(bpf_map_create_opts, opts, .map_flags = inner_info->map_flags);
 
-    fd = bpf_map_create(
-        inner_info->type, NULL, inner_info->key_size, inner_info->value_size, inner_info->max_entries, &opts);
+    fd = bpf_map_create(inner_info->type, NULL, inner_info->key_size,
+                        inner_info->value_size, inner_info->max_entries, &opts);
 #else
-    fd = bpf_create_map_name(
-        inner_info->type,
-        NULL,
-        inner_info->key_size,
-        inner_info->value_size,
-        inner_info->max_entries,
-        inner_info->map_flags);
+    fd = bpf_create_map_name(inner_info->type, NULL, inner_info->key_size,
+                             inner_info->value_size, inner_info->max_entries,
+                             inner_info->map_flags);
 #endif
     return fd;
 }
 
-int inner_map_create_all(struct bpf_map_info *inner_info)
-{
+int inner_map_create_all(struct bpf_map_info* inner_info) {
     int i, fd;
 
     for (i = 1; i < MAX_OUTTER_MAP_ENTRIES; i++) {
@@ -1343,13 +1453,13 @@ int inner_map_create_all(struct bpf_map_info *inner_info)
     }
 
     if (i < MAX_OUTTER_MAP_ENTRIES)
-        LOG_WARN("[warning]inner_map_create (%d->%d) failed:%d, errno:%d\n", i, MAX_OUTTER_MAP_ENTRIES, fd, errno);
+        LOG_WARN("[warning]inner_map_create (%d->%d) failed:%d, errno:%d\n", i,
+                 MAX_OUTTER_MAP_ENTRIES, fd, errno);
     return 0;
 }
 
-void deserial_uninit()
-{
-    for (int i = 1; i < MAX_OUTTER_MAP_ENTRIES; i++) {
+void deserial_uninit() {
+    for (int i = 0; i < MAX_OUTTER_MAP_ENTRIES; i++) {
         g_inner_map_mng.inner_maps[i].in_outer_map = 0;
         g_inner_map_mng.inner_maps[i].used = 0;
         if (g_inner_map_mng.inner_maps[i].map_fd)
@@ -1362,14 +1472,14 @@ void deserial_uninit()
     return;
 }
 
-int deserial_init()
-{
+int deserial_init() {
     int ret = 0;
     int inner_fd = -1, outter_fd = -1;
     struct bpf_map_info outter_info = {0}, inner_info = {0};
 
     do {
-        ret = get_outer_inner_map_infos(&inner_fd, &inner_info, &outter_fd, &outter_info);
+        ret = get_outer_inner_map_infos(&inner_fd, &inner_info, &outter_fd,
+                                        &outter_info);
         if (ret)
             break;
 

--- a/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.c
+++ b/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.c
@@ -19,42 +19,42 @@
 #include "deserialization_to_bpf_map.h"
 #include "../../config/kmesh_marcos_def.h"
 
-#define PRINTF(fmt, args...) \
-    do {                     \
-        printf(fmt, ##args); \
-        fflush(stdout);      \
+#define PRINTF(fmt, args...)                                                                                           \
+    do {                                                                                                               \
+        printf(fmt, ##args);                                                                                           \
+        fflush(stdout);                                                                                                \
     } while (0)
 
-#define LOG_ERR(fmt, args...) PRINTF(fmt, ##args)
+#define LOG_ERR(fmt, args...)  PRINTF(fmt, ##args)
 #define LOG_WARN(fmt, args...) PRINTF(fmt, ##args)
 #define LOG_INFO(fmt, args...) PRINTF(fmt, ##args)
 
 struct op_context {
-    void* key;
-    void* value;
+    void *key;
+    void *value;
     int outter_fd;
     int map_fd;
     int curr_fd;
-    struct bpf_map_info* outter_info;
-    struct bpf_map_info* inner_info;
-    struct bpf_map_info* info;
-    struct bpf_map_info* curr_info;
-    char* inner_map_object;
-    const ProtobufCMessageDescriptor* desc;
+    struct bpf_map_info *outter_info;
+    struct bpf_map_info *inner_info;
+    struct bpf_map_info *info;
+    struct bpf_map_info *curr_info;
+    char *inner_map_object;
+    const ProtobufCMessageDescriptor *desc;
 };
 
-#define init_op_context(context, k, v, desc, o_fd, fd, o_info, i_info, m_info) \
-    do {                                                                       \
-        (context).key = (k);                                                   \
-        (context).value = (v);                                                 \
-        (context).desc = (desc);                                               \
-        (context).outter_fd = (o_fd);                                          \
-        (context).map_fd = (fd);                                               \
-        (context).outter_info = (o_info);                                      \
-        (context).inner_info = (i_info);                                       \
-        (context).info = (m_info);                                             \
-        (context).curr_info = (m_info);                                        \
-        (context).curr_fd = (fd);                                              \
+#define init_op_context(context, k, v, desc, o_fd, fd, o_info, i_info, m_info)                                         \
+    do {                                                                                                               \
+        (context).key = (k);                                                                                           \
+        (context).value = (v);                                                                                         \
+        (context).desc = (desc);                                                                                       \
+        (context).outter_fd = (o_fd);                                                                                  \
+        (context).map_fd = (fd);                                                                                       \
+        (context).outter_info = (o_info);                                                                              \
+        (context).inner_info = (i_info);                                                                               \
+        (context).info = (m_info);                                                                                     \
+        (context).curr_info = (m_info);                                                                                \
+        (context).curr_fd = (fd);                                                                                      \
     } while (0)
 
 #define TASK_SIZE (100)
@@ -78,14 +78,13 @@ struct task_contex {
 
 struct inner_map_mng g_inner_map_mng = {0};
 
-static int update_bpf_map(struct op_context* ctx);
-static void* create_struct(struct op_context* ctx, int* err);
-static int del_bpf_map(struct op_context* ctx, int is_inner);
-static int free_outter_map_entry(struct op_context* ctx, void* outter_key);
+static int update_bpf_map(struct op_context *ctx);
+static void *create_struct(struct op_context *ctx, int *err);
+static int del_bpf_map(struct op_context *ctx, int is_inner);
+static int free_outter_map_entry(struct op_context *ctx, void *outter_key);
 
-static int normalize_key(struct op_context* ctx,
-                         void* key,
-                         const char* map_name) {
+static int normalize_key(struct op_context *ctx, void *key, const char *map_name)
+{
     ctx->key = calloc(1, ctx->curr_info->key_size);
     if (!ctx->key)
         return -errno;
@@ -94,17 +93,16 @@ static int normalize_key(struct op_context* ctx,
         return -errno;
 
     if (!strncmp(map_name, "Listener", strlen(map_name)))
-        memcpy_s(ctx->key, ctx->curr_info->key_size, key,
-                 ctx->curr_info->key_size);
+        memcpy_s(ctx->key, ctx->curr_info->key_size, key, ctx->curr_info->key_size);
     else
         strncpy(ctx->key, key, ctx->curr_info->key_size);
 
     return 0;
 }
 
-static inline int selected_oneof_field(void* value,
-                                       const ProtobufCFieldDescriptor* field) {
-    uint32_t n = *(uint32_t*)((char*)value + field->quantifier_offset);
+static inline int selected_oneof_field(void *value, const ProtobufCFieldDescriptor *field)
+{
+    uint32_t n = *(uint32_t *)((char *)value + field->quantifier_offset);
 
     if ((field->flags & PROTOBUF_C_FIELD_FLAG_ONEOF) && field->id != n)
         return 0;
@@ -112,81 +110,84 @@ static inline int selected_oneof_field(void* value,
     return 1;
 }
 
-static inline int valid_field_value(void* value,
-                                    const ProtobufCFieldDescriptor* field) {
-    uint32_t val = *(uint32_t*)((char*)value + field->offset);
+static inline int valid_field_value(void *value, const ProtobufCFieldDescriptor *field)
+{
+    uint32_t val = *(uint32_t *)((char *)value + field->offset);
 
     if (val == 0) {
         switch (field->type) {
-            case PROTOBUF_C_TYPE_MESSAGE:
-            case PROTOBUF_C_TYPE_STRING:
-                return 0;
-            default:
-                break;
+        case PROTOBUF_C_TYPE_MESSAGE:
+        case PROTOBUF_C_TYPE_STRING:
+            return 0;
+        default:
+            break;
         }
 
         switch (field->label) {
-            case PROTOBUF_C_LABEL_REPEATED:
-                return 0;
-            default:
-                break;
+        case PROTOBUF_C_LABEL_REPEATED:
+            return 0;
+        default:
+            break;
         }
     }
 
     return 1;
 }
 
-static inline size_t sizeof_elt_in_repeated_array(ProtobufCType type) {
+static inline size_t sizeof_elt_in_repeated_array(ProtobufCType type)
+{
     switch (type) {
-        case PROTOBUF_C_TYPE_SINT32:
-        case PROTOBUF_C_TYPE_INT32:
-        case PROTOBUF_C_TYPE_UINT32:
-        case PROTOBUF_C_TYPE_SFIXED32:
-        case PROTOBUF_C_TYPE_FIXED32:
-        case PROTOBUF_C_TYPE_FLOAT:
-        case PROTOBUF_C_TYPE_ENUM:
-            return 4;
-        case PROTOBUF_C_TYPE_SINT64:
-        case PROTOBUF_C_TYPE_INT64:
-        case PROTOBUF_C_TYPE_UINT64:
-        case PROTOBUF_C_TYPE_SFIXED64:
-        case PROTOBUF_C_TYPE_FIXED64:
-        case PROTOBUF_C_TYPE_DOUBLE:
-            return 8;
-        case PROTOBUF_C_TYPE_BOOL:
-            return sizeof(protobuf_c_boolean);
-        case PROTOBUF_C_TYPE_STRING:
-        case PROTOBUF_C_TYPE_MESSAGE:
-            return sizeof(void*);
-        case PROTOBUF_C_TYPE_BYTES:
-            return sizeof(ProtobufCBinaryData);
-        default:
-            break;
+    case PROTOBUF_C_TYPE_SINT32:
+    case PROTOBUF_C_TYPE_INT32:
+    case PROTOBUF_C_TYPE_UINT32:
+    case PROTOBUF_C_TYPE_SFIXED32:
+    case PROTOBUF_C_TYPE_FIXED32:
+    case PROTOBUF_C_TYPE_FLOAT:
+    case PROTOBUF_C_TYPE_ENUM:
+        return 4;
+    case PROTOBUF_C_TYPE_SINT64:
+    case PROTOBUF_C_TYPE_INT64:
+    case PROTOBUF_C_TYPE_UINT64:
+    case PROTOBUF_C_TYPE_SFIXED64:
+    case PROTOBUF_C_TYPE_FIXED64:
+    case PROTOBUF_C_TYPE_DOUBLE:
+        return 8;
+    case PROTOBUF_C_TYPE_BOOL:
+        return sizeof(protobuf_c_boolean);
+    case PROTOBUF_C_TYPE_STRING:
+    case PROTOBUF_C_TYPE_MESSAGE:
+        return sizeof(void *);
+    case PROTOBUF_C_TYPE_BYTES:
+        return sizeof(ProtobufCBinaryData);
+    default:
+        break;
     }
 
     return 0;
 }
 
-static inline int valid_outter_key(struct op_context* ctx,
-                                   unsigned int outter_key) {
+static inline int valid_outter_key(struct op_context *ctx, unsigned int outter_key)
+{
     if (outter_key < 0 || outter_key >= MAX_OUTTER_MAP_ENTRIES)
         return 0;
 
     return 1;
 }
 
-static void free_elem(void* ptr) {
+static void free_elem(void *ptr)
+{
     if ((uintptr_t)ptr < MAX_OUTTER_MAP_ENTRIES)
         return;
 
     free(ptr);
 }
 
-static void free_keys(struct op_context* ctx, void* keys, int n) {
+static void free_keys(struct op_context *ctx, void *keys, int n)
+{
     int i;
     unsigned int key;
     for (i = 0; i < n; i++) {
-        key = *((uintptr_t*)keys + i);
+        key = *((uintptr_t *)keys + i);
         if (!key)
             return;
 
@@ -194,20 +195,19 @@ static void free_keys(struct op_context* ctx, void* keys, int n) {
     }
 }
 
-static unsigned int get_map_id(const char* name) {
-    char* ptr = NULL;
-    char* map_id = getenv(name);
+static unsigned int get_map_id(const char *name)
+{
+    char *ptr = NULL;
+    char *map_id = getenv(name);
     if (!map_id)
         return 0;
     return (unsigned int)strtol(map_id, &ptr, 10);
 }
 
-static int get_map_ids(const char* name,
-                       unsigned int* id,
-                       unsigned int* outter_id,
-                       unsigned int* inner_id) {
-    char* ptr = NULL;
-    char* map_id;
+static int get_map_ids(const char *name, unsigned int *id, unsigned int *outter_id, unsigned int *inner_id)
+{
+    char *ptr = NULL;
+    char *map_id;
 
     map_id = (name == NULL) ? getenv("MAP_ID") : getenv(name);
     if (!map_id) {
@@ -234,9 +234,8 @@ static int get_map_ids(const char* name,
     return -errno;
 }
 
-static int get_map_fd_info(unsigned int id,
-                           int* map_fd,
-                           struct bpf_map_info* info) {
+static int get_map_fd_info(unsigned int id, int *map_fd, struct bpf_map_info *info)
+{
     int ret;
     __u32 map_info_len;
 
@@ -249,8 +248,9 @@ static int get_map_fd_info(unsigned int id,
     return ret;
 }
 
-static int free_outter_map_entry(struct op_context* ctx, void* outter_key) {
-    int key = *(int*)outter_key;
+static int free_outter_map_entry(struct op_context *ctx, void *outter_key)
+{
+    int key = *(int *)outter_key;
     if (key <= 0 || key >= MAX_OUTTER_MAP_ENTRIES)
         return -1;
 
@@ -261,12 +261,11 @@ static int free_outter_map_entry(struct op_context* ctx, void* outter_key) {
     return 0;
 }
 
-static int alloc_outter_map_entry(struct op_context* ctx) {
+static int alloc_outter_map_entry(struct op_context *ctx)
+{
     int i;
-    if (!g_inner_map_mng.init ||
-        g_inner_map_mng.used_cnt >= MAX_OUTTER_MAP_ENTRIES) {
-        LOG_ERR("[%d %d]alloc_outter_map_entry failed\n", g_inner_map_mng.init,
-                g_inner_map_mng.used_cnt);
+    if (!g_inner_map_mng.init || g_inner_map_mng.used_cnt >= MAX_OUTTER_MAP_ENTRIES) {
+        LOG_ERR("[%d %d]alloc_outter_map_entry failed\n", g_inner_map_mng.init, g_inner_map_mng.used_cnt);
         return -1;
     }
 
@@ -282,22 +281,22 @@ static int alloc_outter_map_entry(struct op_context* ctx) {
     return -1;
 }
 
-static int outter_key_to_inner_fd(struct op_context* ctx, unsigned int key) {
+static int outter_key_to_inner_fd(struct op_context *ctx, unsigned int key)
+{
     if (g_inner_map_mng.inner_maps[key].in_outer_map)
         return g_inner_map_mng.inner_maps[key].map_fd;
     return -1;
 }
 
-static int copy_sfield_to_map(struct op_context* ctx,
-                              int o_index,
-                              const ProtobufCFieldDescriptor* field) {
+static int copy_sfield_to_map(struct op_context *ctx, int o_index, const ProtobufCFieldDescriptor *field)
+{
     int ret;
     int key = 0;
     int inner_fd;
-    char** value = (char**)((char*)ctx->value + field->offset);
-    char* save_value = *value;
+    char **value = (char **)((char *)ctx->value + field->offset);
+    char *save_value = *value;
 
-    *(uintptr_t*)value = (size_t)o_index;
+    *(uintptr_t *)value = (size_t)o_index;
     ret = bpf_map_update_elem(ctx->curr_fd, ctx->key, ctx->value, BPF_ANY);
     if (ret) {
         free_outter_map_entry(ctx, &o_index);
@@ -313,18 +312,17 @@ static int copy_sfield_to_map(struct op_context* ctx,
     return ret;
 }
 
-static int copy_msg_field_to_map(struct op_context* ctx,
-                                 int o_index,
-                                 const ProtobufCFieldDescriptor* field) {
+static int copy_msg_field_to_map(struct op_context *ctx, int o_index, const ProtobufCFieldDescriptor *field)
+{
     int ret;
     int key = 0;
     int inner_fd;
-    void** value = (void**)((char*)ctx->value + field->offset);
-    void* msg = *value;
+    void **value = (void **)((char *)ctx->value + field->offset);
+    void *msg = *value;
     struct op_context new_ctx;
-    const ProtobufCMessageDescriptor* desc;
+    const ProtobufCMessageDescriptor *desc;
 
-    *(uintptr_t*)value = (size_t)o_index;
+    *(uintptr_t *)value = (size_t)o_index;
     ret = bpf_map_update_elem(ctx->curr_fd, ctx->key, ctx->value, BPF_ANY);
     if (ret) {
         free_outter_map_entry(ctx, &o_index);
@@ -338,11 +336,11 @@ static int copy_msg_field_to_map(struct op_context* ctx,
     memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
 
     new_ctx.curr_fd = inner_fd;
-    new_ctx.key = (void*)&key;
+    new_ctx.key = (void *)&key;
     new_ctx.value = msg;
     new_ctx.curr_info = ctx->inner_info;
 
-    desc = ((ProtobufCMessage*)new_ctx.value)->descriptor;
+    desc = ((ProtobufCMessage *)new_ctx.value)->descriptor;
     if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
         return -EINVAL;
     }
@@ -353,95 +351,91 @@ static int copy_msg_field_to_map(struct op_context* ctx,
     return ret;
 }
 
-static int field_handle(struct op_context* ctx,
-                        const ProtobufCFieldDescriptor* field) {
+static int field_handle(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
+{
     int key = 0;
 
-    if (field->type == PROTOBUF_C_TYPE_MESSAGE ||
-        field->type == PROTOBUF_C_TYPE_STRING) {
+    if (field->type == PROTOBUF_C_TYPE_MESSAGE || field->type == PROTOBUF_C_TYPE_STRING) {
         key = alloc_outter_map_entry(ctx);
         if (key < 0)
             return key;
     }
 
     switch (field->type) {
-        case PROTOBUF_C_TYPE_MESSAGE:
-            return copy_msg_field_to_map(ctx, key, field);
-        case PROTOBUF_C_TYPE_STRING:
-            return copy_sfield_to_map(ctx, key, field);
-        default:
-            break;
+    case PROTOBUF_C_TYPE_MESSAGE:
+        return copy_msg_field_to_map(ctx, key, field);
+    case PROTOBUF_C_TYPE_STRING:
+        return copy_sfield_to_map(ctx, key, field);
+    default:
+        break;
     }
 
     return 0;
 }
 
-static int copy_indirect_data_to_map(struct op_context* ctx,
-                                     int outter_key,
-                                     void* value,
-                                     ProtobufCType type) {
+static int copy_indirect_data_to_map(struct op_context *ctx, int outter_key, void *value, ProtobufCType type)
+{
     int ret = 0;
     int inner_fd, key = 0;
     struct op_context new_ctx;
-    const ProtobufCMessageDescriptor* desc;
+    const ProtobufCMessageDescriptor *desc;
 
     inner_fd = outter_key_to_inner_fd(ctx, outter_key);
     if (inner_fd < 0)
         return inner_fd;
 
     switch (type) {
-        case PROTOBUF_C_TYPE_MESSAGE:
-            memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
-            new_ctx.curr_fd = inner_fd;
-            new_ctx.key = (void*)&key;
-            new_ctx.value = value;
-            new_ctx.curr_info = ctx->inner_info;
+    case PROTOBUF_C_TYPE_MESSAGE:
+        memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
+        new_ctx.curr_fd = inner_fd;
+        new_ctx.key = (void *)&key;
+        new_ctx.value = value;
+        new_ctx.curr_info = ctx->inner_info;
 
-            desc = ((ProtobufCMessage*)value)->descriptor;
-            if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
-                return -EINVAL;
-            }
+        desc = ((ProtobufCMessage *)value)->descriptor;
+        if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
+            return -EINVAL;
+        }
 
-            new_ctx.desc = desc;
-            ret = update_bpf_map(&new_ctx);
-            break;
-        case PROTOBUF_C_TYPE_STRING:
-            strcpy_s(ctx->inner_map_object, ctx->inner_info->value_size,
-                     (char*)value);
-            ret = bpf_map_update_elem(inner_fd, &key, ctx->inner_map_object,
-                                      BPF_ANY);
-            break;
-        default:
-            break;
+        new_ctx.desc = desc;
+        ret = update_bpf_map(&new_ctx);
+        break;
+    case PROTOBUF_C_TYPE_STRING:
+        strcpy_s(ctx->inner_map_object, ctx->inner_info->value_size, (char *)value);
+        ret = bpf_map_update_elem(inner_fd, &key, ctx->inner_map_object, BPF_ANY);
+        break;
+    default:
+        break;
     }
 
     return ret;
 }
 
-static bool indirect_data_type(ProtobufCType type) {
+static bool indirect_data_type(ProtobufCType type)
+{
     switch (type) {
-        case PROTOBUF_C_TYPE_MESSAGE:
-        case PROTOBUF_C_TYPE_STRING:
-            return true;
-        default:
-            return false;
+    case PROTOBUF_C_TYPE_MESSAGE:
+    case PROTOBUF_C_TYPE_STRING:
+        return true;
+    default:
+        return false;
     }
 }
 
-static int repeat_field_handle(struct op_context* ctx,
-                               const ProtobufCFieldDescriptor* field) {
+static int repeat_field_handle(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
+{
     int ret, ret1;
     unsigned int i;
     int outter_key, inner_fd, key = 0;
-    void* n = ((char*)ctx->value) + field->quantifier_offset;
-    void*** value = (void***)((char*)ctx->value + field->offset);
-    void** origin_value = *value;
-    char* inner_map_object;
+    void *n = ((char *)ctx->value) + field->quantifier_offset;
+    void ***value = (void ***)((char *)ctx->value + field->offset);
+    void **origin_value = *value;
+    char *inner_map_object;
 
     outter_key = alloc_outter_map_entry(ctx);
     if (outter_key < 0)
         return outter_key;
-    *(uintptr_t*)value = (size_t)outter_key;
+    *(uintptr_t *)value = (size_t)outter_key;
     ret = bpf_map_update_elem(ctx->curr_fd, ctx->key, ctx->value, BPF_ANY);
     if (ret) {
         free_outter_map_entry(ctx, &outter_key);
@@ -458,25 +452,26 @@ static int repeat_field_handle(struct op_context* ctx,
     }
 
     switch (field->type) {
-        case PROTOBUF_C_TYPE_MESSAGE:
-        case PROTOBUF_C_TYPE_STRING:
-            for (i = 0; i < *(unsigned int*)n; i++) {
-                outter_key = alloc_outter_map_entry(ctx);
-                if (outter_key < 0)
-                    goto end;
+    case PROTOBUF_C_TYPE_MESSAGE:
+    case PROTOBUF_C_TYPE_STRING:
+        for (i = 0; i < *(unsigned int *)n; i++) {
+            outter_key = alloc_outter_map_entry(ctx);
+            if (outter_key < 0)
+                goto end;
 
-                *((uintptr_t*)inner_map_object + i) = (size_t)outter_key;
-                ret = copy_indirect_data_to_map(ctx, outter_key,
-                                                origin_value[i], field->type);
-                if (ret)
-                    goto end;
-            }
-            break;
-        default:
-            memcpy_s(inner_map_object, ctx->inner_info->value_size,
-                     (void*)origin_value,
-                     *(size_t*)n * sizeof_elt_in_repeated_array(field->type));
-            break;
+            *((uintptr_t *)inner_map_object + i) = (size_t)outter_key;
+            ret = copy_indirect_data_to_map(ctx, outter_key, origin_value[i], field->type);
+            if (ret)
+                goto end;
+        }
+        break;
+    default:
+        memcpy_s(
+            inner_map_object,
+            ctx->inner_info->value_size,
+            (void *)origin_value,
+            *(size_t *)n * sizeof_elt_in_repeated_array(field->type));
+        break;
     }
 
 end:
@@ -484,18 +479,19 @@ end:
     if (ret1) {
         ret = ret1;
         if (indirect_data_type(field->type))
-            free_keys(ctx, inner_map_object, *(size_t*)n);
+            free_keys(ctx, inner_map_object, *(size_t *)n);
     }
 
     free(inner_map_object);
     return ret;
 }
 
-static int update_bpf_map(struct op_context* ctx) {
+static int update_bpf_map(struct op_context *ctx)
+{
     int ret;
     unsigned int i;
-    void* temp_val;
-    const ProtobufCMessageDescriptor* desc = ctx->desc;
+    void *temp_val;
+    const ProtobufCMessageDescriptor *desc = ctx->desc;
 
     if (desc->sizeof_message > ctx->curr_info->value_size) {
         LOG_ERR("map entry size is too small\n");
@@ -506,29 +502,32 @@ static int update_bpf_map(struct op_context* ctx) {
     if (!temp_val)
         return -ENOMEM;
 
-    memcpy_s(temp_val, ctx->curr_info->value_size, ctx->value,
-             ctx->curr_info->value_size);
+    memcpy_s(temp_val, ctx->curr_info->value_size, ctx->value, ctx->curr_info->value_size);
     ctx->value = temp_val;
 
     for (i = 0; i < desc->n_fields; i++) {
-        const ProtobufCFieldDescriptor* field = desc->fields + i;
+        const ProtobufCFieldDescriptor *field = desc->fields + i;
 
-        if (!selected_oneof_field(ctx->value, field) ||
-            !valid_field_value(ctx->value, field))
+        if (!selected_oneof_field(ctx->value, field) || !valid_field_value(ctx->value, field))
             continue;
 
         switch (field->label) {
-            case PROTOBUF_C_LABEL_REPEATED:
-                ret = repeat_field_handle(ctx, field);
-                break;
-            default:
-                ret = field_handle(ctx, field);
-                break;
+        case PROTOBUF_C_LABEL_REPEATED:
+            ret = repeat_field_handle(ctx, field);
+            break;
+        default:
+            ret = field_handle(ctx, field);
+            break;
         }
 
         if (ret) {
-            LOG_INFO("desc.name:%s field[%d - %s] handle failed:%d, errno:%d\n",
-                     desc->short_name, i, desc->fields[i].name, ret, errno);
+            LOG_INFO(
+                "desc.name:%s field[%d - %s] handle failed:%d, errno:%d\n",
+                desc->short_name,
+                i,
+                desc->fields[i].name,
+                ret,
+                errno);
             free(temp_val);
             return ret;
         }
@@ -539,27 +538,26 @@ static int update_bpf_map(struct op_context* ctx) {
     return ret;
 }
 
-static int map_info_check(struct bpf_map_info* outter_info,
-                          struct bpf_map_info* inner_info) {
+static int map_info_check(struct bpf_map_info *outter_info, struct bpf_map_info *inner_info)
+{
     if (outter_info->type != BPF_MAP_TYPE_ARRAY_OF_MAPS) {
         LOG_ERR("outter map type must be BPF_MAP_TYPE_ARRAY_OF_MAPS\n");
         return -EINVAL;
     }
 
-    if (outter_info->max_entries < 2 ||
-        outter_info->max_entries > MAX_OUTTER_MAP_ENTRIES) {
-        LOG_ERR("outter map max_entries must be in[2,%d]\n",
-                MAX_OUTTER_MAP_ENTRIES);
+    if (outter_info->max_entries < 2 || outter_info->max_entries > MAX_OUTTER_MAP_ENTRIES) {
+        LOG_ERR("outter map max_entries must be in[2,%d]\n", MAX_OUTTER_MAP_ENTRIES);
         return -EINVAL;
     }
     return 0;
 }
 
-int deserial_update_elem(void* key, void* value) {
+int deserial_update_elem(void *key, void *value)
+{
     int ret;
-    const char* map_name = NULL;
+    const char *map_name = NULL;
     struct op_context context = {.inner_map_object = NULL};
-    const ProtobufCMessageDescriptor* desc;
+    const ProtobufCMessageDescriptor *desc;
     struct bpf_map_info outter_info = {0}, inner_info = {0}, info = {0};
     int map_fd, outter_fd = 0, inner_fd = 0;
     unsigned int id, outter_id = 0, inner_id = 0;
@@ -567,7 +565,7 @@ int deserial_update_elem(void* key, void* value) {
     if (!key || !value)
         return -EINVAL;
 
-    desc = ((ProtobufCMessage*)value)->descriptor;
+    desc = ((ProtobufCMessage *)value)->descriptor;
     if (desc && desc->magic == PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC)
         map_name = desc->short_name;
 
@@ -593,8 +591,7 @@ int deserial_update_elem(void* key, void* value) {
 
     deserial_delete_elem(key, desc);
 
-    init_op_context(context, key, value, desc, outter_fd, map_fd, &outter_info,
-                    &inner_info, &info);
+    init_op_context(context, key, value, desc, outter_fd, map_fd, &outter_info, &inner_info, &info);
 
     context.inner_map_object = calloc(1, context.inner_info->value_size);
     if (context.inner_map_object == NULL) {
@@ -622,14 +619,14 @@ end:
     return ret;
 }
 
-static int query_string_field(struct op_context* ctx,
-                              const ProtobufCFieldDescriptor* field) {
+static int query_string_field(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
+{
     int key = 0, ret;
     int inner_fd;
-    void* string;
-    void* outter_key = (void*)((char*)ctx->value + field->offset);
+    void *string;
+    void *outter_key = (void *)((char *)ctx->value + field->offset);
 
-    inner_fd = outter_key_to_inner_fd(ctx, *(int*)outter_key);
+    inner_fd = outter_key_to_inner_fd(ctx, *(int *)outter_key);
     if (inner_fd < 0)
         return inner_fd;
 
@@ -638,21 +635,21 @@ static int query_string_field(struct op_context* ctx,
         return -ENOMEM;
     }
 
-    (*(uintptr_t*)outter_key) = (uintptr_t)string;
+    (*(uintptr_t *)outter_key) = (uintptr_t)string;
 
     ret = bpf_map_lookup_elem(inner_fd, &key, string);
     return ret;
 }
 
-static int query_message_field(struct op_context* ctx,
-                               const ProtobufCFieldDescriptor* field) {
+static int query_message_field(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
+{
     int ret;
     int key = 0;
     int inner_fd;
-    void* message;
+    void *message;
     struct op_context new_ctx;
-    const ProtobufCMessageDescriptor* desc;
-    uintptr_t* outter_key = (uintptr_t*)((char*)ctx->value + field->offset);
+    const ProtobufCMessageDescriptor *desc;
+    uintptr_t *outter_key = (uintptr_t *)((char *)ctx->value + field->offset);
 
     inner_fd = outter_key_to_inner_fd(ctx, *outter_key);
     if (inner_fd < 0)
@@ -660,10 +657,10 @@ static int query_message_field(struct op_context* ctx,
 
     memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
     new_ctx.curr_fd = inner_fd;
-    new_ctx.key = (void*)&key;
+    new_ctx.key = (void *)&key;
     new_ctx.curr_info = ctx->inner_info;
 
-    desc = (ProtobufCMessageDescriptor*)field->descriptor;
+    desc = (ProtobufCMessageDescriptor *)field->descriptor;
     if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
         return -EINVAL;
     }
@@ -675,28 +672,27 @@ static int query_message_field(struct op_context* ctx,
     return ret;
 }
 
-static int field_query(struct op_context* ctx,
-                       const ProtobufCFieldDescriptor* field) {
+static int field_query(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
+{
     switch (field->type) {
-        case PROTOBUF_C_TYPE_MESSAGE:
-            return query_message_field(ctx, field);
-        case PROTOBUF_C_TYPE_STRING:
-            return query_string_field(ctx, field);
-        default:
-            break;
+    case PROTOBUF_C_TYPE_MESSAGE:
+        return query_message_field(ctx, field);
+    case PROTOBUF_C_TYPE_STRING:
+        return query_string_field(ctx, field);
+    default:
+        break;
     }
 
     return 0;
 }
 
-static void* create_indirect_struct(struct op_context* ctx,
-                                    unsigned long outter_key,
-                                    const ProtobufCFieldDescriptor* field,
-                                    int* err) {
+static void *create_indirect_struct(
+    struct op_context *ctx, unsigned long outter_key, const ProtobufCFieldDescriptor *field, int *err)
+{
     int inner_fd, key = 0;
-    void* value;
+    void *value;
     struct op_context new_ctx;
-    const ProtobufCMessageDescriptor* desc;
+    const ProtobufCMessageDescriptor *desc;
 
     inner_fd = outter_key_to_inner_fd(ctx, outter_key);
     if (inner_fd < 0) {
@@ -705,49 +701,49 @@ static void* create_indirect_struct(struct op_context* ctx,
     }
 
     switch (field->type) {
-        case PROTOBUF_C_TYPE_MESSAGE:
-            memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
-            new_ctx.curr_fd = inner_fd;
-            new_ctx.key = (void*)&key;
-            new_ctx.curr_info = ctx->inner_info;
+    case PROTOBUF_C_TYPE_MESSAGE:
+        memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
+        new_ctx.curr_fd = inner_fd;
+        new_ctx.key = (void *)&key;
+        new_ctx.curr_info = ctx->inner_info;
 
-            desc = (ProtobufCMessageDescriptor*)field->descriptor;
-            if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
-                *err = -EINVAL;
-                return NULL;
-            }
+        desc = (ProtobufCMessageDescriptor *)field->descriptor;
+        if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
+            *err = -EINVAL;
+            return NULL;
+        }
 
-            new_ctx.desc = desc;
-            value = create_struct(&new_ctx, err);
+        new_ctx.desc = desc;
+        value = create_struct(&new_ctx, err);
+        return value;
+    default:
+        value = malloc(ctx->inner_info->value_size);
+        if (!value) {
+            *err = -ENOMEM;
+            return NULL;
+        }
+
+        *err = bpf_map_lookup_elem(inner_fd, &key, value);
+        if (*err < 0) {
             return value;
-        default:
-            value = malloc(ctx->inner_info->value_size);
-            if (!value) {
-                *err = -ENOMEM;
-                return NULL;
-            }
+        }
 
-            *err = bpf_map_lookup_elem(inner_fd, &key, value);
-            if (*err < 0) {
-                return value;
-            }
-
-            break;
+        break;
     }
 
     *err = 0;
     return value;
 }
 
-static int repeat_field_query(struct op_context* ctx,
-                              const ProtobufCFieldDescriptor* field) {
+static int repeat_field_query(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
+{
     int ret;
     int key = 0;
     int inner_fd;
-    void* array;
+    void *array;
     unsigned int i;
-    void* n = ((char*)ctx->value) + field->quantifier_offset;
-    uintptr_t* outter_key = (uintptr_t*)((char*)ctx->value + field->offset);
+    void *n = ((char *)ctx->value) + field->quantifier_offset;
+    uintptr_t *outter_key = (uintptr_t *)((char *)ctx->value + field->offset);
 
     inner_fd = outter_key_to_inner_fd(ctx, *outter_key);
     if (inner_fd < 0)
@@ -765,37 +761,38 @@ static int repeat_field_query(struct op_context* ctx,
     }
 
     switch (field->type) {
-        case PROTOBUF_C_TYPE_MESSAGE:
-        case PROTOBUF_C_TYPE_STRING:
-            for (i = 0; i < *(unsigned int*)n; i++) {
-                outter_key = (uintptr_t*)array + i;
-                *outter_key = (uintptr_t)create_indirect_struct(
-                    ctx, *outter_key, field, &ret);
-                if (ret)
-                    break;
-            }
-            break;
-        default:
-            break;
+    case PROTOBUF_C_TYPE_MESSAGE:
+    case PROTOBUF_C_TYPE_STRING:
+        for (i = 0; i < *(unsigned int *)n; i++) {
+            outter_key = (uintptr_t *)array + i;
+            *outter_key = (uintptr_t)create_indirect_struct(ctx, *outter_key, field, &ret);
+            if (ret)
+                break;
+        }
+        break;
+    default:
+        break;
     }
 
     return ret;
 }
 
-void deserial_free_elem_list(struct element_list_node* head) {
+void deserial_free_elem_list(struct element_list_node *head)
+{
     while (head != NULL) {
-        struct element_list_node* n = head;
+        struct element_list_node *n = head;
         deserial_free_elem(n->elem);
         head = n->next;
         free(n);
     }
 }
 
-static void* create_struct_list(struct op_context* ctx, int* err) {
-    void* prev_key = NULL;
-    void* value;
-    struct element_list_node* elem_list_head = NULL;
-    struct element_list_node* curr_elem_list_node = NULL;
+static void *create_struct_list(struct op_context *ctx, int *err)
+{
+    void *prev_key = NULL;
+    void *value;
+    struct element_list_node *elem_list_head = NULL;
+    struct element_list_node *curr_elem_list_node = NULL;
 
     *err = 0;
     ctx->key = calloc(1, ctx->curr_info->key_size);
@@ -813,8 +810,7 @@ static void* create_struct_list(struct op_context* ctx, int* err) {
             continue;
         }
 
-        struct element_list_node* new_node = (struct element_list_node*)calloc(
-            1, sizeof(struct element_list_node));
+        struct element_list_node *new_node = (struct element_list_node *)calloc(1, sizeof(struct element_list_node));
         if (!new_node) {
             deserial_free_elem_list(elem_list_head);
             return NULL;
@@ -831,11 +827,12 @@ static void* create_struct_list(struct op_context* ctx, int* err) {
     return elem_list_head;
 }
 
-static void* create_struct(struct op_context* ctx, int* err) {
-    void* value;
+static void *create_struct(struct op_context *ctx, int *err)
+{
+    void *value;
     int ret;
     unsigned int i;
-    const ProtobufCMessageDescriptor* desc = ctx->desc;
+    const ProtobufCMessageDescriptor *desc = ctx->desc;
 
     *err = 0;
 
@@ -856,19 +853,18 @@ static void* create_struct(struct op_context* ctx, int* err) {
 
     ctx->value = value;
     for (i = 0; i < desc->n_fields; i++) {
-        const ProtobufCFieldDescriptor* field = desc->fields + i;
+        const ProtobufCFieldDescriptor *field = desc->fields + i;
 
-        if (!selected_oneof_field(ctx->value, field) ||
-            !valid_field_value(ctx->value, field))
+        if (!selected_oneof_field(ctx->value, field) || !valid_field_value(ctx->value, field))
             continue;
 
         switch (field->label) {
-            case PROTOBUF_C_LABEL_REPEATED:
-                ret = repeat_field_query(ctx, field);
-                break;
-            default:
-                ret = field_query(ctx, field);
-                break;
+        case PROTOBUF_C_LABEL_REPEATED:
+            ret = repeat_field_query(ctx, field);
+            break;
+        default:
+            ret = field_query(ctx, field);
+            break;
         }
 
         if (ret) {
@@ -881,12 +877,13 @@ static void* create_struct(struct op_context* ctx, int* err) {
     return value;
 }
 
-struct element_list_node* deserial_lookup_all_elems(const void* msg_desciptor) {
+struct element_list_node *deserial_lookup_all_elems(const void *msg_desciptor)
+{
     int ret, err;
-    struct element_list_node* value_list_head = NULL;
-    const char* map_name = NULL;
+    struct element_list_node *value_list_head = NULL;
+    const char *map_name = NULL;
     struct op_context context = {.inner_map_object = NULL};
-    const ProtobufCMessageDescriptor* desc;
+    const ProtobufCMessageDescriptor *desc;
     struct bpf_map_info outter_info = {0}, inner_info = {0}, info = {0};
     int map_fd, outter_fd = 0, inner_fd = 0;
     unsigned int id, outter_id = 0, inner_id = 0;
@@ -894,7 +891,7 @@ struct element_list_node* deserial_lookup_all_elems(const void* msg_desciptor) {
     if (msg_desciptor == NULL)
         return NULL;
 
-    desc = (ProtobufCMessageDescriptor*)msg_desciptor;
+    desc = (ProtobufCMessageDescriptor *)msg_desciptor;
     if (desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC)
         return NULL;
 
@@ -914,8 +911,7 @@ struct element_list_node* deserial_lookup_all_elems(const void* msg_desciptor) {
     if (ret < 0 || map_info_check(&outter_info, &inner_info))
         goto end;
 
-    init_op_context(context, NULL, NULL, desc, outter_fd, map_fd, &outter_info,
-                    &inner_info, &info);
+    init_op_context(context, NULL, NULL, desc, outter_fd, map_fd, &outter_info, &inner_info, &info);
 
     value_list_head = create_struct_list(&context, &err);
     if (err != 0) {
@@ -936,12 +932,13 @@ end:
     return value_list_head;
 }
 
-void* deserial_lookup_elem(void* key, const void* msg_desciptor) {
+void *deserial_lookup_elem(void *key, const void *msg_desciptor)
+{
     int ret, err;
-    void* value = NULL;
-    const char* map_name = NULL;
+    void *value = NULL;
+    const char *map_name = NULL;
     struct op_context context = {.inner_map_object = NULL};
-    const ProtobufCMessageDescriptor* desc;
+    const ProtobufCMessageDescriptor *desc;
     struct bpf_map_info outter_info = {0}, inner_info = {0}, info = {0};
     int map_fd, outter_fd = 0, inner_fd = 0;
     unsigned int id, outter_id = 0, inner_id = 0;
@@ -949,7 +946,7 @@ void* deserial_lookup_elem(void* key, const void* msg_desciptor) {
     if (msg_desciptor == NULL || key == NULL)
         return NULL;
 
-    desc = (ProtobufCMessageDescriptor*)msg_desciptor;
+    desc = (ProtobufCMessageDescriptor *)msg_desciptor;
     if (desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC)
         return NULL;
 
@@ -969,8 +966,7 @@ void* deserial_lookup_elem(void* key, const void* msg_desciptor) {
     if (ret < 0 || map_info_check(&outter_info, &inner_info))
         goto end;
 
-    init_op_context(context, key, NULL, desc, outter_fd, map_fd, &outter_info,
-                    &inner_info, &info);
+    init_op_context(context, key, NULL, desc, outter_fd, map_fd, &outter_info, &inner_info, &info);
 
     normalize_key(&context, key, map_name);
     value = create_struct(&context, &err);
@@ -991,13 +987,12 @@ end:
     return value;
 }
 
-static int indirect_field_del(struct op_context* ctx,
-                              unsigned int outter_key,
-                              const ProtobufCFieldDescriptor* field) {
-    char* inner_map_object = NULL;
+static int indirect_field_del(struct op_context *ctx, unsigned int outter_key, const ProtobufCFieldDescriptor *field)
+{
+    char *inner_map_object = NULL;
     int inner_fd, key = 0;
     struct op_context new_ctx;
-    const ProtobufCMessageDescriptor* desc;
+    const ProtobufCMessageDescriptor *desc;
 
     if (!valid_outter_key(ctx, outter_key))
         return -EINVAL;
@@ -1009,43 +1004,43 @@ static int indirect_field_del(struct op_context* ctx,
     free_outter_map_entry(ctx, &outter_key);
 
     switch (field->type) {
-        case PROTOBUF_C_TYPE_MESSAGE:
-            desc = (ProtobufCMessageDescriptor*)field->descriptor;
-            if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
-                return -EINVAL;
-            }
+    case PROTOBUF_C_TYPE_MESSAGE:
+        desc = (ProtobufCMessageDescriptor *)field->descriptor;
+        if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
+            return -EINVAL;
+        }
 
-            inner_map_object = malloc(ctx->inner_info->value_size);
-            if (!inner_map_object) {
-                return -ENOMEM;
-            }
+        inner_map_object = malloc(ctx->inner_info->value_size);
+        if (!inner_map_object) {
+            return -ENOMEM;
+        }
 
-            memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
-            new_ctx.curr_fd = inner_fd;
-            new_ctx.key = (void*)&key;
-            new_ctx.curr_info = ctx->inner_info;
-            new_ctx.value = inner_map_object;
-            new_ctx.desc = desc;
+        memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
+        new_ctx.curr_fd = inner_fd;
+        new_ctx.key = (void *)&key;
+        new_ctx.curr_info = ctx->inner_info;
+        new_ctx.value = inner_map_object;
+        new_ctx.desc = desc;
 
-            (void)del_bpf_map(&new_ctx, 1);
-            free(inner_map_object);
-            break;
+        (void)del_bpf_map(&new_ctx, 1);
+        free(inner_map_object);
+        break;
 
-        default:
-            break;
+    default:
+        break;
     }
 
     return 0;
 }
 
-static int repeat_field_del(struct op_context* ctx,
-                            const ProtobufCFieldDescriptor* field) {
+static int repeat_field_del(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
+{
     int ret;
     unsigned int i;
     int inner_fd, key = 0;
-    void* inner_map_object = NULL;
-    void* n;
-    uintptr_t* outter_key;
+    void *inner_map_object = NULL;
+    void *n;
+    uintptr_t *outter_key;
 
     ret = bpf_map_lookup_elem(ctx->curr_fd, ctx->key, ctx->value);
     if (ret < 0) {
@@ -1053,7 +1048,7 @@ static int repeat_field_del(struct op_context* ctx,
         return ret;
     }
 
-    outter_key = (uintptr_t*)((char*)ctx->value + field->offset);
+    outter_key = (uintptr_t *)((char *)ctx->value + field->offset);
     if (!valid_outter_key(ctx, *outter_key))
         return -EINVAL;
 
@@ -1065,28 +1060,28 @@ static int repeat_field_del(struct op_context* ctx,
     if (ret)
         return ret;
 
-    n = ((char*)ctx->value) + field->quantifier_offset;
+    n = ((char *)ctx->value) + field->quantifier_offset;
 
     switch (field->type) {
-        case PROTOBUF_C_TYPE_MESSAGE:
-            // lint -fallthrough
-        case PROTOBUF_C_TYPE_STRING:
-            inner_map_object = calloc(1, ctx->inner_info->value_size);
-            if (!inner_map_object) {
-                ret = -ENOMEM;
-                goto end;
-            }
+    case PROTOBUF_C_TYPE_MESSAGE:
+        // lint -fallthrough
+    case PROTOBUF_C_TYPE_STRING:
+        inner_map_object = calloc(1, ctx->inner_info->value_size);
+        if (!inner_map_object) {
+            ret = -ENOMEM;
+            goto end;
+        }
 
-            ret = bpf_map_lookup_elem(inner_fd, &key, inner_map_object);
-            if (ret < 0)
-                goto end;
+        ret = bpf_map_lookup_elem(inner_fd, &key, inner_map_object);
+        if (ret < 0)
+            goto end;
 
-            for (i = 0; i < *(size_t*)n; i++) {
-                outter_key = (uintptr_t*)inner_map_object + i;
-                indirect_field_del(ctx, *outter_key, field);
-            }
-        default:
-            break;
+        for (i = 0; i < *(size_t *)n; i++) {
+            outter_key = (uintptr_t *)inner_map_object + i;
+            indirect_field_del(ctx, *outter_key, field);
+        }
+    default:
+        break;
     }
 
 end:
@@ -1095,16 +1090,15 @@ end:
     return ret;
 }
 
-static int msg_field_del(struct op_context* ctx,
-                         int inner_fd,
-                         const ProtobufCFieldDescriptor* field) {
+static int msg_field_del(struct op_context *ctx, int inner_fd, const ProtobufCFieldDescriptor *field)
+{
     int key = 0;
     int ret;
-    char* inner_map_object = NULL;
+    char *inner_map_object = NULL;
     struct op_context new_ctx;
-    const ProtobufCMessageDescriptor* desc;
+    const ProtobufCMessageDescriptor *desc;
 
-    desc = (ProtobufCMessageDescriptor*)field->descriptor;
+    desc = (ProtobufCMessageDescriptor *)field->descriptor;
     if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC)
         return -EINVAL;
 
@@ -1114,7 +1108,7 @@ static int msg_field_del(struct op_context* ctx,
 
     memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
     new_ctx.curr_fd = inner_fd;
-    new_ctx.key = (void*)&key;
+    new_ctx.key = (void *)&key;
     new_ctx.curr_info = ctx->inner_info;
     new_ctx.value = inner_map_object;
     new_ctx.desc = desc;
@@ -1124,69 +1118,69 @@ static int msg_field_del(struct op_context* ctx,
     return ret;
 }
 
-static int field_del(struct op_context* ctx,
-                     const ProtobufCFieldDescriptor* field) {
+static int field_del(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
+{
     int ret;
     int inner_fd;
-    uintptr_t* outter_key;
+    uintptr_t *outter_key;
 
     switch (field->type) {
-        case PROTOBUF_C_TYPE_MESSAGE:
-        case PROTOBUF_C_TYPE_STRING:
-            ret = bpf_map_lookup_elem(ctx->curr_fd, ctx->key, ctx->value);
-            if (ret < 0)
-                return ret;
+    case PROTOBUF_C_TYPE_MESSAGE:
+    case PROTOBUF_C_TYPE_STRING:
+        ret = bpf_map_lookup_elem(ctx->curr_fd, ctx->key, ctx->value);
+        if (ret < 0)
+            return ret;
 
-            outter_key = (uintptr_t*)((char*)ctx->value + field->offset);
-            if (!valid_outter_key(ctx, *outter_key))
-                return -EINVAL;
+        outter_key = (uintptr_t *)((char *)ctx->value + field->offset);
+        if (!valid_outter_key(ctx, *outter_key))
+            return -EINVAL;
 
-            inner_fd = outter_key_to_inner_fd(ctx, *outter_key);
-            if (inner_fd < 0)
-                return inner_fd;
+        inner_fd = outter_key_to_inner_fd(ctx, *outter_key);
+        if (inner_fd < 0)
+            return inner_fd;
 
-            free_outter_map_entry(ctx, outter_key);
+        free_outter_map_entry(ctx, outter_key);
 
-            if (field->type == PROTOBUF_C_TYPE_STRING) {
-                break;
-            }
-
-            msg_field_del(ctx, inner_fd, field);
+        if (field->type == PROTOBUF_C_TYPE_STRING) {
             break;
-        default:
-            break;
+        }
+
+        msg_field_del(ctx, inner_fd, field);
+        break;
+    default:
+        break;
     }
 
     return 0;
 }
 
-static int del_bpf_map(struct op_context* ctx, int is_inner) {
+static int del_bpf_map(struct op_context *ctx, int is_inner)
+{
     int ret;
     unsigned int i;
-    const ProtobufCMessageDescriptor* desc = ctx->desc;
+    const ProtobufCMessageDescriptor *desc = ctx->desc;
 
     ret = bpf_map_lookup_elem(ctx->curr_fd, ctx->key, ctx->value);
     if (ret < 0)
         return ret;
 
     for (i = 0; i < desc->n_fields; i++) {
-        const ProtobufCFieldDescriptor* field = desc->fields + i;
+        const ProtobufCFieldDescriptor *field = desc->fields + i;
 
-        if (!selected_oneof_field(ctx->value, field) ||
-            !valid_field_value(ctx->value, field))
+        if (!selected_oneof_field(ctx->value, field) || !valid_field_value(ctx->value, field))
             continue;
 
         switch (field->label) {
-            case PROTOBUF_C_LABEL_REPEATED:
-                ret = repeat_field_del(ctx, field);
-                if (ret)
-                    goto end;
-                break;
-            default:
-                ret = field_del(ctx, field);
-                if (ret)
-                    goto end;
-                break;
+        case PROTOBUF_C_LABEL_REPEATED:
+            ret = repeat_field_del(ctx, field);
+            if (ret)
+                goto end;
+            break;
+        default:
+            ret = field_del(ctx, field);
+            if (ret)
+                goto end;
+            break;
         }
     }
 
@@ -1194,20 +1188,21 @@ end:
     return (is_inner == 1) ?: bpf_map_delete_elem(ctx->curr_fd, ctx->key);
 }
 
-int deserial_delete_elem(void* key, const void* msg_desciptor) {
+int deserial_delete_elem(void *key, const void *msg_desciptor)
+{
     int ret;
-    const char* map_name = NULL;
+    const char *map_name = NULL;
     struct op_context context = {.inner_map_object = NULL};
-    const ProtobufCMessageDescriptor* desc;
+    const ProtobufCMessageDescriptor *desc;
     struct bpf_map_info outter_info = {0}, inner_info = {0}, info = {0};
     int map_fd, outter_fd = 0, inner_fd = 0;
     unsigned int id, outter_id = 0, inner_id = 0;
-    char* inner_map_object = NULL;
+    char *inner_map_object = NULL;
 
     if (!key || !msg_desciptor)
         return -EINVAL;
 
-    desc = (ProtobufCMessageDescriptor*)msg_desciptor;
+    desc = (ProtobufCMessageDescriptor *)msg_desciptor;
     if (desc->magic == PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC)
         map_name = desc->short_name;
 
@@ -1231,8 +1226,7 @@ int deserial_delete_elem(void* key, const void* msg_desciptor) {
     if (ret < 0 || map_info_check(&outter_info, &inner_info))
         goto end;
 
-    init_op_context(context, key, NULL, desc, outter_fd, map_fd, &outter_info,
-                    &inner_info, &info);
+    init_op_context(context, key, NULL, desc, outter_fd, map_fd, &outter_info, &inner_info, &info);
 
     context.inner_map_object = calloc(1, context.inner_info->value_size);
     context.value = calloc(1, context.curr_info->value_size);
@@ -1262,56 +1256,58 @@ end:
     return ret;
 }
 
-static void repeat_field_free(void* value,
-                              const ProtobufCFieldDescriptor* field) {
+static void repeat_field_free(void *value, const ProtobufCFieldDescriptor *field)
+{
     unsigned int i;
-    void* n = ((char*)value) + field->quantifier_offset;
-    uintptr_t* ptr_array = *(uintptr_t**)((char*)value + field->offset);
+    void *n = ((char *)value) + field->quantifier_offset;
+    uintptr_t *ptr_array = *(uintptr_t **)((char *)value + field->offset);
 
     switch (field->type) {
-        case PROTOBUF_C_TYPE_MESSAGE:
-        case PROTOBUF_C_TYPE_STRING:
-            for (i = 0; i < *(unsigned int*)n; i++) {
-                if (field->type == PROTOBUF_C_TYPE_STRING)
-                    free_elem((void*)ptr_array[i]);
-                else
-                    deserial_free_elem((void*)ptr_array[i]);
-            }
-            break;
-        default:
-            free_elem((void*)ptr_array);
-            break;
+    case PROTOBUF_C_TYPE_MESSAGE:
+    case PROTOBUF_C_TYPE_STRING:
+        for (i = 0; i < *(unsigned int *)n; i++) {
+            if (field->type == PROTOBUF_C_TYPE_STRING)
+                free_elem((void *)ptr_array[i]);
+            else
+                deserial_free_elem((void *)ptr_array[i]);
+        }
+        break;
+    default:
+        free_elem((void *)ptr_array);
+        break;
     }
 
     return;
 }
 
-static void field_free(void* value, const ProtobufCFieldDescriptor* field) {
-    uintptr_t* tobe_free = (uintptr_t*)((char*)value + field->offset);
+static void field_free(void *value, const ProtobufCFieldDescriptor *field)
+{
+    uintptr_t *tobe_free = (uintptr_t *)((char *)value + field->offset);
 
     switch (field->type) {
-        case PROTOBUF_C_TYPE_MESSAGE:
-            deserial_free_elem((void*)(*tobe_free));
-            break;
-        case PROTOBUF_C_TYPE_STRING:
-            free_elem((void*)*tobe_free);
-            break;
-        default:
-            break;
+    case PROTOBUF_C_TYPE_MESSAGE:
+        deserial_free_elem((void *)(*tobe_free));
+        break;
+    case PROTOBUF_C_TYPE_STRING:
+        free_elem((void *)*tobe_free);
+        break;
+    default:
+        break;
     }
 
     return;
 }
 
-void deserial_free_elem(void* value) {
+void deserial_free_elem(void *value)
+{
     unsigned int i;
-    const char* map_name = NULL;
-    const ProtobufCMessageDescriptor* desc;
+    const char *map_name = NULL;
+    const ProtobufCMessageDescriptor *desc;
 
     if (!value || (uintptr_t)value < MAX_OUTTER_MAP_ENTRIES)
         return;
 
-    desc = ((ProtobufCMessage*)value)->descriptor;
+    desc = ((ProtobufCMessage *)value)->descriptor;
     if (desc && desc->magic == PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC)
         map_name = desc->short_name;
 
@@ -1322,19 +1318,18 @@ void deserial_free_elem(void* value) {
     }
 
     for (i = 0; i < desc->n_fields; i++) {
-        const ProtobufCFieldDescriptor* field = desc->fields + i;
+        const ProtobufCFieldDescriptor *field = desc->fields + i;
 
-        if (!selected_oneof_field(value, field) ||
-            !valid_field_value(value, field))
+        if (!selected_oneof_field(value, field) || !valid_field_value(value, field))
             continue;
 
         switch (field->label) {
-            case PROTOBUF_C_LABEL_REPEATED:
-                repeat_field_free(value, field);
-                break;
-            default:
-                field_free(value, field);
-                break;
+        case PROTOBUF_C_LABEL_REPEATED:
+            repeat_field_free(value, field);
+            break;
+        default:
+            field_free(value, field);
+            break;
         }
     }
 
@@ -1342,10 +1337,9 @@ void deserial_free_elem(void* value) {
     return;
 }
 
-int get_outer_inner_map_infos(int* inner_fd,
-                              struct bpf_map_info* inner_info,
-                              int* outter_fd,
-                              struct bpf_map_info* outter_info) {
+int get_outer_inner_map_infos(
+    int *inner_fd, struct bpf_map_info *inner_info, int *outter_fd, struct bpf_map_info *outter_info)
+{
     int ret;
     unsigned int outter_id, inner_id;
 
@@ -1361,23 +1355,22 @@ int get_outer_inner_map_infos(int* inner_fd,
     return 0;
 }
 
-void* outter_map_update_task(void* arg) {
+void *outter_map_update_task(void *arg)
+{
     int i, end, ret = 0;
     pthread_t tid = pthread_self();
-    struct task_contex* ctx = (struct task_contex*)arg;
+    struct task_contex *ctx = (struct task_contex *)arg;
     if (!ctx)
         return NULL;
 
-    i = ctx->task_id * TASK_SIZE;
-    end = ((i + TASK_SIZE) < MAX_OUTTER_MAP_ENTRIES) ? (i + TASK_SIZE)
-                                                     : MAX_OUTTER_MAP_ENTRIES;
+    i = (ctx->task_id * TASK_SIZE) ? (ctx->task_id * TASK_SIZE) : 1;
+    end = ((i + TASK_SIZE) < MAX_OUTTER_MAP_ENTRIES) ? (i + TASK_SIZE) : MAX_OUTTER_MAP_ENTRIES;
     for (; i < end; i++) {
         if (!g_inner_map_mng.inner_maps[i].map_fd) {
             continue;
         }
 
-        ret = bpf_map_update_elem(
-            ctx->outter_fd, &i, &g_inner_map_mng.inner_maps[i].map_fd, BPF_ANY);
+        ret = bpf_map_update_elem(ctx->outter_fd, &i, &g_inner_map_mng.inner_maps[i].map_fd, BPF_ANY);
         if (ret)
             break;
         g_inner_map_mng.inner_maps[i].in_outer_map = 1;
@@ -1390,17 +1383,19 @@ void* outter_map_update_task(void* arg) {
     return NULL;
 }
 
-void wait_sem_value(sem_t* sem, int wait_value) {
+void wait_sem_value(sem_t *sem, int wait_value)
+{
     int sem_val;
     do {
         sem_getvalue(sem, &sem_val);
     } while (sem_val < wait_value);
 }
 
-int outter_map_update(int outter_fd) {
+int outter_map_update(int outter_fd)
+{
     int i, ret = 0;
     pthread_t tid;
-    struct task_contex* task_ctx = NULL;
+    struct task_contex *task_ctx = NULL;
     int threads = MAX_OUTTER_MAP_ENTRIES / TASK_SIZE + 1;
 
     ret = sem_init(&g_inner_map_mng.fin_tasks, 0, 0);
@@ -1410,7 +1405,7 @@ int outter_map_update(int outter_fd) {
     }
 
     for (i = 0; i < threads; i++) {
-        task_ctx = (struct task_contex*)malloc(sizeof(struct task_contex));
+        task_ctx = (struct task_contex *)malloc(sizeof(struct task_contex));
         if (!task_ctx)
             break;
 
@@ -1426,22 +1421,28 @@ int outter_map_update(int outter_fd) {
     return ret;
 }
 
-int inner_map_create(struct bpf_map_info* inner_info) {
+int inner_map_create(struct bpf_map_info *inner_info)
+{
     int fd;
 #if LIBBPF_HIGHER_0_6_0_VERSION
     LIBBPF_OPTS(bpf_map_create_opts, opts, .map_flags = inner_info->map_flags);
 
-    fd = bpf_map_create(inner_info->type, NULL, inner_info->key_size,
-                        inner_info->value_size, inner_info->max_entries, &opts);
+    fd = bpf_map_create(
+        inner_info->type, NULL, inner_info->key_size, inner_info->value_size, inner_info->max_entries, &opts);
 #else
-    fd = bpf_create_map_name(inner_info->type, NULL, inner_info->key_size,
-                             inner_info->value_size, inner_info->max_entries,
-                             inner_info->map_flags);
+    fd = bpf_create_map_name(
+        inner_info->type,
+        NULL,
+        inner_info->key_size,
+        inner_info->value_size,
+        inner_info->max_entries,
+        inner_info->map_flags);
 #endif
     return fd;
 }
 
-int inner_map_create_all(struct bpf_map_info* inner_info) {
+int inner_map_create_all(struct bpf_map_info *inner_info)
+{
     int i, fd;
 
     for (i = 1; i < MAX_OUTTER_MAP_ENTRIES; i++) {
@@ -1453,13 +1454,13 @@ int inner_map_create_all(struct bpf_map_info* inner_info) {
     }
 
     if (i < MAX_OUTTER_MAP_ENTRIES)
-        LOG_WARN("[warning]inner_map_create (%d->%d) failed:%d, errno:%d\n", i,
-                 MAX_OUTTER_MAP_ENTRIES, fd, errno);
+        LOG_WARN("[warning]inner_map_create (%d->%d) failed:%d, errno:%d\n", i, MAX_OUTTER_MAP_ENTRIES, fd, errno);
     return 0;
 }
 
-void deserial_uninit() {
-    for (int i = 0; i < MAX_OUTTER_MAP_ENTRIES; i++) {
+void deserial_uninit()
+{
+    for (int i = 1; i < MAX_OUTTER_MAP_ENTRIES; i++) {
         g_inner_map_mng.inner_maps[i].in_outer_map = 0;
         g_inner_map_mng.inner_maps[i].used = 0;
         if (g_inner_map_mng.inner_maps[i].map_fd)
@@ -1472,14 +1473,14 @@ void deserial_uninit() {
     return;
 }
 
-int deserial_init() {
+int deserial_init()
+{
     int ret = 0;
     int inner_fd = -1, outter_fd = -1;
     struct bpf_map_info outter_info = {0}, inner_info = {0};
 
     do {
-        ret = get_outer_inner_map_infos(&inner_fd, &inner_info, &outter_fd,
-                                        &outter_info);
+        ret = get_outer_inner_map_infos(&inner_fd, &inner_info, &outter_fd, &outter_info);
         if (ret)
             break;
 

--- a/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.h
+++ b/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.h
@@ -7,10 +7,17 @@
 /* equal MAP_SIZE_OF_OUTTER_MAP */
 #define MAX_OUTTER_MAP_ENTRIES (8192)
 
-int deserial_update_elem(void *key, void *value);
-void *deserial_lookup_elem(void *key, const void *msg_desciptor);
-void deserial_free_elem(void *value);
-int deserial_delete_elem(void *key, const void *msg_desciptor);
+struct element_list_node {
+    void* elem;
+    struct element_list_node* next;
+};
+
+int deserial_update_elem(void* key, void* value);
+void* deserial_lookup_elem(void* key, const void* msg_desciptor);
+struct element_list_node* deserial_lookup_all_elems(const void* msg_desciptor);
+void deserial_free_elem(void* value);
+void deserial_free_elem_list(struct element_list_node* head);
+int deserial_delete_elem(void* key, const void* msg_desciptor);
 
 int deserial_init();
 void deserial_uninit();

--- a/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.h
+++ b/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.h
@@ -8,16 +8,16 @@
 #define MAX_OUTTER_MAP_ENTRIES (8192)
 
 struct element_list_node {
-    void* elem;
-    struct element_list_node* next;
+    void *elem;
+    struct element_list_node *next;
 };
 
-int deserial_update_elem(void* key, void* value);
-void* deserial_lookup_elem(void* key, const void* msg_desciptor);
-struct element_list_node* deserial_lookup_all_elems(const void* msg_desciptor);
-void deserial_free_elem(void* value);
-void deserial_free_elem_list(struct element_list_node* head);
-int deserial_delete_elem(void* key, const void* msg_desciptor);
+int deserial_update_elem(void *key, void *value);
+void *deserial_lookup_elem(void *key, const void *msg_desciptor);
+struct element_list_node *deserial_lookup_all_elems(const void *msg_desciptor);
+void deserial_free_elem(void *value);
+void deserial_free_elem_list(struct element_list_node *head);
+int deserial_delete_elem(void *key, const void *msg_desciptor);
 
 int deserial_init();
 void deserial_uninit();

--- a/pkg/bpf/bpf_kmesh.go
+++ b/pkg/bpf/bpf_kmesh.go
@@ -441,3 +441,7 @@ func (sc *BpfKmesh) Detach() error {
 	}
 	return nil
 }
+
+func AdsL7Enabled() bool {
+	return true
+}

--- a/pkg/bpf/bpf_kmesh_l4.go
+++ b/pkg/bpf/bpf_kmesh_l4.go
@@ -111,3 +111,7 @@ func (sc *BpfKmesh) Detach() error {
 	}
 	return nil
 }
+
+func AdsL7Enabled() bool {
+	return false
+}

--- a/pkg/cache/v2/cluster.go
+++ b/pkg/cache/v2/cluster.go
@@ -165,20 +165,10 @@ func (cache *ClusterCache) Delete() {
 }
 
 func (cache *ClusterCache) DumpBpf() []*cluster_v2.Cluster {
-	cache.mutex.RLock()
-	defer cache.mutex.RUnlock()
-	clusters := make([]*cluster_v2.Cluster, 0, len(cache.apiClusterCache))
-	for name, c := range cache.apiClusterCache {
-		tmp := &cluster_v2.Cluster{}
-		if err := maps_v2.ClusterLookup(name, tmp); err != nil {
-			log.Errorf("ClusterLookup failed, %s", name)
-			continue
-		}
-
-		tmp.ApiStatus = c.ApiStatus
-		clusters = append(clusters, tmp)
+	clusters, err := maps_v2.ClusterLookupAll()
+	if err != nil {
+		log.Errorf("ClusterLookup failed, %v", err)
 	}
-
 	return clusters
 }
 

--- a/pkg/cache/v2/cluster.go
+++ b/pkg/cache/v2/cluster.go
@@ -164,14 +164,6 @@ func (cache *ClusterCache) Delete() {
 	}
 }
 
-func (cache *ClusterCache) DumpBpf() []*cluster_v2.Cluster {
-	clusters, err := maps_v2.ClusterLookupAll()
-	if err != nil {
-		log.Errorf("ClusterLookup failed, %v", err)
-	}
-	return clusters
-}
-
 func (cache *ClusterCache) Dump() []*cluster_v2.Cluster {
 	cache.mutex.RLock()
 	defer cache.mutex.RUnlock()

--- a/pkg/cache/v2/listener.go
+++ b/pkg/cache/v2/listener.go
@@ -127,14 +127,6 @@ func (cache *ListenerCache) Flush() {
 	}
 }
 
-func (cache *ListenerCache) DumpBpf() []*listener_v2.Listener {
-	listeners, err := maps_v2.ListenerLookupAll()
-	if err != nil {
-		log.Errorf("ListenerLookupAll failed, %v", err)
-	}
-	return listeners
-}
-
 func (cache *ListenerCache) Dump() []*listener_v2.Listener {
 	cache.mutex.RLock()
 	defer cache.mutex.RUnlock()

--- a/pkg/cache/v2/listener.go
+++ b/pkg/cache/v2/listener.go
@@ -128,20 +128,10 @@ func (cache *ListenerCache) Flush() {
 }
 
 func (cache *ListenerCache) DumpBpf() []*listener_v2.Listener {
-	cache.mutex.RLock()
-	defer cache.mutex.RUnlock()
-	listeners := make([]*listener_v2.Listener, 0, len(cache.apiListenerCache))
-	for name, listener := range cache.apiListenerCache {
-		tmp := &listener_v2.Listener{}
-		if err := maps_v2.ListenerLookup(listener.GetAddress(), tmp); err != nil {
-			log.Errorf("ListenerLookup failed, %s", name)
-			continue
-		}
-
-		tmp.ApiStatus = listener.ApiStatus
-		listeners = append(listeners, tmp)
+	listeners, err := maps_v2.ListenerLookupAll()
+	if err != nil {
+		log.Errorf("ListenerLookupAll failed, %v", err)
 	}
-
 	return listeners
 }
 

--- a/pkg/cache/v2/maps/cluster.go
+++ b/pkg/cache/v2/maps/cluster.go
@@ -24,6 +24,7 @@ package maps
 // #include "cluster/cluster.pb-c.h"
 import "C"
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 
@@ -77,19 +78,17 @@ func ClusterLookup(key string, value *cluster_v2.Cluster) error {
 }
 
 func ClusterLookupAll() ([]*cluster_v2.Cluster, error) {
-	var (
-		err      error
-		clusters []*cluster_v2.Cluster
-	)
+	var err error
 
 	cMsg := C.deserial_lookup_all_elems(unsafe.Pointer(&C.cluster__cluster__descriptor))
 	if cMsg == nil {
-		return nil, fmt.Errorf("ClusterLookupAll deserial_lookup_all_elems failed")
+		return nil, errors.New("ClusterLookupAll deserial_lookup_all_elems failed")
 	}
 
 	elem_list_head := (*C.struct_element_list_node)(cMsg)
 	defer C.deserial_free_elem_list(elem_list_head)
 
+	var clusters []*cluster_v2.Cluster
 	for elem_list_head != nil {
 		cValue := elem_list_head.elem
 		elem_list_head = elem_list_head.next

--- a/pkg/cache/v2/maps/cluster.go
+++ b/pkg/cache/v2/maps/cluster.go
@@ -78,8 +78,6 @@ func ClusterLookup(key string, value *cluster_v2.Cluster) error {
 }
 
 func ClusterLookupAll() ([]*cluster_v2.Cluster, error) {
-	var err error
-
 	cMsg := C.deserial_lookup_all_elems(unsafe.Pointer(&C.cluster__cluster__descriptor))
 	if cMsg == nil {
 		return nil, errors.New("ClusterLookupAll deserial_lookup_all_elems failed")
@@ -88,7 +86,10 @@ func ClusterLookupAll() ([]*cluster_v2.Cluster, error) {
 	elem_list_head := (*C.struct_element_list_node)(cMsg)
 	defer C.deserial_free_elem_list(elem_list_head)
 
-	var clusters []*cluster_v2.Cluster
+	var (
+		clusters []*cluster_v2.Cluster
+		err      error
+	)
 	for elem_list_head != nil {
 		cValue := elem_list_head.elem
 		elem_list_head = elem_list_head.next

--- a/pkg/cache/v2/maps/listener.go
+++ b/pkg/cache/v2/maps/listener.go
@@ -24,6 +24,7 @@ package maps
 // #include "listener/listener.pb-c.h"
 import "C"
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 
@@ -63,6 +64,34 @@ func listenerToClang(goMsg *listener_v2.Listener) (*C.Listener__Listener, error)
 
 func listenerFreeClang(cMsg *C.Listener__Listener) {
 	C.listener__listener__free_unpacked(cMsg, nil)
+}
+
+func ListenerLookupAll() ([]*listener_v2.Listener, error) {
+	cMsg := C.deserial_lookup_all_elems(unsafe.Pointer(&C.listener__listener__descriptor))
+	if cMsg == nil {
+		return nil, errors.New("ListenerLookupAll deserial_lookup_all_elems failed")
+	}
+
+	elem_list_head := (*C.struct_element_list_node)(cMsg)
+	defer C.deserial_free_elem_list(elem_list_head)
+
+	var (
+		listeners []*listener_v2.Listener
+		err       error
+	)
+	for elem_list_head != nil {
+		cValue := elem_list_head.elem
+		elem_list_head = elem_list_head.next
+		listener := listener_v2.Listener{}
+		err = listenerToGolang(&listener, (*C.Listener__Listener)(cValue))
+		log.Debugf("ListenerLookupAll, value [%s]", listener.String())
+		if err != nil {
+			return nil, err
+		}
+		listeners = append(listeners, &listener)
+	}
+
+	return listeners, nil
 }
 
 func ListenerLookup(key *core_v2.SocketAddress, value *listener_v2.Listener) error {

--- a/pkg/cache/v2/maps/route.go
+++ b/pkg/cache/v2/maps/route.go
@@ -24,6 +24,7 @@ package maps
 // #include "route/route.pb-c.h"
 import "C"
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 
@@ -57,6 +58,34 @@ func routeConfigToClang(goMsg *route_v2.RouteConfiguration) (*C.Route__RouteConf
 
 func routeConfigFreeClang(cMsg *C.Route__RouteConfiguration) {
 	C.route__route_configuration__free_unpacked(cMsg, nil)
+}
+
+func RouteConfigLookupAll() ([]*route_v2.RouteConfiguration, error) {
+	cMsg := C.deserial_lookup_all_elems(unsafe.Pointer(&C.route__route_configuration__descriptor))
+	if cMsg == nil {
+		return nil, errors.New("RouteConfigLookupAll deserial_lookup_all_elems failed")
+	}
+
+	elem_list_head := (*C.struct_element_list_node)(cMsg)
+	defer C.deserial_free_elem_list(elem_list_head)
+
+	var (
+		routes []*route_v2.RouteConfiguration
+		err    error
+	)
+	for elem_list_head != nil {
+		cValue := elem_list_head.elem
+		elem_list_head = elem_list_head.next
+		route := route_v2.RouteConfiguration{}
+		err = routeConfigToGolang(&route, (*C.Route__RouteConfiguration)(cValue))
+		log.Debugf("RouteConfigLookupAll, value [%s]", route.String())
+		if err != nil {
+			return nil, err
+		}
+		routes = append(routes, &route)
+	}
+
+	return routes, nil
 }
 
 func RouteConfigLookup(key string, value *route_v2.RouteConfiguration) error {

--- a/pkg/cache/v2/route.go
+++ b/pkg/cache/v2/route.go
@@ -23,7 +23,6 @@ import (
 
 	core_v2 "kmesh.net/kmesh/api/v2/core"
 	route_v2 "kmesh.net/kmesh/api/v2/route"
-	"kmesh.net/kmesh/pkg/bpf"
 	maps_v2 "kmesh.net/kmesh/pkg/cache/v2/maps"
 )
 
@@ -107,19 +106,6 @@ func (cache *RouteConfigCache) Flush() {
 			log.Errorf("routeConfig %s %s flush failed: %v", name, route.ApiStatus, err)
 		}
 	}
-}
-
-func (cache *RouteConfigCache) DumpBpf() []*route_v2.RouteConfiguration {
-	// if L7 not enabled, should just return nil
-	if !bpf.AdsL7Enabled() {
-		return nil
-	}
-
-	routes, err := maps_v2.RouteConfigLookupAll()
-	if err != nil {
-		log.Errorf("RouteConfigLookupAll failed, %v", err)
-	}
-	return routes
 }
 
 func (cache *RouteConfigCache) Dump() []*route_v2.RouteConfiguration {


### PR DESCRIPTION
**What type of PR is this?**
feature
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
support cluster lookup all for dump all the kv of bpf map.
It's for #820 

i've met some problem in developing, seems to be related to the deserialization problem(#702 ) talked about before:
![image](https://github.com/user-attachments/assets/d5dfe263-6c07-4adb-9ba6-ca5733fd33e1)

i update cluster 1 here, but the lookup and the newly written lookupall both got empty cluster name.

the output is:
lookup: cluster: api_status:UPDATE  connect_timeout:1, api_status:UPDATE  name:"ut-cluster-2"  connect_timeout:1

`ut-cluster-2` is shown, but `ut-cluster-1` does not work.

If we only define `Name` field, the test will even panic.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
