### PR TITLE
optimize kmesh-daemon binary

### DIFF
--- a/daemon/manager/manager.go
+++ b/daemon/manager/manager.go
@@ -48,9 +48,8 @@ var log = logger.NewLoggerScope(pkgSubsys)
 func NewCommand() *cobra.Command {
 	configs := options.NewBootstrapConfigs()
 	cmd := &cobra.Command{
-		Use:          "kmesh-daemon",
-		Short:        "Start kmesh daemon",
-		SilenceUsage: true,
+		Use:   "kmesh-daemon",
+		Short: "Start kmesh daemon",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			printFlags(cmd.Flags())
 			if err := configs.ParseConfigs(); err != nil {
@@ -58,8 +57,8 @@ func NewCommand() *cobra.Command {
 			}
 			return Execute(configs)
 		},
-		FParseErrWhitelist: cobra.FParseErrWhitelist{
-			UnknownFlags: true,
+		CompletionOptions: cobra.CompletionOptions{
+			DisableDefaultCmd: true,
 		},
 	}
 

--- a/daemon/manager/manager.go
+++ b/daemon/manager/manager.go
@@ -48,14 +48,18 @@ var log = logger.NewLoggerScope(pkgSubsys)
 func NewCommand() *cobra.Command {
 	configs := options.NewBootstrapConfigs()
 	cmd := &cobra.Command{
-		Use:   "kmesh-daemon",
-		Short: "Start kmesh daemon",
+		Use:          "kmesh-daemon",
+		Short:        "Start kmesh daemon",
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			printFlags(cmd.Flags())
 			if err := configs.ParseConfigs(); err != nil {
 				return err
 			}
 			return Execute(configs)
+		},
+		FParseErrWhitelist: cobra.FParseErrWhitelist{
+			UnknownFlags: true,
 		},
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement


**What this PR does / why we need it**:

Now kmesh-daemon has unwanted subcommand `completion`:

```bash
[root@kmesh-7jz9n kmesh]# kmesh-daemon --help
Start kmesh daemon

Usage:
  kmesh-daemon [flags]
  kmesh-daemon [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  dump        Dump config of ads or workload mode
  help        Help about any command
  log         Get or set kmesh-daemon's logger level
  uninstall   Uninstall kmesh-cni
  version     Print the version of kmesh daemon
```

And will ignore invalid flag:

```
[root@kmesh-7jz9n kmesh]# kmesh-daemon --abc
time="2024-09-23T02:46:14Z" level=info msg="FLAG: --bpf-fs-path=\"/sys/fs/bpf\"" subsys=manager
time="2024-09-23T02:46:14Z" level=info msg="FLAG: --cgroup2-path=\"/mnt/kmesh_cgroup2\"" subsys=manager
time="2024-09-23T02:46:14Z" level=info msg="FLAG: --cni-etc-path=\"/etc/cni/net.d\"" subsys=manager
time="2024-09-23T02:46:14Z" level=info msg="FLAG: --conflist-name=\"\"" subsys=manager
time="2024-09-23T02:46:14Z" level=info msg="FLAG: --enable-bpf-log=\"false\"" subsys=manager
time="2024-09-23T02:46:14Z" level=info msg="FLAG: --enable-bypass=\"false\"" subsys=manager
time="2024-09-23T02:46:14Z" level=info msg="FLAG: --enable-mda=\"false\"" subsys=manager
time="2024-09-23T02:46:14Z" level=info msg="FLAG: --enable-secret-manager=\"false\"" subsys=manager
time="2024-09-23T02:46:14Z" level=info msg="FLAG: --help=\"false\"" subsys=manager
time="2024-09-23T02:46:14Z" level=info msg="FLAG: --mode=\"workload\"" subsys=manager
time="2024-09-23T02:46:14Z" level=info msg="FLAG: --plugin-cni-chained=\"true\"" subsys=manager
time="2024-09-23T02:46:14Z" level=info msg="oldGitVersion: 1563676948 newGitVersion: 1563676948" subsys=pkg/bpf
time="2024-09-23T02:46:14Z" level=info msg="kmesh start with Restart, load bpf maps and prog from last" subsys=pkg/bpf
```

This PR fixes these issues

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
