### PR TITLE
fix clean bpf_map twice in test

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -183,11 +183,13 @@ func (l *BpfLoader) Stop() {
 	if l.config.AdsEnabled() {
 		C.deserial_uninit()
 		if err = l.obj.Detach(); err != nil {
+			CleanupBpfMap()
 			log.Errorf("failed detach when stop kmesh, err:%s", err)
 			return
 		}
 	} else if l.config.WdsEnabled() {
 		if err = l.workloadObj.Detach(); err != nil {
+			CleanupBpfMap()
 			log.Errorf("failed detach when stop kmesh, err:%s", err)
 			return
 		}
@@ -195,6 +197,7 @@ func (l *BpfLoader) Stop() {
 
 	if l.config.EnableMda {
 		if err = StopMda(); err != nil {
+			CleanupBpfMap()
 			log.Errorf("failed disable mda when stop kmesh, err:%s", err)
 			return
 		}

--- a/pkg/bpf/bpf_restart_test.go
+++ b/pkg/bpf/bpf_restart_test.go
@@ -38,23 +38,19 @@ func TestRestart(t *testing.T) {
 }
 
 func setDir(t *testing.T) options.BpfConfig {
-	CleanupBpfMap()
-	err := os.MkdirAll("/mnt/kmesh_cgroup2", 0755)
-	if err != nil {
+	if err := os.MkdirAll("/mnt/kmesh_cgroup2", 0755); err != nil {
 		t.Fatalf("Failed to create dir /mnt/kmesh_cgroup2: %v", err)
 	}
-	err = syscall.Mount("none", "/mnt/kmesh_cgroup2/", "cgroup2", 0, "")
-	if err != nil {
+	if err := syscall.Mount("none", "/mnt/kmesh_cgroup2/", "cgroup2", 0, ""); err != nil {
 		CleanupBpfMap()
 		t.Fatalf("Failed to mount /mnt/kmesh_cgroup2/: %v", err)
 	}
-	err = syscall.Mount("/sys/fs/bpf", "/sys/fs/bpf", "bpf", 0, "")
-	if err != nil {
+	if err := syscall.Mount("/sys/fs/bpf", "/sys/fs/bpf", "bpf", 0, ""); err != nil {
 		CleanupBpfMap()
 		t.Fatalf("Failed to mount /sys/fs/bpf: %v", err)
 	}
 
-	if err = rlimit.RemoveMemlock(); err != nil {
+	if err := rlimit.RemoveMemlock(); err != nil {
 		CleanupBpfMap()
 		t.Fatalf("Failed to remove mem limit: %v", err)
 	}

--- a/pkg/controller/ads/ads_processor_test.go
+++ b/pkg/controller/ads/ads_processor_test.go
@@ -485,8 +485,7 @@ func TestHandleLdsResponse(t *testing.T) {
 		BpfFsPath:   "/sys/fs/bpf",
 		Cgroup2Path: "/mnt/kmesh_cgroup2",
 	}
-	cleanup, _ := test.InitBpfMap(t, config)
-	t.Cleanup(cleanup)
+	_, loader := test.InitBpfMap(t, config)
 	t.Run("normal function test", func(t *testing.T) {
 		adsLoader := NewAdsCache()
 		adsLoader.routeNames = []string{
@@ -655,6 +654,7 @@ func TestHandleLdsResponse(t *testing.T) {
 		assert.Equal(t, wantHash, actualHash)
 		assert.Equal(t, []string{"ut-rds"}, p.req.ResourceNames)
 	})
+	loader.Stop()
 }
 
 func TestHandleRdsResponse(t *testing.T) {
@@ -663,8 +663,7 @@ func TestHandleRdsResponse(t *testing.T) {
 		BpfFsPath:   "/sys/fs/bpf",
 		Cgroup2Path: "/mnt/kmesh_cgroup2",
 	}
-	cleanup, _ := test.InitBpfMap(t, config)
-	t.Cleanup(cleanup)
+	_, loader := test.InitBpfMap(t, config)
 	t.Run("normal function test", func(t *testing.T) {
 		p := newProcessor()
 		p.ack = &service_discovery_v3.DiscoveryRequest{
@@ -816,4 +815,5 @@ func TestHandleRdsResponse(t *testing.T) {
 		assert.Equal(t, wantHash2, actualHash2)
 		assert.Equal(t, []string{"ut-routeconfig1", "ut-routeconfig2"}, p.ack.ResourceNames)
 	})
+	loader.Stop()
 }

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -166,7 +166,7 @@ func (s *Server) loggersHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func (s *Server) getLoggerNames(w http.ResponseWriter, r *http.Request) {
+func (s *Server) getLoggerNames(w http.ResponseWriter) {
 	loggerNames := append(logger.GetLoggerNames(), bpfLoggerName)
 	data, err := json.MarshalIndent(&loggerNames, "", "    ")
 	if err != nil {
@@ -180,7 +180,7 @@ func (s *Server) getLoggerNames(w http.ResponseWriter, r *http.Request) {
 func (s *Server) getLoggerLevel(w http.ResponseWriter, r *http.Request) {
 	loggerName := r.URL.Query().Get("name")
 	if loggerName == "" {
-		s.getLoggerNames(w, r)
+		s.getLoggerNames(w)
 		return
 	}
 	var loggerInfo *LoggerInfo

--- a/pkg/status/status_server_test.go
+++ b/pkg/status/status_server_test.go
@@ -106,7 +106,6 @@ func TestServer_getAndSetBpfLevel(t *testing.T) {
 	for _, config := range configs {
 		t.Run(config.Mode, func(t *testing.T) {
 			cleanup, bpfLoader := test.InitBpfMap(t, config)
-			defer cleanup()
 			server := &Server{
 				xdsClient: &controller.XdsClient{
 					WorkloadController: &workload.Controller{
@@ -155,6 +154,7 @@ func TestServer_getAndSetBpfLevel(t *testing.T) {
 			assert.NotNil(t, expectedLoggerInfo)
 			assert.Equal(t, expectedLoggerInfo.Level, actualLoggerInfo.Level)
 			assert.Equal(t, expectedLoggerInfo.Name, actualLoggerInfo.Name)
+			cleanup()
 		})
 	}
 }

--- a/pkg/utils/test/bpf_map.go
+++ b/pkg/utils/test/bpf_map.go
@@ -66,7 +66,6 @@ func InitBpfMap(t *testing.T, config options.BpfConfig) (CleanupFn, *bpf.BpfLoad
 	}
 	return func() {
 		loader.Stop()
-		bpf.CleanupBpfMap()
 	}, loader
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
Because cleanup bpf map in `loader.Stop()`. so there is no need to execute `bpf.cleanup` again
**Which issue(s) this PR fixes**:
Fixes #844 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
