### PR TITLE
cgo: using CC=clang and CXX=clang++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ include ./mk/bpf.vars.mk
 include ./mk/bpf.print.mk
 
 # compiler flags
+CC=clang
+CXX=clang++
 GOFLAGS := $(EXTRA_GOFLAGS)
 EXTLDFLAGS := '-fPIE -pie -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack'
 LDFLAGS := "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn \


### PR DESCRIPTION
**What type of PR is this?**
The cgo using gcc to compile *.h files, where the libkmesh_api_v2_c.so using clang which may have conflicts.

```
root@vagrant:/app# docker run -it ghcr.io/kmesh-net/kmesh-build:latest sh
sh-5.2# go env
...
CC='gcc'
CXX='g++'
```
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #702

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
