### PR TITLE
remove spammy cni installer log

### DIFF
--- a/pkg/cni/install.go
+++ b/pkg/cni/install.go
@@ -12,9 +12,6 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: bitcoffee
- * Create: 2023-11-19
  */
 
 package cni
@@ -102,7 +99,7 @@ func (i *Installer) WatchServiceAccountToken() error {
 				}
 
 			case event := <-i.Watcher.Events(tokenPath):
-				log.Infof("got event %s", event.String())
+				log.Debugf("got event %s", event.String())
 
 				if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
 					if timerC == nil {

--- a/pkg/cni/kubeconfig.go
+++ b/pkg/cni/kubeconfig.go
@@ -114,7 +114,6 @@ func maybeWriteKubeConfigFile(serviceAccountPath, kubeconfigFilepath string) err
 	}
 
 	if shouldCreateKubeConfigFile(kc, kubeconfigFilepath) {
-		log.Info("kubeconfig either does not exist or is out of date, writing a new one")
 		if err := utils.AtomicWrite(kubeconfigFilepath, []byte(kc), os.FileMode(0o600)); err != nil {
 			return err
 		}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

```
time="2024-09-19T03:22:34Z" level=info msg="got event CHMOD         \"/var/run/secrets/kubernetes.io/serviceaccount/..2024_09_19_03_22_34.2403565555\"" subsys="cni installer"
time="2024-09-19T03:39:30Z" level=info msg="grpc reconnect succeed" subsys=controller
time="2024-09-19T04:11:58Z" level=info msg="got event CREATE        \"/var/run/secrets/kubernetes.io/serviceaccount/..2024_09_19_04_11_58.3748894910\"" subsys="cni installer"
time="2024-09-19T04:11:58Z" level=info msg="kubeconfig either does not exist or is out of date, writing a new one" subsys="cni installer"
time="2024-09-19T04:11:58Z" level=info msg="wrote kubeconfig file /etc/cni/net.d/kmesh-cni-kubeconfig" subsys="cni installer"
time="2024-09-19T04:12:35Z" level=info msg="grpc reconnect succeed" subsys=controller
time="2024-09-19T04:42:11Z" level=info msg="grpc reconnect succeed" subsys=controller
time="2024-09-19T05:00:44Z" level=info msg="got event CREATE        \"/var/run/secrets/kubernetes.io/serviceaccount/..2024_09_19_05_00_44.1767391557\"" subsys="cni installer"
time="2024-09-19T05:00:45Z" level=info msg="kubeconfig either does not exist or is out of date, writing a new one" subsys="cni installer"
time="2024-09-19T05:00:45Z" level=info msg="wrote kubeconfig file /etc/cni/net.d/kmesh-cni-kubeconfig" subsys="cni installer"
time="2024-09-19T05:15:15Z" level=info msg="grpc reconnect succeed" subsys=controller
time="2024-09-19T05:42:52Z" level=info msg="grpc reconnect succeed" subsys=controller
time="2024-09-19T05:49:06Z" level=info msg="got event CHMOD         \"/var/run/secrets/kubernetes.io/serviceaccount/..2024_09_19_05_49_06.2133897411\"" subsys="cni installer"
time="2024-09-19T06:16:02Z" level=info msg="grpc reconnect succeed" subsys=controller
time="2024-09-19T06:37:54Z" level=info msg="got event CHMOD         \"/var/run/secrets/kubernetes.io/serviceaccount/..2024_09_19_06_37_54.3984797432\"" subsys="cni installer"
time="2024-09-19T06:47:17Z" level=info msg="grpc reconnect succeed" subsys=controller
time="2024-09-19T07:18:02Z" level=info msg="grpc reconnect succeed" subsys=controller
time="2024-09-19T07:27:03Z" level=info msg="got event CHMOD         \"/var/run/secrets/kubernetes.io/serviceaccount/..2024_09_19_07_27_03.1502562703\"" subsys="cni installer"
time="2024-09-19T07:49:02Z" level=info msg="grpc reconnect succeed" subsys=controller

```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
