### PR TITLE
Build 2 series of eBPF objects(kernel ver. <5.13 & >=5.13) and load eBPF dynamically when Kmesh starts up

### DIFF
--- a/bpf/include/bpf_common.h
+++ b/bpf/include/bpf_common.h
@@ -5,6 +5,7 @@
 #define __KMESH_BPF_COMMON_H__
 
 #include "common.h"
+#include "inner_map_defs.h"
 
 #define map_of_manager      kmesh_manage
 #define MAP_SIZE_OF_MANAGER 8192
@@ -21,7 +22,6 @@
 #define BPF_DATA_MAX_LEN                                                                                               \
     192 /* this value should be                                                                                        \
 small that make compile success */
-#define BPF_INNER_MAP_DATA_LEN 1300
 
 struct manager_key {
     union {

--- a/bpf/include/inner_map_defs.h
+++ b/bpf/include/inner_map_defs.h
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Kmesh */
+
+#ifndef __INNER_MAP_H__
+#define __INNER_MAP_H__
+
+#define BPF_INNER_MAP_DATA_LEN 1300
+
+#endif // __INNER_MAP_H__

--- a/bpf/kmesh/ads/include/kmesh_common.h
+++ b/bpf/kmesh/ads/include/kmesh_common.h
@@ -9,6 +9,7 @@
 #include "bpf_common.h"
 #include "config.h"
 #include "core/address.pb-c.h"
+#include "tail_call_index.h"
 
 #define BPF_LOGTYPE_LISTENER      BPF_DEBUG_ON
 #define BPF_LOGTYPE_FILTERCHAIN   BPF_DEBUG_ON
@@ -68,15 +69,6 @@ static inline char *bpf_strncpy(char *dst, int n, const char *src)
     return dst;
 }
 #endif
-
-typedef enum {
-    KMESH_TAIL_CALL_LISTENER = 1,
-    KMESH_TAIL_CALL_FILTER_CHAIN,
-    KMESH_TAIL_CALL_FILTER,
-    KMESH_TAIL_CALL_ROUTER,
-    KMESH_TAIL_CALL_CLUSTER,
-    KMESH_TAIL_CALL_ROUTER_CONFIG,
-} tail_call_index_t;
 
 typedef Core__SocketAddress address_t;
 

--- a/bpf/kmesh/ads/include/tail_call_index.h
+++ b/bpf/kmesh/ads/include/tail_call_index.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Kmesh */
+
+#ifndef _TAIL_CALL_INDEX_H_
+#define _TAIL_CALL_INDEX_H_
+
+typedef enum {
+    KMESH_TAIL_CALL_LISTENER = 1,
+    KMESH_TAIL_CALL_FILTER_CHAIN,
+    KMESH_TAIL_CALL_FILTER,
+    KMESH_TAIL_CALL_ROUTER,
+    KMESH_TAIL_CALL_CLUSTER,
+    KMESH_TAIL_CALL_ROUTER_CONFIG,
+} tail_call_index_t;
+
+#endif // _TAIL_CALL_INDEX_H_

--- a/bpf/kmesh/bpf2go/bpf2go.go
+++ b/bpf/kmesh/bpf2go/bpf2go.go
@@ -18,10 +18,18 @@
 package bpf2go
 
 // go run github.com/cilium/ebpf/cmd/bpf2go --help
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshCgroupSock ../ads/cgroup_sock.c -- -I../ads/include -I../../include -I../../../api/v2-c -DCGROUP_SOCK_MANAGE
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshCgroupSockWorkload ../workload/cgroup_sock.c -- -I../workload/include -I../../include -I../probes
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshSockops ../ads/sockops.c -- -I../ads/include -I../../include -I../../../api/v2-c
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshTracePoint ../ads/tracepoint.c -- -I../ads/include -I../../include
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshSockopsWorkload ../workload/sockops.c -- -I../workload/include -I../../include -I../probes
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshXDPAuth ../workload/xdp.c -- -I../workload/include -I../../include -I../../../api/v2-c
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshSendmsg ../workload/sendmsg.c -- -I../workload/include -I../../include
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshCgroupSock ../ads/cgroup_sock.c -- -I../ads/include -I../../include -I../../../api/v2-c -DCGROUP_SOCK_MANAGE -DKERNEL_VERSION_HIGHER_5_13_0=1
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshCgroupSockWorkload ../workload/cgroup_sock.c -- -I../workload/include -I../../include -I../probes -DKERNEL_VERSION_HIGHER_5_13_0=1
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshSockops ../ads/sockops.c -- -I../ads/include -I../../include -I../../../api/v2-c -DKERNEL_VERSION_HIGHER_5_13_0=1
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshTracePoint ../ads/tracepoint.c -- -I../ads/include -I../../include -DKERNEL_VERSION_HIGHER_5_13_0=1
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshSockopsWorkload ../workload/sockops.c -- -I../workload/include -I../../include -I../probes -DKERNEL_VERSION_HIGHER_5_13_0=1
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshXDPAuth ../workload/xdp.c -- -I../workload/include -I../../include -I../../../api/v2-c -DKERNEL_VERSION_HIGHER_5_13_0=1
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshSendmsg ../workload/sendmsg.c -- -I../workload/include -I../../include -DKERNEL_VERSION_HIGHER_5_13_0=1
+
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshCgroupSockCompat ../ads/cgroup_sock.c -- -I../ads/include -I../../include -I../../../api/v2-c -DCGROUP_SOCK_MANAGE -DKERNEL_VERSION_HIGHER_5_13_0=0
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshCgroupSockWorkloadCompat ../workload/cgroup_sock.c -- -I../workload/include -I../../include -I../probes -DKERNEL_VERSION_HIGHER_5_13_0=0
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshSockopsCompat ../ads/sockops.c -- -I../ads/include -I../../include -I../../../api/v2-c -DKERNEL_VERSION_HIGHER_5_13_0=0
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshTracePointCompat ../ads/tracepoint.c -- -I../ads/include -I../../include -DKERNEL_VERSION_HIGHER_5_13_0=0
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshSockopsWorkloadCompat ../workload/sockops.c -- -I../workload/include -I../../include -I../probes -DKERNEL_VERSION_HIGHER_5_13_0=0
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshXDPAuthCompat ../workload/xdp.c -- -I../workload/include -I../../include -I../../../api/v2-c -DKERNEL_VERSION_HIGHER_5_13_0=0
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go -cc clang  --cflags $EXTRA_CFLAGS --cflags $EXTRA_CDEFINE KmeshSendmsgCompat ../workload/sendmsg.c -- -I../workload/include -I../../include -DKERNEL_VERSION_HIGHER_5_13_0=0

--- a/config/kmesh_marcos_def.h
+++ b/config/kmesh_marcos_def.h
@@ -81,8 +81,3 @@
  * is enabled accordingly.
  * */
 #define LIBBPF_HIGHER_0_6_0_VERSION 0
-
-/*
-
- */
-#define KERNEL_VERSION_HIGHER_5_13_0 0

--- a/kmesh_macros_env.sh
+++ b/kmesh_macros_env.sh
@@ -61,9 +61,3 @@ if [[ "$LIBBPF_VERSION" < "0.6.0" ]]; then
 else
 	set_config LIBBPF_HIGHER_0_6_0_VERSION 1
 fi
-
-if [[ "$KERNEL_VERSION" < "5.13.0" ]]; then
-	set_config KERNEL_VERSION_HIGHER_5_13_0 0
-else
-	set_config KERNEL_VERSION_HIGHER_5_13_0 1
-fi

--- a/pkg/bpf/bpf_kmesh_common.go
+++ b/pkg/bpf/bpf_kmesh_common.go
@@ -20,7 +20,8 @@
 package bpf
 
 // #cgo pkg-config: bpf api-v2-c
-// #include "kmesh/ads/include/kmesh_common.h"
+// #include "kmesh/ads/include/tail_call_index.h"
+// #include "inner_map_defs.h"
 import "C"
 import (
 	"os"
@@ -32,6 +33,7 @@ import (
 
 	"kmesh.net/kmesh/bpf/kmesh/bpf2go"
 	"kmesh.net/kmesh/daemon/options"
+	"kmesh.net/kmesh/pkg/utils"
 )
 
 var KMESH_TAIL_CALL_LISTENER = uint32(C.KMESH_TAIL_CALL_LISTENER)
@@ -94,9 +96,12 @@ func (sc *BpfSockConn) loadKmeshSockConnObjects() (*ebpf.CollectionSpec, error) 
 	)
 	opts.Maps.PinPath = sc.Info.MapPath
 
-	spec, err = bpf2go.LoadKmeshCgroupSock()
-
-	if err != nil || spec == nil {
+	if utils.KernelVersionLowerThan5_13() {
+		spec, err = bpf2go.LoadKmeshCgroupSockCompat()
+	} else {
+		spec, err = bpf2go.LoadKmeshCgroupSock()
+	}
+	if err != nil {
 		return nil, err
 	}
 

--- a/pkg/utils/kernel_version.go
+++ b/pkg/utils/kernel_version.go
@@ -1,0 +1,69 @@
+//go:build linux
+// +build linux
+
+/*
+* Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+package utils
+
+import (
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// KernelVersionLowerThan5_13 return whether the current kernel version is lower than 5.13,
+// and will fallback to less BPF log ability(return true) if error
+func KernelVersionLowerThan5_13() bool {
+	kernelVersion := GetKernelVersion()
+	if len(kernelVersion) == 0 {
+		return true
+	}
+	splitVers := strings.Split(kernelVersion, ".")
+	if len(splitVers) < 2 {
+		return true
+	}
+
+	mainVer, err := strconv.Atoi(splitVers[0])
+	if err != nil || mainVer < 5 {
+		return true
+	}
+	if mainVer > 5 {
+		return false
+	}
+
+	subVer, err := strconv.Atoi(splitVers[1])
+	return err != nil || subVer < 13
+}
+
+// GetKernelVersion return part of the result of 'uname -a' like '5.15.153.1-xxxx'
+func GetKernelVersion() string {
+	var uname syscall.Utsname
+	if err := syscall.Uname(&uname); err != nil {
+		return ""
+	}
+	return int8ToStr(uname.Release[:])
+}
+
+func int8ToStr(arr []int8) string {
+	b := make([]byte, 0, len(arr))
+	for _, v := range arr {
+		if v == 0x00 {
+			break
+		}
+		b = append(b, byte(v))
+	}
+	return string(b)
+}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->
/kind enhancement
**What this PR does / why we need it**:
**Problem:** Kernel version lower than 5.13 does not support `bpf_snprintf()`, thus eBPF log can not be redirected to Kmesh daemon. There is no good solution for now.
**Solution:** Build 2 series of eBPF objects, one of them with `-DKERNEL_VERSION_HIGHER_5_13_0=0`, another with `-DKERNEL_VERSION_HIGHER_5_13_0=1`. When Kmesh starts up, detect the kernel version then load one of them.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```

TODOs:
1. Use `interface` to reduce code lines