### PR TITLE
Support passing VERSION to docker when run make docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ uninstall:
 
 .PHONY: build
 build:
-	./kmesh_compile.sh
+	 VERSION=$(VERSION) ./kmesh_compile.sh
 
 .PHONY: docker
 docker: build

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -34,8 +34,8 @@ function get_arch() {
 function build_kmesh() {
     local container_id=$1
     docker exec $container_id git config --global --add safe.directory /kmesh
-    docker exec $container_id sh /kmesh/build.sh
-    docker exec $container_id sh /kmesh/build.sh -i
+    docker exec -e VERSION=$VERSION $container_id sh /kmesh/build.sh
+    docker exec -e VERSION=$VERSION $container_id sh /kmesh/build.sh -i
     docker exec $container_id sh -c "$(declare -f copy_to_host); copy_to_host"
 }
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

/kind enhancement


**What this PR does / why we need it**:


Now run make docker VERSION=x.y.z can be passed to builder container, and  kmesh-daemon version can show x.y.z

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
