### PR TITLE
Add locality loadbalance to kmesh workload mode.

### DIFF
--- a/bpf/kmesh/workload/include/service.h
+++ b/bpf/kmesh/workload/include/service.h
@@ -23,7 +23,7 @@ static inline int lb_random_handle(struct kmesh_context *kmesh_ctx, __u32 servic
         return 0;
 
     endpoint_k.service_id = service_id;
-    endpoint_k.prio = 0; // for random handle，all endpoints are saved in max priority
+    endpoint_k.prio = 0; // for random handle，all endpoints are saved with highest priority
 
     rand_k = bpf_get_prandom_u32() % service_v->prio_endpoint_count[0] + 1;
     endpoint_k.backend_index = rand_k;

--- a/bpf/kmesh/workload/include/service.h
+++ b/bpf/kmesh/workload/include/service.h
@@ -17,9 +17,13 @@ static inline int lb_random_handle(struct kmesh_context *kmesh_ctx, __u32 servic
     int ret = 0;
     endpoint_key endpoint_k = {0};
     endpoint_value *endpoint_v = NULL;
+    int rand_k = 0;
 
     endpoint_k.service_id = service_id;
-    endpoint_k.backend_index = bpf_get_prandom_u32() % service_v->endpoint_count + 1;
+    endpoint_k.prio = MAX_PRIO; // for random handle，all endpoints are saved in MAX_PRIO
+
+    rand_k = bpf_get_prandom_u32() % service_v->prio_endpoint_count[MAX_PRIO] + 1;
+    endpoint_k.backend_index = rand_k;
 
     endpoint_v = map_lookup_endpoint(&endpoint_k);
     if (!endpoint_v) {
@@ -35,6 +39,47 @@ static inline int lb_random_handle(struct kmesh_context *kmesh_ctx, __u32 servic
     }
 
     return 0;
+}
+
+static inline int
+lb_locality_failover_handle(struct kmesh_context *kmesh_ctx, __u32 service_id, service_value *service_v, bool is_strict)
+{
+    int ret = 0;
+    uint32_t rand_k = 0;
+    endpoint_key endpoint_k = {0};
+    endpoint_value *endpoint_v = NULL;
+    endpoint_k.service_id = service_id;
+
+    // #pragma unroll
+    for (int match_rank = MAX_PRIO; match_rank >= 0; match_rank--) {
+        endpoint_k.prio = match_rank; // 6->0
+        // if we have endpoints in this prio
+        if (service_v->prio_endpoint_count[match_rank] > 0) {
+            rand_k = bpf_get_prandom_u32() % service_v->prio_endpoint_count[match_rank] + 1;
+            if (rand_k >= MAP_SIZE_OF_BACKEND) {
+                return -ENOENT;
+            }
+            endpoint_k.backend_index = rand_k;
+            endpoint_v = map_lookup_endpoint(&endpoint_k);
+            if (!endpoint_v) {
+                BPF_LOG(
+                    ERR, SERVICE, "find endpoint [%u/%u/%u] failed", service_id, match_rank, endpoint_k.backend_index);
+                return -ENOENT;
+            }
+            ret = endpoint_manager(kmesh_ctx, endpoint_v, service_id, service_v);
+            if (ret != 0) {
+                if (ret != -ENOENT)
+                    BPF_LOG(ERR, SERVICE, "endpoint_manager failed, ret:%d\n", ret);
+                return ret;
+            }
+            return 0; // find the backend successfully
+        }
+        if (is_strict && match_rank == service_v->lb_strict_index) { // only match lb strict index
+            return -ENOENT;
+        }
+    }
+    // no backend matched
+    return -ENOENT;
 }
 
 static inline int service_manager(struct kmesh_context *kmesh_ctx, __u32 service_id, service_value *service_v)
@@ -55,14 +100,17 @@ static inline int service_manager(struct kmesh_context *kmesh_ctx, __u32 service
         return ret;
     }
 
-    if (service_v->endpoint_count == 0) {
-        BPF_LOG(DEBUG, SERVICE, "service %u has no endpoint", service_id);
-        return 0;
-    }
+    BPF_LOG(DEBUG, SERVICE, "service [%u] policy [%u] failed", service_id, service_v->lb_policy);
 
     switch (service_v->lb_policy) {
     case LB_POLICY_RANDOM:
         ret = lb_random_handle(kmesh_ctx, service_id, service_v);
+        break;
+    case LB_POLICY_STRICT:
+        ret = lb_locality_failover_handle(kmesh_ctx, service_id, service_v, true);
+        break;
+    case LB_POLICY_FAILOVER:
+        ret = lb_locality_failover_handle(kmesh_ctx, service_id, service_v, false);
         break;
     default:
         BPF_LOG(ERR, SERVICE, "unsupported load balance type:%u\n", service_v->lb_policy);

--- a/bpf/kmesh/workload/include/service.h
+++ b/bpf/kmesh/workload/include/service.h
@@ -61,9 +61,6 @@ lb_locality_failover_handle(struct kmesh_context *kmesh_ctx, __u32 service_id, s
         // if we have endpoints in this prio
         if (service_v->prio_endpoint_count[match_prio] > 0) {
             rand_k = bpf_get_prandom_u32() % service_v->prio_endpoint_count[match_prio] + 1;
-            if (rand_k >= MAP_SIZE_OF_BACKEND) {
-                return -ENOENT;
-            }
             endpoint_k.backend_index = rand_k;
             endpoint_v = map_lookup_endpoint(&endpoint_k);
             if (!endpoint_v) {

--- a/bpf/kmesh/workload/include/workload.h
+++ b/bpf/kmesh/workload/include/workload.h
@@ -10,7 +10,6 @@
 #define MAX_PORT_COUNT            10
 #define MAX_SERVICE_COUNT         10
 #define RINGBUF_SIZE              (1 << 12)
-#define MIN_PRIO                  6
 #define PRIO_COUNT                7
 #define MAX_MEMBER_NUM_PER_POLICY 4
 
@@ -31,9 +30,8 @@ typedef struct {
 
 typedef struct {
     __u32 prio_endpoint_count[PRIO_COUNT]; // endpoint count of current service with prio
-    __u32 lb_policy;      // load balancing algorithm, currently supports random algorithm, locality loadbalance
-                          // Failover/strict mode
-    __u32 lb_strict_prio; // for failover strict mode
+    __u32 lb_policy; // load balancing algorithm, currently supports random algorithm, locality loadbalance
+                     // Failover/strict mode
     __u32 service_port[MAX_PORT_COUNT]; // service_port[i] and target_port[i] are a pair, i starts from 0 and max value
                                         // is MAX_PORT_COUNT-1
     __u32 target_port[MAX_PORT_COUNT];

--- a/bpf/kmesh/workload/include/workload.h
+++ b/bpf/kmesh/workload/include/workload.h
@@ -10,6 +10,8 @@
 #define MAX_PORT_COUNT            10
 #define MAX_SERVICE_COUNT         10
 #define RINGBUF_SIZE              (1 << 12)
+#define MAX_PRIO                  6
+#define MAX_PRIO_COUNT            MAX_PRIO + 1 // 6 means match all scope, 0 means match nothing
 #define MAX_MEMBER_NUM_PER_POLICY 4
 
 #pragma pack(1)
@@ -28,8 +30,10 @@ typedef struct {
 } service_key;
 
 typedef struct {
-    __u32 endpoint_count;               // endpoint count of current service
-    __u32 lb_policy;                    // load balancing algorithm, currently only supports random algorithm
+    __u32 prio_endpoint_count[MAX_PRIO_COUNT]; // endpoint count of current service with prio, prio from 6->0
+    __u32 lb_policy;       // load balancing algorithm, currently supports random algorithm, locality loadbalance
+                           // Failover/strict mode
+    __u32 lb_strict_index; // for failover strict mode
     __u32 service_port[MAX_PORT_COUNT]; // service_port[i] and target_port[i] are a pair, i starts from 0 and max value
                                         // is MAX_PORT_COUNT-1
     __u32 target_port[MAX_PORT_COUNT];
@@ -40,6 +44,7 @@ typedef struct {
 // endpoint map
 typedef struct {
     __u32 service_id;    // service id
+    __u32 prio;          // prio means rank, 6 means match all, and 0 means match nothing
     __u32 backend_index; // if endpoint_count = 3, then backend_index = 0/1/2
 } endpoint_key;
 

--- a/bpf/kmesh/workload/include/workload.h
+++ b/bpf/kmesh/workload/include/workload.h
@@ -10,8 +10,8 @@
 #define MAX_PORT_COUNT            10
 #define MAX_SERVICE_COUNT         10
 #define RINGBUF_SIZE              (1 << 12)
-#define MAX_PRIO                  6
-#define MAX_PRIO_COUNT            MAX_PRIO + 1 // 6 means match all scope, 0 means match nothing
+#define MIN_PRIO                  6
+#define PRIO_COUNT                7
 #define MAX_MEMBER_NUM_PER_POLICY 4
 
 #pragma pack(1)
@@ -30,10 +30,10 @@ typedef struct {
 } service_key;
 
 typedef struct {
-    __u32 prio_endpoint_count[MAX_PRIO_COUNT]; // endpoint count of current service with prio, prio from 6->0
-    __u32 lb_policy;       // load balancing algorithm, currently supports random algorithm, locality loadbalance
-                           // Failover/strict mode
-    __u32 lb_strict_index; // for failover strict mode
+    __u32 prio_endpoint_count[PRIO_COUNT]; // endpoint count of current service with prio
+    __u32 lb_policy;      // load balancing algorithm, currently supports random algorithm, locality loadbalance
+                          // Failover/strict mode
+    __u32 lb_strict_prio; // for failover strict mode
     __u32 service_port[MAX_PORT_COUNT]; // service_port[i] and target_port[i] are a pair, i starts from 0 and max value
                                         // is MAX_PORT_COUNT-1
     __u32 target_port[MAX_PORT_COUNT];
@@ -44,7 +44,7 @@ typedef struct {
 // endpoint map
 typedef struct {
     __u32 service_id;    // service id
-    __u32 prio;          // prio means rank, 6 means match all, and 0 means match nothing
+    __u32 prio;          // 0 means heightest prio, match all scope, 6 means lowest prio.
     __u32 backend_index; // if endpoint_count = 3, then backend_index = 0/1/2
 } endpoint_key;
 

--- a/bpf/kmesh/workload/include/workload_common.h
+++ b/bpf/kmesh/workload/include/workload_common.h
@@ -22,6 +22,8 @@
 // loadbalance type
 typedef enum {
     LB_POLICY_RANDOM = 0,
+    LB_POLICY_STRICT = 1,
+    LB_POLICY_FAILOVER = 2,
 } lb_policy_t;
 
 #pragma pack(1)

--- a/pkg/controller/workload/bpfcache/endpoint.go
+++ b/pkg/controller/workload/bpfcache/endpoint.go
@@ -22,8 +22,8 @@ import (
 )
 
 const (
-	MaxPrio    = 6
-	MaxPrioNum = 7
+	MinPrio   = 6
+	PrioCount = 7
 )
 
 type EndpointKey struct {

--- a/pkg/controller/workload/bpfcache/endpoint.go
+++ b/pkg/controller/workload/bpfcache/endpoint.go
@@ -22,7 +22,6 @@ import (
 )
 
 const (
-	MinPrio   = 6
 	PrioCount = 7
 )
 

--- a/pkg/controller/workload/bpfcache/endpoint.go
+++ b/pkg/controller/workload/bpfcache/endpoint.go
@@ -21,8 +21,14 @@ import (
 	"istio.io/istio/pkg/util/sets"
 )
 
+const (
+	MaxPrio    = 6
+	MaxPrioNum = 7
+)
+
 type EndpointKey struct {
 	ServiceId    uint32 // service id
+	Prio         uint32
 	BackendIndex uint32 // if endpoint_count = 3, then backend_index = 1/2/3
 }
 
@@ -59,15 +65,17 @@ func (c *Cache) EndpointDelete(key *EndpointKey) error {
 }
 
 // EndpointSwap update the last endpoint index and remove the current endpoint
-func (c *Cache) EndpointSwap(currentIndex, lastIndex uint32, serviceId uint32) error {
+func (c *Cache) EndpointSwap(currentIndex, lastIndex uint32, serviceId uint32, prio uint32) error {
 	if currentIndex == lastIndex {
 		return c.EndpointDelete(&EndpointKey{
 			ServiceId:    serviceId,
+			Prio:         prio,
 			BackendIndex: lastIndex,
 		})
 	}
 	lastKey := &EndpointKey{
 		ServiceId:    serviceId,
+		Prio:         prio,
 		BackendIndex: lastIndex,
 	}
 	lastValue := &EndpointValue{}
@@ -77,6 +85,7 @@ func (c *Cache) EndpointSwap(currentIndex, lastIndex uint32, serviceId uint32) e
 
 	currentKey := &EndpointKey{
 		ServiceId:    serviceId,
+		Prio:         prio,
 		BackendIndex: currentIndex,
 	}
 	currentValue := &EndpointValue{}

--- a/pkg/controller/workload/bpfcache/locality_cache.go
+++ b/pkg/controller/workload/bpfcache/locality_cache.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package bpfcache
 
 import (
@@ -59,7 +75,7 @@ func (l *localityInfo) IsSet(param uint32) bool {
 type LocalityCache struct {
 	LbPolicy               uint32
 	localityInfo           localityInfo
-	LbStrictIndex          uint32 // for failover strict mode
+	LbStrictPrio           uint32 // for failover strict mode
 	isLocalityInfoSet      bool
 	RoutingPreference      []workloadapi.LoadBalancing_Scope
 	isRoutingPreferenceSet bool
@@ -92,7 +108,7 @@ func (l *LocalityCache) SetRoutingPreference(s []workloadapi.LoadBalancing_Scope
 	// notice: s should set by lb.GetRoutingPreference()
 	if len(s) > 0 {
 		l.RoutingPreference = s
-		l.LbStrictIndex = uint32(len(s))
+		l.LbStrictPrio = uint32(MinPrio - len(s))
 		l.isRoutingPreferenceSet = true
 	}
 }
@@ -138,7 +154,7 @@ func (l *LocalityCache) CalcuLocalityLBPrio(wl *workloadapi.Workload) uint32 {
 			}
 		}
 	}
-	return rank
+	return MinPrio - rank
 }
 
 func (l *LocalityCache) SaveToWaitQueue(wl *workloadapi.Workload) {

--- a/pkg/controller/workload/bpfcache/locality_cache.go
+++ b/pkg/controller/workload/bpfcache/locality_cache.go
@@ -116,7 +116,7 @@ func (l *LocalityCache) SetRoutingPreference(s []workloadapi.LoadBalancing_Scope
 	}
 }
 
-func (l *LocalityCache) CanLocalityLB() bool {
+func (l *LocalityCache) IsLocalityInfoSet() bool {
 	log.Debugf("isLocalityInfoSet: %#v, isRoutingPreferenceSet: %#v", l.isLocalityInfoSet, l.isRoutingPreferenceSet)
 	return l.isLocalityInfoSet && l.isRoutingPreferenceSet
 }

--- a/pkg/controller/workload/bpfcache/locality_cache.go
+++ b/pkg/controller/workload/bpfcache/locality_cache.go
@@ -1,0 +1,154 @@
+package bpfcache
+
+import (
+	"kmesh.net/kmesh/api/v2/workloadapi"
+)
+
+const (
+	REGION    = 1 << iota // 000001
+	ZONE                  // 000010
+	SUBZONE               // 000100
+	NODENAME              // 001000
+	CLUSTERID             // 010000
+	NETWORK               // 100000
+)
+
+type localityInfo struct {
+	region    string // init from workload.GetLocality().GetRegion()
+	zone      string // init from workload.GetLocality().GetZone()
+	subZone   string // init from workload.GetLocality().GetSubZone()
+	nodeName  string // init from os.Getenv("NODE_NAME"), workload.GetNode()
+	clusterId string // init from workload.GetClusterId()
+	network   string // workload.GetNetwork()
+	mask      uint32 // mask
+}
+
+func Valid(s string) bool {
+	return s != ""
+}
+
+func (l *localityInfo) Set(s string, param uint32) {
+	if !Valid(s) {
+		return
+	}
+	switch param {
+	case REGION:
+		l.region = s
+	case ZONE:
+		l.zone = s
+	case SUBZONE:
+		l.subZone = s
+	case NODENAME:
+		l.nodeName = s
+	case CLUSTERID:
+		l.clusterId = s
+	case NETWORK:
+		l.network = s
+	}
+	l.mask |= param
+}
+
+func (l *localityInfo) Clear(param uint32) {
+	l.mask &= ^param
+}
+
+func (l *localityInfo) IsSet(param uint32) bool {
+	return l.mask&param != 0
+}
+
+type LocalityCache struct {
+	LbPolicy               uint32
+	localityInfo           localityInfo
+	LbStrictIndex          uint32 // for failover strict mode
+	isLocalityInfoSet      bool
+	RoutingPreference      []workloadapi.LoadBalancing_Scope
+	isRoutingPreferenceSet bool
+	workloadWaitQueue      map[*workloadapi.Workload]struct{}
+}
+
+func NewLocalityCache() *LocalityCache {
+	return &LocalityCache{
+		localityInfo:           localityInfo{},
+		isLocalityInfoSet:      false,
+		RoutingPreference:      make([]workloadapi.LoadBalancing_Scope, 0),
+		isRoutingPreferenceSet: false,
+		workloadWaitQueue:      make(map[*workloadapi.Workload]struct{}),
+	}
+}
+
+func (l *LocalityCache) SetLocality(nodeName, clusterId, network string, locality *workloadapi.Locality) {
+	// notice: nodeName should set by processor or os.Getenv("NODE_NAME"),
+	l.localityInfo.Set(nodeName, NODENAME)
+	l.localityInfo.Set(locality.GetRegion(), REGION)
+	l.localityInfo.Set(locality.GetSubzone(), SUBZONE)
+	l.localityInfo.Set(locality.GetZone(), ZONE)
+	l.localityInfo.Set(clusterId, CLUSTERID)
+	l.localityInfo.Set(network, NETWORK)
+
+	l.isLocalityInfoSet = true
+}
+
+func (l *LocalityCache) SetRoutingPreference(s []workloadapi.LoadBalancing_Scope) {
+	// notice: s should set by lb.GetRoutingPreference()
+	if len(s) > 0 {
+		l.RoutingPreference = s
+		l.LbStrictIndex = uint32(len(s))
+		l.isRoutingPreferenceSet = true
+	}
+}
+
+func (l *LocalityCache) CanLocalityLB() bool {
+	log.Debugf("isLocalityInfoSet: %#v, isRoutingPreferenceSet: %#v", l.isLocalityInfoSet, l.isRoutingPreferenceSet)
+	return l.isLocalityInfoSet && l.isRoutingPreferenceSet
+}
+
+func (l *LocalityCache) CalcuLocalityLBPrio(wl *workloadapi.Workload) uint32 {
+	var rank uint32 = 0
+	for scope := range l.RoutingPreference {
+		switch scope {
+		case int(workloadapi.LoadBalancing_REGION):
+			log.Debugf("l.localityInfo.IsSet(REGION) %#v, Valid(wl.GetLocality().GetRegion()) %#v, l.localityInfo.region %#v, wl.GetLocality().GetRegion() %#v", l.localityInfo.IsSet(REGION), Valid(wl.GetLocality().GetRegion()), l.localityInfo.region, wl.GetLocality().GetRegion())
+			if l.localityInfo.IsSet(REGION) && Valid(wl.GetLocality().GetRegion()) && l.localityInfo.region == wl.GetLocality().GetRegion() {
+				rank++
+			}
+		case int(workloadapi.LoadBalancing_ZONE):
+			log.Debugf("l.localityInfo.IsSet(ZONE) %#v, Valid(wl.GetLocality().GetZone()) %#v, l.localityInfo.zone %#v, wl.GetLocality().GetZone() %#v", l.localityInfo.IsSet(ZONE), Valid(wl.GetLocality().GetZone()), l.localityInfo.zone, wl.GetLocality().GetZone())
+			if l.localityInfo.IsSet(ZONE) && Valid(wl.GetLocality().GetZone()) && l.localityInfo.zone == wl.GetLocality().GetZone() {
+				rank++
+			}
+		case int(workloadapi.LoadBalancing_SUBZONE):
+			log.Debugf("l.localityInfo.IsSet(SUBZONE) %#v, Valid(wl.GetLocality().GetSubzone()) %#v, l.localityInfo.subZone %#v, wl.GetLocality().GetSubzone() %#v", l.localityInfo.IsSet(SUBZONE), Valid(wl.GetLocality().GetSubzone()), l.localityInfo.subZone, wl.GetLocality().GetSubzone())
+			if l.localityInfo.IsSet(SUBZONE) && Valid(wl.GetLocality().GetSubzone()) && l.localityInfo.subZone == wl.GetLocality().GetSubzone() {
+				rank++
+			}
+		case int(workloadapi.LoadBalancing_NODE):
+			log.Debugf("l.localityInfo.IsSet(NODENAME) %#v, Valid(wl.GetNode()) %#v, l.localityInfo.nodeName %#v, wl.GetNode() %#v", l.localityInfo.IsSet(NODENAME), Valid(wl.GetNode()), l.localityInfo.nodeName, wl.GetNode())
+			if l.localityInfo.IsSet(NODENAME) && Valid(wl.GetNode()) && l.localityInfo.nodeName == wl.GetNode() {
+				rank++
+			}
+		case int(workloadapi.LoadBalancing_NETWORK):
+			log.Debugf("l.localityInfo.IsSet(NETWORK) %#v, Valid(wl.GetNetwork()) %#v, l.localityInfo.network %#v, wl.GetNetwork() %#v", l.localityInfo.IsSet(NETWORK), Valid(wl.GetNetwork()), l.localityInfo.network, wl.GetNetwork())
+			if l.localityInfo.IsSet(NETWORK) && Valid(wl.GetNetwork()) && l.localityInfo.network == wl.GetNetwork() {
+				rank++
+			}
+		case int(workloadapi.LoadBalancing_CLUSTER):
+			log.Debugf("l.localityInfo.IsSet(CLUSTERID) %#v, Valid(wl.GetClusterId()) %#v, l.localityInfo.clusterId %#v, wl.GetClusterId() %#v", l.localityInfo.IsSet(CLUSTERID), Valid(wl.GetClusterId()), l.localityInfo.clusterId, wl.GetClusterId())
+			if l.localityInfo.IsSet(CLUSTERID) && Valid(wl.GetClusterId()) && l.localityInfo.clusterId == wl.GetClusterId() {
+				rank++
+			}
+		}
+	}
+	return rank
+}
+
+func (l *LocalityCache) SaveToWaitQueue(wl *workloadapi.Workload) {
+	l.workloadWaitQueue[wl] = struct{}{}
+}
+
+func (l *LocalityCache) DelWorkloadFromWaitQueue(wl *workloadapi.Workload) {
+	delete(l.workloadWaitQueue, wl)
+}
+
+func (l *LocalityCache) GetFromWaitQueue() map[*workloadapi.Workload]struct{} {
+	return l.workloadWaitQueue
+}

--- a/pkg/controller/workload/bpfcache/locality_cache.go
+++ b/pkg/controller/workload/bpfcache/locality_cache.go
@@ -104,37 +104,43 @@ func (l *LocalityCache) SetLocality(nodeName, clusterId, network string, localit
 func (l *LocalityCache) CalcLocalityLBPrio(wl *workloadapi.Workload, rp []workloadapi.LoadBalancing_Scope) uint32 {
 	var rank uint32 = 0
 	for _, scope := range rp {
+		match := false
 		switch scope {
 		case workloadapi.LoadBalancing_REGION:
 			log.Debugf("l.LocalityInfo.region %#v, wl.GetLocality().GetRegion() %#v", l.LocalityInfo.region, wl.GetLocality().GetRegion())
 			if l.LocalityInfo.region == wl.GetLocality().GetRegion() {
-				rank++
+				match = true
 			}
 		case workloadapi.LoadBalancing_ZONE:
 			log.Debugf("l.LocalityInfo.zone %#v, wl.GetLocality().GetZone() %#v", l.LocalityInfo.zone, wl.GetLocality().GetZone())
 			if l.LocalityInfo.zone == wl.GetLocality().GetZone() {
-				rank++
+				match = true
 			}
 		case workloadapi.LoadBalancing_SUBZONE:
 			log.Debugf("l.LocalityInfo.subZone %#v, wl.GetLocality().GetSubzone() %#v", l.LocalityInfo.subZone, wl.GetLocality().GetSubzone())
 			if l.LocalityInfo.subZone == wl.GetLocality().GetSubzone() {
-				rank++
+				match = true
 			}
 		case workloadapi.LoadBalancing_NODE:
 			log.Debugf("l.LocalityInfo.nodeName %#v, wl.GetNode() %#v", l.LocalityInfo.nodeName, wl.GetNode())
 			if l.LocalityInfo.nodeName == wl.GetNode() {
-				rank++
-			}
-		case workloadapi.LoadBalancing_NETWORK:
-			log.Debugf("l.LocalityInfo.network %#v, wl.GetNetwork() %#v", l.LocalityInfo.network, wl.GetNetwork())
-			if l.LocalityInfo.network == wl.GetNetwork() {
-				rank++
+				match = true
 			}
 		case workloadapi.LoadBalancing_CLUSTER:
 			log.Debugf("l.LocalityInfo.clusterId %#v, wl.GetClusterId() %#v", l.LocalityInfo.clusterId, wl.GetClusterId())
 			if l.LocalityInfo.clusterId == wl.GetClusterId() {
-				rank++
+				match = true
 			}
+		case workloadapi.LoadBalancing_NETWORK:
+			log.Debugf("l.LocalityInfo.network %#v, wl.GetNetwork() %#v", l.LocalityInfo.network, wl.GetNetwork())
+			if l.LocalityInfo.network == wl.GetNetwork() {
+				match = true
+			}
+		}
+		if match {
+			rank++
+		} else {
+			break
 		}
 	}
 	return uint32(len(rp)) - rank

--- a/pkg/controller/workload/bpfcache/locality_cache_test.go
+++ b/pkg/controller/workload/bpfcache/locality_cache_test.go
@@ -1,0 +1,180 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package bpfcache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"kmesh.net/kmesh/api/v2/workloadapi"
+)
+
+func TestCalcLocalityLBPrio(t *testing.T) {
+	// Create a sample LocalityCache instance
+	localityCache := &LocalityCache{
+		LocalityInfo: &localityInfo{
+			region:    "region1",
+			zone:      "zone1",
+			subZone:   "subzone1",
+			nodeName:  "node1",
+			clusterId: "cluster1",
+			network:   "network1",
+		},
+	}
+	workload1 := &workloadapi.Workload{
+		Locality: &workloadapi.Locality{
+			Region:  "region1",
+			Zone:    "zone1",
+			Subzone: "subzone1",
+		},
+		Node:      "node1",
+		Network:   "network1",
+		ClusterId: "cluster1",
+	}
+	testCases := []struct {
+		name     string
+		wl       *workloadapi.Workload
+		scopes   []workloadapi.LoadBalancing_Scope
+		priority uint32
+	}{
+		{
+			name: "match all scopes",
+			wl:   workload1,
+			scopes: []workloadapi.LoadBalancing_Scope{
+				workloadapi.LoadBalancing_REGION,
+				workloadapi.LoadBalancing_ZONE,
+				workloadapi.LoadBalancing_SUBZONE,
+				workloadapi.LoadBalancing_NODE,
+				workloadapi.LoadBalancing_CLUSTER,
+				workloadapi.LoadBalancing_NETWORK,
+			},
+			priority: 0,
+		},
+		{
+			name: "match only region/zone/subzone",
+			wl: &workloadapi.Workload{
+				Locality: &workloadapi.Locality{
+					Region:  "region1",
+					Zone:    "zone1",
+					Subzone: "subzone1",
+				},
+				Node:      "node2",
+				Network:   "network2",
+				ClusterId: "cluster2",
+			},
+			scopes: []workloadapi.LoadBalancing_Scope{
+				workloadapi.LoadBalancing_REGION,
+				workloadapi.LoadBalancing_ZONE,
+				workloadapi.LoadBalancing_SUBZONE,
+				workloadapi.LoadBalancing_NODE,
+				workloadapi.LoadBalancing_CLUSTER,
+				workloadapi.LoadBalancing_NETWORK,
+			}, priority: 3,
+		},
+		{
+			name: "match only first region/zone/subzone",
+			wl: &workloadapi.Workload{
+				Locality: &workloadapi.Locality{
+					Region:  "region1",
+					Zone:    "zone1",
+					Subzone: "subzone1",
+				},
+				Node:      "node2",
+				Network:   "network1",
+				ClusterId: "cluster1",
+			},
+			scopes: []workloadapi.LoadBalancing_Scope{
+				workloadapi.LoadBalancing_REGION,
+				workloadapi.LoadBalancing_ZONE,
+				workloadapi.LoadBalancing_SUBZONE,
+				workloadapi.LoadBalancing_NODE,
+				workloadapi.LoadBalancing_CLUSTER,
+				workloadapi.LoadBalancing_NETWORK,
+			}, priority: 3,
+		},
+		{
+			name: "match first scope",
+			wl: &workloadapi.Workload{
+				Locality: &workloadapi.Locality{
+					Region:  "region1",
+					Zone:    "zone2",
+					Subzone: "subzone2",
+				},
+				Node:      "node2",
+				Network:   "network1",
+				ClusterId: "cluster1",
+			},
+			scopes: []workloadapi.LoadBalancing_Scope{
+				workloadapi.LoadBalancing_REGION,
+				workloadapi.LoadBalancing_ZONE,
+				workloadapi.LoadBalancing_SUBZONE,
+				workloadapi.LoadBalancing_NODE,
+				workloadapi.LoadBalancing_CLUSTER,
+				workloadapi.LoadBalancing_NETWORK,
+			},
+			priority: 5,
+		},
+		{
+			name: "first scope doesnot match",
+			wl: &workloadapi.Workload{
+				Locality: &workloadapi.Locality{
+					Region:  "region2",
+					Zone:    "zone1",
+					Subzone: "subzone1",
+				},
+				Node:      "node1",
+				Network:   "network1",
+				ClusterId: "cluster1",
+			},
+			scopes: []workloadapi.LoadBalancing_Scope{
+				workloadapi.LoadBalancing_REGION,
+				workloadapi.LoadBalancing_ZONE,
+				workloadapi.LoadBalancing_SUBZONE,
+				workloadapi.LoadBalancing_NODE,
+				workloadapi.LoadBalancing_CLUSTER,
+				workloadapi.LoadBalancing_NETWORK,
+			},
+			priority: 6,
+		},
+		{
+			name: "first 2 scope match",
+			wl: &workloadapi.Workload{
+				Locality: &workloadapi.Locality{
+					Region:  "region1",
+					Zone:    "zone2",
+					Subzone: "subzone1",
+				},
+				Node:      "node1",
+				Network:   "network1",
+				ClusterId: "cluster1",
+			},
+			scopes: []workloadapi.LoadBalancing_Scope{
+				workloadapi.LoadBalancing_NETWORK,
+				workloadapi.LoadBalancing_REGION,
+				workloadapi.LoadBalancing_ZONE,
+				workloadapi.LoadBalancing_SUBZONE,
+			},
+			priority: 2,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := localityCache.CalcLocalityLBPrio(tc.wl, tc.scopes)
+			assert.Equal(t, tc.priority, result)
+		})
+	}
+}

--- a/pkg/controller/workload/bpfcache/service.go
+++ b/pkg/controller/workload/bpfcache/service.go
@@ -34,8 +34,7 @@ type TargetPorts [MaxPortNum]uint32
 type ServiceValue struct {
 	EndpointCount [PrioCount]uint32 // endpoint count of current service
 	LbPolicy      uint32            // load balancing algorithm, currently only supports random algorithm
-	LbStrictPrio  uint32
-	ServicePort   ServicePorts // ServicePort[i] and TargetPort[i] are a pair, i starts from 0 and max value is MaxPortNum-1
+	ServicePort   ServicePorts      // ServicePort[i] and TargetPort[i] are a pair, i starts from 0 and max value is MaxPortNum-1
 	TargetPort    TargetPorts
 	WaypointAddr  [16]byte
 	WaypointPort  uint32

--- a/pkg/controller/workload/bpfcache/service.go
+++ b/pkg/controller/workload/bpfcache/service.go
@@ -32,9 +32,9 @@ type ServicePorts [MaxPortNum]uint32
 type TargetPorts [MaxPortNum]uint32
 
 type ServiceValue struct {
-	EndpointCount [MaxPrioNum]uint32 // endpoint count of current service
-	LbPolicy      uint32             // load balancing algorithm, currently only supports random algorithm
-	LbStrictIndex uint32
+	EndpointCount [PrioCount]uint32 // endpoint count of current service
+	LbPolicy      uint32            // load balancing algorithm, currently only supports random algorithm
+	LbStrictPrio  uint32
 	ServicePort   ServicePorts // ServicePort[i] and TargetPort[i] are a pair, i starts from 0 and max value is MaxPortNum-1
 	TargetPort    TargetPorts
 	WaypointAddr  [16]byte

--- a/pkg/controller/workload/bpfcache/service.go
+++ b/pkg/controller/workload/bpfcache/service.go
@@ -32,8 +32,9 @@ type ServicePorts [MaxPortNum]uint32
 type TargetPorts [MaxPortNum]uint32
 
 type ServiceValue struct {
-	EndpointCount uint32       // endpoint count of current service
-	LbPolicy      uint32       // load balancing algorithm, currently only supports random algorithm
+	EndpointCount [MaxPrioNum]uint32 // endpoint count of current service
+	LbPolicy      uint32             // load balancing algorithm, currently only supports random algorithm
+	LbStrictIndex uint32
 	ServicePort   ServicePorts // ServicePort[i] and TargetPort[i] are a pair, i starts from 0 and max value is MaxPortNum-1
 	TargetPort    TargetPorts
 	WaypointAddr  [16]byte

--- a/pkg/controller/workload/cache/endpoint_cache.go
+++ b/pkg/controller/workload/cache/endpoint_cache.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cache
+
+import (
+	"sync"
+)
+
+type Endpoint struct {
+	ServiceId    uint32
+	Prio         uint32
+	BackendIndex uint32
+}
+
+type EndpointCache interface {
+	List(uint32) []Endpoint // Endpoint slice by ServiceId
+	AddEndpointToService(Endpoint)
+	DeleteEndpoint(Endpoint)
+}
+
+type endpointCache struct {
+	mutex sync.RWMutex
+	// keyed by namespace/hostname->service
+	endpointsByServiceId map[uint32]map[Endpoint]struct{} // we use backend
+}
+
+func NewEndpointCache() *endpointCache {
+	return &endpointCache{
+		endpointsByServiceId: make(map[uint32]map[Endpoint]struct{}),
+	}
+}
+
+func (s *endpointCache) AddEndpointToService(ep Endpoint) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	tmp, ok := s.endpointsByServiceId[ep.ServiceId]
+	if !ok {
+		tmp = make(map[Endpoint]struct{})
+	}
+	tmp[ep] = struct{}{}
+}
+
+func (s *endpointCache) DeleteEndpoint(ep Endpoint) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	delete(s.endpointsByServiceId[ep.ServiceId], ep)
+}
+
+func (s *endpointCache) RestoreEndpoint() {
+	// we need update endpoint_cache after bpfcache.RestoreEndpointKeys
+	// Todo
+}
+
+func (s *endpointCache) List(serviceId uint32) []Endpoint {
+	s.mutex.RLock()
+	defer s.mutex.RUnlock()
+	out := make([]Endpoint, 0, len(s.endpointsByServiceId[serviceId]))
+	for ep := range s.endpointsByServiceId[serviceId] {
+		out = append(out, ep)
+	}
+
+	return out
+}

--- a/pkg/controller/workload/cache/endpoint_cache_test.go
+++ b/pkg/controller/workload/cache/endpoint_cache_test.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEndpointCache(t *testing.T) {
+	// Create a sample LocalityCache instance
+	ec := NewEndpointCache()
+
+	// create test endpoints
+	var serviceId uint32 = 1
+	var serviceId1 uint32 = 2
+	var prio uint32 = 0
+	var prio1 uint32 = 1
+
+	ep1 := Endpoint{
+		ServiceId:    serviceId,
+		Prio:         prio,
+		BackendIndex: 1,
+	}
+	ep2 := Endpoint{
+		ServiceId:    serviceId,
+		Prio:         prio,
+		BackendIndex: 2,
+	}
+	ep3 := Endpoint{
+		ServiceId:    serviceId,
+		Prio:         prio1,
+		BackendIndex: 1,
+	}
+	ep4 := Endpoint{
+		ServiceId:    serviceId1,
+		Prio:         prio,
+		BackendIndex: 1,
+	}
+
+	// add to ec
+	ec.AddEndpointToService(ep1, 123)
+	ec.AddEndpointToService(ep2, 234)
+	ec.AddEndpointToService(ep3, 345)
+	ec.AddEndpointToService(ep4, 456)
+
+	// check
+	assert.Equal(t, 3, len(ec.endpointsByServiceId[serviceId]))
+	assert.Equal(t, 1, len(ec.endpointsByServiceId[serviceId1]))
+
+	// search
+	eplist := ec.List(serviceId)
+	assert.Equal(t, 3, len(eplist))
+
+	// delete
+	ec.DeleteEndpoint(ep2, 234)
+	assert.Equal(t, 2, len(ec.endpointsByServiceId[serviceId]))
+	eplist = ec.List(serviceId)
+	assert.Equal(t, 2, len(eplist))
+
+	// delete by serviceId
+	ec.DeleteEndpointByServiceId(serviceId1)
+	assert.Equal(t, 0, len(ec.List(serviceId1)))
+}

--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -638,7 +638,7 @@ func (p *Processor) handleAddressTypeResponse(rsp *service_discovery_v3.DeltaDis
 	}
 
 	workloadInQueue := p.locality.GetFromWaitQueue() // locality LB mode
-	for workload, _ := range workloadInQueue {
+	for workload := range workloadInQueue {
 		if err = p.handleWorkload(workload); err != nil {
 			log.Errorf("handle workload %s failed, err: %v", workload.ResourceName(), err)
 		}

--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -496,15 +496,19 @@ func (p *Processor) storeServiceFrontendData(serviceId uint32, service *workload
 	return nil
 }
 
-func (p *Processor) updateEndpointOneByOne(serviceId uint32, epsDelete []cache.Endpoint, toLLb bool) error {
+func (p *Processor) updateEndpointOneByOne(serviceId uint32, epsUpdate []cache.Endpoint, toLLb bool) error {
 	var prio uint32
 
-	if len(epsDelete) == 0 {
+	if len(epsUpdate) == 0 {
 		return nil
 	}
 
-	for i := len(epsDelete) - 1; i >= 0; i-- {
-		ep := epsDelete[i]
+	// When calling deleteEndpointRecords, it causes the endpoint to be updated and swaps it with the endpoint
+	// with the highest BackendIndex in the priority, leading to a Endpoint shift. Therefore, we iterate over the
+	// sorted Endpoint slice in reverse order to ensure that the BackendIndex of the endpoints updated later
+	// remains unchanged.
+	for i := len(epsUpdate) - 1; i >= 0; i-- {
+		ep := epsUpdate[i]
 		ek := bpf.EndpointKey{
 			ServiceId:    ep.ServiceId,
 			Prio:         ep.Prio,

--- a/pkg/controller/workload/workload_processor_test.go
+++ b/pkg/controller/workload/workload_processor_test.go
@@ -674,7 +674,7 @@ func serviceToAddress(service *workloadapi.Service) *workloadapi.Address {
 	}
 }
 
-func TestCalcuLocalityLbPrio(t *testing.T) {
+func TestCalcLocalityLbPrio(t *testing.T) {
 	workloadMap := bpfcache.NewFakeWorkloadMap(t)
 	defer bpfcache.CleanupFakeWorkloadMap(workloadMap)
 
@@ -693,10 +693,10 @@ func TestCalcuLocalityLbPrio(t *testing.T) {
 	wl2 := createWorkload("wl2", "10.244.0.2", os.Getenv("NODE_NAME"), workloadapi.NetworkMode_STANDARD, createLocality("r1", "z1", "s2"), "svc1") // prio 1
 	wl3 := createWorkload("wl3", "10.244.0.3", os.Getenv("NODE_NAME"), workloadapi.NetworkMode_STANDARD, createLocality("r1", "z2", "s2"), "svc1") // prio 2
 	wl4 := createWorkload("wl4", "10.244.0.4", os.Getenv("NODE_NAME"), workloadapi.NetworkMode_STANDARD, createLocality("r2", "z2", "s2"), "svc1") // prio 3
-	assert.Equal(t, uint32(0), p.locality.CalcuLocalityLBPrio(wl1, llbSvc.GetLoadBalancing().GetRoutingPreference()))
-	assert.Equal(t, uint32(1), p.locality.CalcuLocalityLBPrio(wl2, llbSvc.GetLoadBalancing().GetRoutingPreference()))
-	assert.Equal(t, uint32(2), p.locality.CalcuLocalityLBPrio(wl3, llbSvc.GetLoadBalancing().GetRoutingPreference()))
-	assert.Equal(t, uint32(3), p.locality.CalcuLocalityLBPrio(wl4, llbSvc.GetLoadBalancing().GetRoutingPreference()))
+	assert.Equal(t, uint32(0), p.locality.CalcLocalityLBPrio(wl1, llbSvc.GetLoadBalancing().GetRoutingPreference()))
+	assert.Equal(t, uint32(1), p.locality.CalcLocalityLBPrio(wl2, llbSvc.GetLoadBalancing().GetRoutingPreference()))
+	assert.Equal(t, uint32(2), p.locality.CalcLocalityLBPrio(wl3, llbSvc.GetLoadBalancing().GetRoutingPreference()))
+	assert.Equal(t, uint32(3), p.locality.CalcLocalityLBPrio(wl4, llbSvc.GetLoadBalancing().GetRoutingPreference()))
 
 	hashNameClean(p)
 }

--- a/pkg/controller/workload/workload_processor_test.go
+++ b/pkg/controller/workload/workload_processor_test.go
@@ -18,6 +18,7 @@ package workload
 
 import (
 	"net/netip"
+	"os"
 	"strings"
 	"testing"
 
@@ -50,7 +51,7 @@ func Test_handleWorkload(t *testing.T) {
 	)
 
 	// 1. add related service
-	fakeSvc := createFakeService("testsvc", "10.240.10.1", "10.240.10.2")
+	fakeSvc := createFakeService("testsvc", "10.240.10.1", "10.240.10.2", createLoadBalancing(workloadapi.LoadBalancing_UNSPECIFIED_MODE, make([]workloadapi.LoadBalancing_Scope, 0)))
 	_ = p.handleService(fakeSvc)
 
 	// 2. add workload
@@ -65,7 +66,7 @@ func Test_handleWorkload(t *testing.T) {
 	svcID := checkFrontEndMap(t, fakeSvc.Addresses[0].Address, p)
 
 	// 2.2 check service map contains service
-	checkServiceMap(t, p, svcID, fakeSvc, bpfcache.MinPrio, 1)
+	checkServiceMap(t, p, svcID, fakeSvc, 0, 1)
 
 	// 2.3 check endpoint map now contains the workloads
 	ek.BackendIndex = 1
@@ -88,7 +89,7 @@ func Test_handleWorkload(t *testing.T) {
 	assert.Equal(t, ev.BackendUid, workload2ID)
 
 	// 3.2 check service map contains service
-	checkServiceMap(t, p, svcID, fakeSvc, bpfcache.MinPrio, 2)
+	checkServiceMap(t, p, svcID, fakeSvc, 0, 2)
 
 	// 4 modify workload2 attribute not related with services
 	workload2.Waypoint = &workloadapi.GatewayAddress{
@@ -113,7 +114,7 @@ func Test_handleWorkload(t *testing.T) {
 	assert.Equal(t, ev.BackendUid, workload2ID)
 
 	// 4.2 check service map contains service
-	checkServiceMap(t, p, svcID, fakeSvc, bpfcache.MinPrio, 2)
+	checkServiceMap(t, p, svcID, fakeSvc, 0, 2)
 
 	// 4.3 check backend map contains waypoint
 	checkBackendMap(t, p, workload2ID, workload2)
@@ -125,7 +126,7 @@ func Test_handleWorkload(t *testing.T) {
 	assert.NoError(t, err)
 
 	// 5.1 check service map
-	checkServiceMap(t, p, svcID, fakeSvc, bpfcache.MinPrio, 1)
+	checkServiceMap(t, p, svcID, fakeSvc, 0, 1)
 
 	// 5.2 check endpoint map
 	ek.BackendIndex = 1
@@ -135,13 +136,13 @@ func Test_handleWorkload(t *testing.T) {
 	assert.Equal(t, workload2ID, ev.BackendUid)
 
 	// 6. add namespace scoped waypoint service
-	wpSvc := createFakeService("waypoint", "10.240.10.5", "10.240.10.5")
+	wpSvc := createFakeService("waypoint", "10.240.10.5", "10.240.10.5", createLoadBalancing(workloadapi.LoadBalancing_UNSPECIFIED_MODE, make([]workloadapi.LoadBalancing_Scope, 0)))
 	_ = p.handleService(wpSvc)
 	assert.Nil(t, wpSvc.Waypoint)
 	// 6.1 check front end map contains service
 	svcID = checkFrontEndMap(t, wpSvc.Addresses[0].Address, p)
 	// 6.2 check service map contains service, but no waypoint address
-	checkServiceMap(t, p, svcID, wpSvc, bpfcache.MinPrio, 0)
+	checkServiceMap(t, p, svcID, wpSvc, 0, 0)
 
 	// 7. test add unhealthy workload
 	workload3 := createFakeWorkload("1.2.3.7", workloadapi.NetworkMode_STANDARD)
@@ -178,9 +179,9 @@ func Test_handleServiceWithWaypoint(t *testing.T) {
 	p := NewProcessor(workloadMap)
 
 	// Waypoint with network address.
-	svc1 := createFakeService("svc1", "10.240.10.1", "10.240.10.200")
+	svc1 := createFakeService("svc1", "10.240.10.1", "10.240.10.200", createLoadBalancing(workloadapi.LoadBalancing_UNSPECIFIED_MODE, make([]workloadapi.LoadBalancing_Scope, 0)))
 	// Waypoint with hostname.
-	svc2 := createFakeService("svc2", "10.240.10.1", "gateway.example.com/default")
+	svc2 := createFakeService("svc2", "10.240.10.1", "gateway.example.com/default", createLoadBalancing(workloadapi.LoadBalancing_UNSPECIFIED_MODE, make([]workloadapi.LoadBalancing_Scope, 0)))
 
 	assert.NoError(t, p.handleService(svc1))
 	assert.NoError(t, p.handleService(svc2))
@@ -393,7 +394,14 @@ func createFakeWorkload(ip string, networkMode workloadapi.NetworkMode) *workloa
 	return &workload
 }
 
-func createFakeService(name, ip, waypoint string) *workloadapi.Service {
+func createLoadBalancing(mode workloadapi.LoadBalancing_Mode, scopes []workloadapi.LoadBalancing_Scope) *workloadapi.LoadBalancing {
+	return &workloadapi.LoadBalancing{
+		RoutingPreference: scopes,
+		Mode:              mode,
+	}
+}
+
+func createFakeService(name, ip, waypoint string, lbPolicy *workloadapi.LoadBalancing) *workloadapi.Service {
 	var w *workloadapi.GatewayAddress
 	res := strings.Split(waypoint, "/")
 	if len(res) == 2 {
@@ -440,13 +448,23 @@ func createFakeService(name, ip, waypoint string) *workloadapi.Service {
 				TargetPort:  82,
 			},
 		},
-		Waypoint: w,
+		Waypoint:      w,
+		LoadBalancing: lbPolicy,
 	}
 }
 
-func createWorkload(name, ip string, networkload workloadapi.NetworkMode, services ...string) *workloadapi.Workload {
+func createLocality(region, zone, subzone string) *workloadapi.Locality {
+	return &workloadapi.Locality{
+		Region:  region,
+		Zone:    zone,
+		Subzone: subzone,
+	}
+}
+
+func createWorkload(name, ip, nodeName string, networkload workloadapi.NetworkMode, locality *workloadapi.Locality, services ...string) *workloadapi.Workload {
 	workload := workloadapi.Workload{
 		Uid:               "cluster0//Pod/default/" + name,
+		Node:              nodeName,
 		Namespace:         "default",
 		Name:              name,
 		Addresses:         [][]byte{netip.MustParseAddr(ip).AsSlice()},
@@ -458,6 +476,7 @@ func createWorkload(name, ip string, networkload workloadapi.NetworkMode, servic
 		Status:            workloadapi.WorkloadStatus_HEALTHY,
 		ClusterId:         "cluster0",
 		NetworkMode:       networkload,
+		Locality:          locality,
 	}
 	workload.Services = make(map[string]*workloadapi.PortList, len(services))
 	for _, svc := range services {
@@ -491,9 +510,9 @@ func TestRestart(t *testing.T) {
 
 	// 1. First simulate normal start
 	// 1.1 add related service
-	svc1 := createFakeService("svc1", "10.240.10.1", "10.240.10.200")
-	svc2 := createFakeService("svc2", "10.240.10.2", "10.240.10.200")
-	svc3 := createFakeService("svc3", "10.240.10.3", "10.240.10.200")
+	svc1 := createFakeService("svc1", "10.240.10.1", "10.240.10.200", createLoadBalancing(workloadapi.LoadBalancing_UNSPECIFIED_MODE, make([]workloadapi.LoadBalancing_Scope, 0)))
+	svc2 := createFakeService("svc2", "10.240.10.2", "10.240.10.200", createLoadBalancing(workloadapi.LoadBalancing_UNSPECIFIED_MODE, make([]workloadapi.LoadBalancing_Scope, 0)))
+	svc3 := createFakeService("svc3", "10.240.10.3", "10.240.10.200", createLoadBalancing(workloadapi.LoadBalancing_UNSPECIFIED_MODE, make([]workloadapi.LoadBalancing_Scope, 0)))
 	for _, svc := range []*workloadapi.Service{svc1, svc2, svc3} {
 		addr := serviceToAddress(svc)
 		res.Resources = append(res.Resources, &service_discovery_v3.Resource{
@@ -502,9 +521,9 @@ func TestRestart(t *testing.T) {
 	}
 
 	// 1.2 add workload
-	wl1 := createWorkload("wl1", "10.244.0.1", workloadapi.NetworkMode_STANDARD, "svc1", "svc2")
-	wl2 := createWorkload("wl2", "10.244.0.2", workloadapi.NetworkMode_STANDARD, "svc2", "svc3")
-	wl3 := createWorkload("wl3", "10.244.0.3", workloadapi.NetworkMode_STANDARD, "svc3")
+	wl1 := createWorkload("wl1", "10.244.0.1", os.Getenv("NODE_NAME"), workloadapi.NetworkMode_STANDARD, createLocality("r1", "z1", "s1"), "svc1", "svc2")
+	wl2 := createWorkload("wl2", "10.244.0.2", os.Getenv("NODE_NAME"), workloadapi.NetworkMode_STANDARD, createLocality("r1", "z1", "s1"), "svc2", "svc3")
+	wl3 := createWorkload("wl3", "10.244.0.3", os.Getenv("NODE_NAME"), workloadapi.NetworkMode_STANDARD, createLocality("r1", "z1", "s1"), "svc3")
 	for _, wl := range []*workloadapi.Workload{wl1, wl2, wl3} {
 		addr := workloadToAddress(wl)
 		res.Resources = append(res.Resources, &service_discovery_v3.Resource{
@@ -525,9 +544,9 @@ func TestRestart(t *testing.T) {
 	assert.Equal(t, 6, p.bpf.FrontendCount())
 	// check service map
 	t.Log("1. check service map")
-	checkServiceMap(t, p, p.hashName.Hash(svc1.ResourceName()), svc1, bpfcache.MinPrio, 1)
-	checkServiceMap(t, p, p.hashName.Hash(svc2.ResourceName()), svc2, bpfcache.MinPrio, 2)
-	checkServiceMap(t, p, p.hashName.Hash(svc3.ResourceName()), svc3, bpfcache.MinPrio, 2)
+	checkServiceMap(t, p, p.hashName.Hash(svc1.ResourceName()), svc1, 0, 1)
+	checkServiceMap(t, p, p.hashName.Hash(svc2.ResourceName()), svc2, 0, 2)
+	checkServiceMap(t, p, p.hashName.Hash(svc3.ResourceName()), svc3, 0, 2)
 	assert.Equal(t, 3, p.bpf.ServiceCount())
 	// check endpoint map
 	t.Log("1. check endpoint map")
@@ -570,8 +589,8 @@ func TestRestart(t *testing.T) {
 		},
 	}
 
-	wl4 := createWorkload("wl4", "10.244.0.4", workloadapi.NetworkMode_STANDARD, "svc4")
-	svc4 := createFakeService("svc4", "10.240.10.4", "10.240.10.200")
+	wl4 := createWorkload("wl4", "10.244.0.4", os.Getenv("NODE_NAME"), workloadapi.NetworkMode_STANDARD, createLocality("r1", "z1", "s1"), "svc4")
+	svc4 := createFakeService("svc4", "10.240.10.4", "10.240.10.200", createLoadBalancing(workloadapi.LoadBalancing_UNSPECIFIED_MODE, make([]workloadapi.LoadBalancing_Scope, 0)))
 
 	res = &service_discovery_v3.DeltaDiscoveryResponse{}
 	// wl3 deleted during restart
@@ -603,10 +622,10 @@ func TestRestart(t *testing.T) {
 	assert.Equal(t, 7, p.bpf.FrontendCount())
 
 	// check service map
-	checkServiceMap(t, p, p.hashName.Hash(svc1.ResourceName()), svc1, bpfcache.MinPrio, 2) // svc1 has 2 wl1, wl2
-	checkServiceMap(t, p, p.hashName.Hash(svc2.ResourceName()), svc2, bpfcache.MinPrio, 1) // svc2 has 1  wl2
-	checkServiceMap(t, p, p.hashName.Hash(svc3.ResourceName()), svc3, bpfcache.MinPrio, 1) // svc3 has 1  wl2
-	checkServiceMap(t, p, p.hashName.Hash(svc4.ResourceName()), svc4, bpfcache.MinPrio, 1) // svc4 has 1  wl4
+	checkServiceMap(t, p, p.hashName.Hash(svc1.ResourceName()), svc1, 0, 2) // svc1 has 2 wl1, wl2
+	checkServiceMap(t, p, p.hashName.Hash(svc2.ResourceName()), svc2, 0, 1) // svc2 has 1  wl2
+	checkServiceMap(t, p, p.hashName.Hash(svc3.ResourceName()), svc3, 0, 1) // svc3 has 1  wl2
+	checkServiceMap(t, p, p.hashName.Hash(svc4.ResourceName()), svc4, 0, 1) // svc4 has 1  wl4
 	assert.Equal(t, 4, p.bpf.ServiceCount())
 	// check endpoint map
 	checkEndpointMap(t, p, svc1, []uint32{p.hashName.Hash(wl1.ResourceName()), p.hashName.Hash(wl2.ResourceName())})
@@ -653,4 +672,116 @@ func serviceToAddress(service *workloadapi.Service) *workloadapi.Address {
 			Service: service,
 		},
 	}
+}
+
+func TestLBPolicyUpdate(t *testing.T) {
+	workloadMap := bpfcache.NewFakeWorkloadMap(t)
+	defer bpfcache.CleanupFakeWorkloadMap(workloadMap)
+
+	p := NewProcessor(workloadMap)
+
+	res1 := &service_discovery_v3.DeltaDiscoveryResponse{}
+	res2 := &service_discovery_v3.DeltaDiscoveryResponse{}
+	res3 := &service_discovery_v3.DeltaDiscoveryResponse{}
+
+	// 1. First normal start
+	// 1.1 add related service
+	localityLBScope := make([]workloadapi.LoadBalancing_Scope, 0)
+	localityLBScope = append(localityLBScope, workloadapi.LoadBalancing_REGION)
+	localityLBScope = append(localityLBScope, workloadapi.LoadBalancing_ZONE)
+	localityLBScope = append(localityLBScope, workloadapi.LoadBalancing_SUBZONE)
+	localityLoadBlanacing := createLoadBalancing(workloadapi.LoadBalancing_UNSPECIFIED_MODE, localityLBScope)
+	randomLoadBlanacing := createLoadBalancing(workloadapi.LoadBalancing_UNSPECIFIED_MODE, make([]workloadapi.LoadBalancing_Scope, 0))
+	randomSvc := createFakeService("svc1", "10.240.10.1", "10.240.10.200", randomLoadBlanacing)
+	llbSvc := createFakeService("svc1", "10.240.10.1", "10.240.10.200", localityLoadBlanacing)
+
+	addr := serviceToAddress(randomSvc)
+	res1.Resources = append(res1.Resources, &service_discovery_v3.Resource{
+		Resource: protoconv.MessageToAny(addr),
+	})
+
+	// 1.2 add workload
+	// The nodeName of kmesh processor are set with os.Getenv("NODE_NAME"), same nodeName means workload and kmesh are belongs to one node, they have same Locality.
+	wl1 := createWorkload("wl1", "10.244.0.1", os.Getenv("NODE_NAME"), workloadapi.NetworkMode_STANDARD, createLocality("r1", "z1", "s1"), "svc1") // prio 0
+	wl2 := createWorkload("wl2", "10.244.0.2", "other", workloadapi.NetworkMode_STANDARD, createLocality("r1", "z1", "s2"), "svc1")                // prio 1
+	wl3 := createWorkload("wl3", "10.244.0.3", "other", workloadapi.NetworkMode_STANDARD, createLocality("r1", "z2", "s2"), "svc1")                // prio 2
+	wl4 := createWorkload("wl4", "10.244.0.4", "other", workloadapi.NetworkMode_STANDARD, createLocality("r2", "z2", "s2"), "svc1")                // prio 3
+	for _, wl := range []*workloadapi.Workload{wl1, wl2, wl3, wl4} {
+		addr := workloadToAddress(wl)
+		res1.Resources = append(res1.Resources, &service_discovery_v3.Resource{
+			Resource: protoconv.MessageToAny(addr),
+		})
+	}
+
+	err := p.handleAddressTypeResponse(res1)
+	assert.NoError(t, err)
+
+	// check front end map
+	for _, wl := range []*workloadapi.Workload{wl1, wl2, wl3, wl4} {
+		checkFrontEndMap(t, wl.Addresses[0], p)
+	}
+
+	checkFrontEndMap(t, randomSvc.Addresses[0].Address, p)
+
+	assert.Equal(t, 4, p.bpf.FrontendCount())
+	// check service map
+	t.Log("1. check service map")
+	checkServiceMap(t, p, p.hashName.Hash(randomSvc.ResourceName()), randomSvc, 0, 4)
+	checkServiceMap(t, p, p.hashName.Hash(randomSvc.ResourceName()), randomSvc, 1, 0)
+	checkServiceMap(t, p, p.hashName.Hash(randomSvc.ResourceName()), randomSvc, 2, 0)
+	checkServiceMap(t, p, p.hashName.Hash(randomSvc.ResourceName()), randomSvc, 3, 0)
+	assert.Equal(t, 1, p.bpf.ServiceCount())
+	// check endpoint map
+	t.Log("1. check endpoint map")
+	checkEndpointMap(t, p, randomSvc, []uint32{p.hashName.Hash(wl1.ResourceName()), p.hashName.Hash((wl2.ResourceName())), p.hashName.Hash((wl3.ResourceName())), p.hashName.Hash((wl4.ResourceName()))})
+	assert.Equal(t, 4, p.bpf.EndpointCount())
+	// check backend map
+	for _, wl := range []*workloadapi.Workload{wl1, wl2, wl3, wl4} {
+		checkBackendMap(t, p, p.hashName.Hash(wl.ResourceName()), wl)
+	}
+	assert.Equal(t, 4, p.bpf.BackendCount())
+
+	// 2. Locality Loadbalance Update from random to locality LB
+	addr = serviceToAddress(llbSvc)
+	res2.Resources = append(res2.Resources, &service_discovery_v3.Resource{
+		Resource: protoconv.MessageToAny(addr),
+	})
+
+	err = p.handleAddressTypeResponse(res2)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 4, p.bpf.FrontendCount())
+	// check service map
+	t.Log("2. check service map")
+	checkServiceMap(t, p, p.hashName.Hash(llbSvc.ResourceName()), llbSvc, 0, 1)
+	checkServiceMap(t, p, p.hashName.Hash(llbSvc.ResourceName()), llbSvc, 1, 1)
+	checkServiceMap(t, p, p.hashName.Hash(llbSvc.ResourceName()), llbSvc, 2, 1)
+	checkServiceMap(t, p, p.hashName.Hash(llbSvc.ResourceName()), llbSvc, 3, 1)
+	assert.Equal(t, 1, p.bpf.ServiceCount())
+	// check endpoint map
+	t.Log("2. check endpoint map")
+	checkEndpointMap(t, p, llbSvc, []uint32{p.hashName.Hash(wl1.ResourceName()), p.hashName.Hash((wl2.ResourceName())), p.hashName.Hash((wl3.ResourceName())), p.hashName.Hash((wl4.ResourceName()))})
+	assert.Equal(t, 4, p.bpf.EndpointCount())
+
+	// 3. Locality Loadbalance Update from random to locality LB
+	addr = serviceToAddress(randomSvc)
+	res3.Resources = append(res3.Resources, &service_discovery_v3.Resource{
+		Resource: protoconv.MessageToAny(addr),
+	})
+
+	err = p.handleAddressTypeResponse(res3)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 4, p.bpf.FrontendCount())
+	// check service map
+	t.Log("3. check service map")
+	checkServiceMap(t, p, p.hashName.Hash(randomSvc.ResourceName()), randomSvc, 0, 4)
+	checkServiceMap(t, p, p.hashName.Hash(randomSvc.ResourceName()), randomSvc, 1, 0)
+	checkServiceMap(t, p, p.hashName.Hash(randomSvc.ResourceName()), randomSvc, 2, 0)
+	checkServiceMap(t, p, p.hashName.Hash(randomSvc.ResourceName()), randomSvc, 3, 0)
+	assert.Equal(t, 1, p.bpf.ServiceCount())
+	// check endpoint map
+	t.Log("3. check endpoint map")
+	checkEndpointMap(t, p, randomSvc, []uint32{p.hashName.Hash(wl1.ResourceName()), p.hashName.Hash((wl2.ResourceName())), p.hashName.Hash((wl3.ResourceName())), p.hashName.Hash((wl4.ResourceName()))})
+	assert.Equal(t, 4, p.bpf.EndpointCount())
 }

--- a/pkg/controller/workload/workload_processor_test.go
+++ b/pkg/controller/workload/workload_processor_test.go
@@ -65,7 +65,7 @@ func Test_handleWorkload(t *testing.T) {
 	svcID := checkFrontEndMap(t, fakeSvc.Addresses[0].Address, p)
 
 	// 2.2 check service map contains service
-	checkServiceMap(t, p, svcID, fakeSvc, 1, bpfcache.MaxPrio)
+	checkServiceMap(t, p, svcID, fakeSvc, bpfcache.MaxPrio, 1)
 
 	// 2.3 check endpoint map now contains the workloads
 	ek.BackendIndex = 1
@@ -88,7 +88,7 @@ func Test_handleWorkload(t *testing.T) {
 	assert.Equal(t, ev.BackendUid, workload2ID)
 
 	// 3.2 check service map contains service
-	checkServiceMap(t, p, svcID, fakeSvc, 2, bpfcache.MaxPrio)
+	checkServiceMap(t, p, svcID, fakeSvc, bpfcache.MaxPrio, 2)
 
 	// 4 modify workload2 attribute not related with services
 	workload2.Waypoint = &workloadapi.GatewayAddress{
@@ -113,7 +113,7 @@ func Test_handleWorkload(t *testing.T) {
 	assert.Equal(t, ev.BackendUid, workload2ID)
 
 	// 4.2 check service map contains service
-	checkServiceMap(t, p, svcID, fakeSvc, 2, bpfcache.MaxPrio)
+	checkServiceMap(t, p, svcID, fakeSvc, bpfcache.MaxPrio, 2)
 
 	// 4.3 check backend map contains waypoint
 	checkBackendMap(t, p, workload2ID, workload2)
@@ -125,7 +125,7 @@ func Test_handleWorkload(t *testing.T) {
 	assert.NoError(t, err)
 
 	// 5.1 check service map
-	checkServiceMap(t, p, svcID, fakeSvc, 1, bpfcache.MaxPrio)
+	checkServiceMap(t, p, svcID, fakeSvc, bpfcache.MaxPrio, 1)
 
 	// 5.2 check endpoint map
 	ek.BackendIndex = 1
@@ -141,7 +141,7 @@ func Test_handleWorkload(t *testing.T) {
 	// 6.1 check front end map contains service
 	svcID = checkFrontEndMap(t, wpSvc.Addresses[0].Address, p)
 	// 6.2 check service map contains service, but no waypoint address
-	checkServiceMap(t, p, svcID, wpSvc, 0, bpfcache.MaxPrio)
+	checkServiceMap(t, p, svcID, wpSvc, bpfcache.MaxPrio, 0)
 
 	// 7. test add unhealthy workload
 	workload3 := createFakeWorkload("1.2.3.7", workloadapi.NetworkMode_STANDARD)
@@ -225,11 +225,11 @@ func checkWorkloadCache(t *testing.T, p *Processor, workload *workloadapi.Worklo
 	assert.NotNil(t, p.WorkloadCache.GetWorkloadByUid(workload.Uid))
 }
 
-func checkServiceMap(t *testing.T, p *Processor, svcId uint32, fakeSvc *workloadapi.Service, prio uint32, endpointCount uint32) {
+func checkServiceMap(t *testing.T, p *Processor, svcId uint32, fakeSvc *workloadapi.Service, priority uint32, endpointCount uint32) {
 	var sv bpfcache.ServiceValue
 	err := p.bpf.ServiceLookup(&bpfcache.ServiceKey{ServiceId: svcId}, &sv)
 	assert.NoError(t, err)
-	assert.Equal(t, endpointCount, sv.EndpointCount[prio])
+	assert.Equal(t, endpointCount, sv.EndpointCount[priority])
 	waypointAddr := fakeSvc.GetWaypoint().GetAddress().GetAddress()
 	if waypointAddr != nil {
 		assert.Equal(t, test.EqualIp(sv.WaypointAddr, waypointAddr), true)
@@ -525,9 +525,9 @@ func TestRestart(t *testing.T) {
 	assert.Equal(t, 6, p.bpf.FrontendCount())
 	// check service map
 	t.Log("1. check service map")
-	checkServiceMap(t, p, p.hashName.Hash(svc1.ResourceName()), svc1, 1)
-	checkServiceMap(t, p, p.hashName.Hash(svc2.ResourceName()), svc2, 2)
-	checkServiceMap(t, p, p.hashName.Hash(svc3.ResourceName()), svc3, 2)
+	checkServiceMap(t, p, p.hashName.Hash(svc1.ResourceName()), svc1, bpfcache.MaxPrio, 1)
+	checkServiceMap(t, p, p.hashName.Hash(svc2.ResourceName()), svc2, bpfcache.MaxPrio, 2)
+	checkServiceMap(t, p, p.hashName.Hash(svc3.ResourceName()), svc3, bpfcache.MaxPrio, 2)
 	assert.Equal(t, 3, p.bpf.ServiceCount())
 	// check endpoint map
 	t.Log("1. check endpoint map")
@@ -603,10 +603,10 @@ func TestRestart(t *testing.T) {
 	assert.Equal(t, 7, p.bpf.FrontendCount())
 
 	// check service map
-	checkServiceMap(t, p, p.hashName.Hash(svc1.ResourceName()), svc1, 2, bpfcache.MaxPrio) // svc1 has 2 wl1, wl2
-	checkServiceMap(t, p, p.hashName.Hash(svc2.ResourceName()), svc2, 1, bpfcache.MaxPrio) // svc2 has 1  wl2
-	checkServiceMap(t, p, p.hashName.Hash(svc3.ResourceName()), svc3, 1, bpfcache.MaxPrio) // svc3 has 1  wl2
-	checkServiceMap(t, p, p.hashName.Hash(svc4.ResourceName()), svc4, 1, bpfcache.MaxPrio) // svc4 has 1  wl4
+	checkServiceMap(t, p, p.hashName.Hash(svc1.ResourceName()), svc1, bpfcache.MaxPrio, 2) // svc1 has 2 wl1, wl2
+	checkServiceMap(t, p, p.hashName.Hash(svc2.ResourceName()), svc2, bpfcache.MaxPrio, 1) // svc2 has 1  wl2
+	checkServiceMap(t, p, p.hashName.Hash(svc3.ResourceName()), svc3, bpfcache.MaxPrio, 1) // svc3 has 1  wl2
+	checkServiceMap(t, p, p.hashName.Hash(svc4.ResourceName()), svc4, bpfcache.MaxPrio, 1) // svc4 has 1  wl4
 	assert.Equal(t, 4, p.bpf.ServiceCount())
 	// check endpoint map
 	checkEndpointMap(t, p, svc1, []uint32{p.hashName.Hash(wl1.ResourceName()), p.hashName.Hash(wl2.ResourceName())})

--- a/pkg/controller/workload/workload_processor_test.go
+++ b/pkg/controller/workload/workload_processor_test.go
@@ -65,7 +65,7 @@ func Test_handleWorkload(t *testing.T) {
 	svcID := checkFrontEndMap(t, fakeSvc.Addresses[0].Address, p)
 
 	// 2.2 check service map contains service
-	checkServiceMap(t, p, svcID, fakeSvc, 1)
+	checkServiceMap(t, p, svcID, fakeSvc, 1, bpfcache.MaxPrio)
 
 	// 2.3 check endpoint map now contains the workloads
 	ek.BackendIndex = 1
@@ -88,7 +88,7 @@ func Test_handleWorkload(t *testing.T) {
 	assert.Equal(t, ev.BackendUid, workload2ID)
 
 	// 3.2 check service map contains service
-	checkServiceMap(t, p, svcID, fakeSvc, 2)
+	checkServiceMap(t, p, svcID, fakeSvc, 2, bpfcache.MaxPrio)
 
 	// 4 modify workload2 attribute not related with services
 	workload2.Waypoint = &workloadapi.GatewayAddress{
@@ -113,7 +113,7 @@ func Test_handleWorkload(t *testing.T) {
 	assert.Equal(t, ev.BackendUid, workload2ID)
 
 	// 4.2 check service map contains service
-	checkServiceMap(t, p, svcID, fakeSvc, 2)
+	checkServiceMap(t, p, svcID, fakeSvc, 2, bpfcache.MaxPrio)
 
 	// 4.3 check backend map contains waypoint
 	checkBackendMap(t, p, workload2ID, workload2)
@@ -125,7 +125,7 @@ func Test_handleWorkload(t *testing.T) {
 	assert.NoError(t, err)
 
 	// 5.1 check service map
-	checkServiceMap(t, p, svcID, fakeSvc, 1)
+	checkServiceMap(t, p, svcID, fakeSvc, 1, bpfcache.MaxPrio)
 
 	// 5.2 check endpoint map
 	ek.BackendIndex = 1
@@ -141,7 +141,7 @@ func Test_handleWorkload(t *testing.T) {
 	// 6.1 check front end map contains service
 	svcID = checkFrontEndMap(t, wpSvc.Addresses[0].Address, p)
 	// 6.2 check service map contains service, but no waypoint address
-	checkServiceMap(t, p, svcID, wpSvc, 0)
+	checkServiceMap(t, p, svcID, wpSvc, 0, bpfcache.MaxPrio)
 
 	// 7. test add unhealthy workload
 	workload3 := createFakeWorkload("1.2.3.7", workloadapi.NetworkMode_STANDARD)
@@ -225,11 +225,11 @@ func checkWorkloadCache(t *testing.T, p *Processor, workload *workloadapi.Worklo
 	assert.NotNil(t, p.WorkloadCache.GetWorkloadByUid(workload.Uid))
 }
 
-func checkServiceMap(t *testing.T, p *Processor, svcId uint32, fakeSvc *workloadapi.Service, endpointCount uint32) {
+func checkServiceMap(t *testing.T, p *Processor, svcId uint32, fakeSvc *workloadapi.Service, prio uint32, endpointCount uint32) {
 	var sv bpfcache.ServiceValue
 	err := p.bpf.ServiceLookup(&bpfcache.ServiceKey{ServiceId: svcId}, &sv)
 	assert.NoError(t, err)
-	assert.Equal(t, endpointCount, sv.EndpointCount)
+	assert.Equal(t, endpointCount, sv.EndpointCount[prio])
 	waypointAddr := fakeSvc.GetWaypoint().GetAddress().GetAddress()
 	if waypointAddr != nil {
 		assert.Equal(t, test.EqualIp(sv.WaypointAddr, waypointAddr), true)
@@ -603,10 +603,10 @@ func TestRestart(t *testing.T) {
 	assert.Equal(t, 7, p.bpf.FrontendCount())
 
 	// check service map
-	checkServiceMap(t, p, p.hashName.Hash(svc1.ResourceName()), svc1, 2) // svc1 has 2 wl1, wl2
-	checkServiceMap(t, p, p.hashName.Hash(svc2.ResourceName()), svc2, 1) // svc2 has 1  wl2
-	checkServiceMap(t, p, p.hashName.Hash(svc3.ResourceName()), svc3, 1) // svc3 has 1  wl2
-	checkServiceMap(t, p, p.hashName.Hash(svc4.ResourceName()), svc4, 1) // svc4 has 1  wl4
+	checkServiceMap(t, p, p.hashName.Hash(svc1.ResourceName()), svc1, 2, bpfcache.MaxPrio) // svc1 has 2 wl1, wl2
+	checkServiceMap(t, p, p.hashName.Hash(svc2.ResourceName()), svc2, 1, bpfcache.MaxPrio) // svc2 has 1  wl2
+	checkServiceMap(t, p, p.hashName.Hash(svc3.ResourceName()), svc3, 1, bpfcache.MaxPrio) // svc3 has 1  wl2
+	checkServiceMap(t, p, p.hashName.Hash(svc4.ResourceName()), svc4, 1, bpfcache.MaxPrio) // svc4 has 1  wl4
 	assert.Equal(t, 4, p.bpf.ServiceCount())
 	// check endpoint map
 	checkEndpointMap(t, p, svc1, []uint32{p.hashName.Hash(wl1.ResourceName()), p.hashName.Hash(wl2.ResourceName())})

--- a/pkg/controller/workload/workload_processor_test.go
+++ b/pkg/controller/workload/workload_processor_test.go
@@ -65,7 +65,7 @@ func Test_handleWorkload(t *testing.T) {
 	svcID := checkFrontEndMap(t, fakeSvc.Addresses[0].Address, p)
 
 	// 2.2 check service map contains service
-	checkServiceMap(t, p, svcID, fakeSvc, bpfcache.MaxPrio, 1)
+	checkServiceMap(t, p, svcID, fakeSvc, bpfcache.MinPrio, 1)
 
 	// 2.3 check endpoint map now contains the workloads
 	ek.BackendIndex = 1
@@ -88,7 +88,7 @@ func Test_handleWorkload(t *testing.T) {
 	assert.Equal(t, ev.BackendUid, workload2ID)
 
 	// 3.2 check service map contains service
-	checkServiceMap(t, p, svcID, fakeSvc, bpfcache.MaxPrio, 2)
+	checkServiceMap(t, p, svcID, fakeSvc, bpfcache.MinPrio, 2)
 
 	// 4 modify workload2 attribute not related with services
 	workload2.Waypoint = &workloadapi.GatewayAddress{
@@ -113,7 +113,7 @@ func Test_handleWorkload(t *testing.T) {
 	assert.Equal(t, ev.BackendUid, workload2ID)
 
 	// 4.2 check service map contains service
-	checkServiceMap(t, p, svcID, fakeSvc, bpfcache.MaxPrio, 2)
+	checkServiceMap(t, p, svcID, fakeSvc, bpfcache.MinPrio, 2)
 
 	// 4.3 check backend map contains waypoint
 	checkBackendMap(t, p, workload2ID, workload2)
@@ -125,7 +125,7 @@ func Test_handleWorkload(t *testing.T) {
 	assert.NoError(t, err)
 
 	// 5.1 check service map
-	checkServiceMap(t, p, svcID, fakeSvc, bpfcache.MaxPrio, 1)
+	checkServiceMap(t, p, svcID, fakeSvc, bpfcache.MinPrio, 1)
 
 	// 5.2 check endpoint map
 	ek.BackendIndex = 1
@@ -141,7 +141,7 @@ func Test_handleWorkload(t *testing.T) {
 	// 6.1 check front end map contains service
 	svcID = checkFrontEndMap(t, wpSvc.Addresses[0].Address, p)
 	// 6.2 check service map contains service, but no waypoint address
-	checkServiceMap(t, p, svcID, wpSvc, bpfcache.MaxPrio, 0)
+	checkServiceMap(t, p, svcID, wpSvc, bpfcache.MinPrio, 0)
 
 	// 7. test add unhealthy workload
 	workload3 := createFakeWorkload("1.2.3.7", workloadapi.NetworkMode_STANDARD)
@@ -525,9 +525,9 @@ func TestRestart(t *testing.T) {
 	assert.Equal(t, 6, p.bpf.FrontendCount())
 	// check service map
 	t.Log("1. check service map")
-	checkServiceMap(t, p, p.hashName.Hash(svc1.ResourceName()), svc1, bpfcache.MaxPrio, 1)
-	checkServiceMap(t, p, p.hashName.Hash(svc2.ResourceName()), svc2, bpfcache.MaxPrio, 2)
-	checkServiceMap(t, p, p.hashName.Hash(svc3.ResourceName()), svc3, bpfcache.MaxPrio, 2)
+	checkServiceMap(t, p, p.hashName.Hash(svc1.ResourceName()), svc1, bpfcache.MinPrio, 1)
+	checkServiceMap(t, p, p.hashName.Hash(svc2.ResourceName()), svc2, bpfcache.MinPrio, 2)
+	checkServiceMap(t, p, p.hashName.Hash(svc3.ResourceName()), svc3, bpfcache.MinPrio, 2)
 	assert.Equal(t, 3, p.bpf.ServiceCount())
 	// check endpoint map
 	t.Log("1. check endpoint map")
@@ -603,10 +603,10 @@ func TestRestart(t *testing.T) {
 	assert.Equal(t, 7, p.bpf.FrontendCount())
 
 	// check service map
-	checkServiceMap(t, p, p.hashName.Hash(svc1.ResourceName()), svc1, bpfcache.MaxPrio, 2) // svc1 has 2 wl1, wl2
-	checkServiceMap(t, p, p.hashName.Hash(svc2.ResourceName()), svc2, bpfcache.MaxPrio, 1) // svc2 has 1  wl2
-	checkServiceMap(t, p, p.hashName.Hash(svc3.ResourceName()), svc3, bpfcache.MaxPrio, 1) // svc3 has 1  wl2
-	checkServiceMap(t, p, p.hashName.Hash(svc4.ResourceName()), svc4, bpfcache.MaxPrio, 1) // svc4 has 1  wl4
+	checkServiceMap(t, p, p.hashName.Hash(svc1.ResourceName()), svc1, bpfcache.MinPrio, 2) // svc1 has 2 wl1, wl2
+	checkServiceMap(t, p, p.hashName.Hash(svc2.ResourceName()), svc2, bpfcache.MinPrio, 1) // svc2 has 1  wl2
+	checkServiceMap(t, p, p.hashName.Hash(svc3.ResourceName()), svc3, bpfcache.MinPrio, 1) // svc3 has 1  wl2
+	checkServiceMap(t, p, p.hashName.Hash(svc4.ResourceName()), svc4, bpfcache.MinPrio, 1) // svc4 has 1  wl4
 	assert.Equal(t, 4, p.bpf.ServiceCount())
 	// check endpoint map
 	checkEndpointMap(t, p, svc1, []uint32{p.hashName.Hash(wl1.ResourceName()), p.hashName.Hash(wl2.ResourceName())})

--- a/pkg/controller/workload/workload_processor_test.go
+++ b/pkg/controller/workload/workload_processor_test.go
@@ -684,18 +684,19 @@ func TestCalcuLocalityLbPrio(t *testing.T) {
 	localityLBScope = append(localityLBScope, workloadapi.LoadBalancing_REGION)
 	localityLBScope = append(localityLBScope, workloadapi.LoadBalancing_ZONE)
 	localityLBScope = append(localityLBScope, workloadapi.LoadBalancing_SUBZONE)
+	localityLoadBlanacing := createLoadBalancing(workloadapi.LoadBalancing_FAILOVER, localityLBScope)
+	llbSvc := createFakeService("svc1", "10.240.10.1", "10.240.10.200", localityLoadBlanacing)
 
 	p.locality.SetLocality(os.Getenv("NODE_NAME"), "", "", createLocality("r1", "z1", "s1"))
-	p.locality.SetRoutingPreference(localityLBScope)
 
 	wl1 := createWorkload("wl1", "10.244.0.1", os.Getenv("NODE_NAME"), workloadapi.NetworkMode_STANDARD, createLocality("r1", "z1", "s1"), "svc1") // prio 0
 	wl2 := createWorkload("wl2", "10.244.0.2", os.Getenv("NODE_NAME"), workloadapi.NetworkMode_STANDARD, createLocality("r1", "z1", "s2"), "svc1") // prio 1
 	wl3 := createWorkload("wl3", "10.244.0.3", os.Getenv("NODE_NAME"), workloadapi.NetworkMode_STANDARD, createLocality("r1", "z2", "s2"), "svc1") // prio 2
 	wl4 := createWorkload("wl4", "10.244.0.4", os.Getenv("NODE_NAME"), workloadapi.NetworkMode_STANDARD, createLocality("r2", "z2", "s2"), "svc1") // prio 3
-	assert.Equal(t, uint32(0), p.locality.CalcuLocalityLBPrio(wl1))
-	assert.Equal(t, uint32(1), p.locality.CalcuLocalityLBPrio(wl2))
-	assert.Equal(t, uint32(2), p.locality.CalcuLocalityLBPrio(wl3))
-	assert.Equal(t, uint32(3), p.locality.CalcuLocalityLBPrio(wl4))
+	assert.Equal(t, uint32(0), p.locality.CalcuLocalityLBPrio(wl1, llbSvc.GetLoadBalancing().GetRoutingPreference()))
+	assert.Equal(t, uint32(1), p.locality.CalcuLocalityLBPrio(wl2, llbSvc.GetLoadBalancing().GetRoutingPreference()))
+	assert.Equal(t, uint32(2), p.locality.CalcuLocalityLBPrio(wl3, llbSvc.GetLoadBalancing().GetRoutingPreference()))
+	assert.Equal(t, uint32(3), p.locality.CalcuLocalityLBPrio(wl4, llbSvc.GetLoadBalancing().GetRoutingPreference()))
 
 	hashNameClean(p)
 }

--- a/pkg/status/status_server_test.go
+++ b/pkg/status/status_server_test.go
@@ -388,7 +388,7 @@ func TestServer_dumpWorkloadBpfMap(t *testing.T) {
 			{ServiceId: 1}, {ServiceId: 2},
 		}
 		testServiceVals := []bpfcache.ServiceValue{
-			{EndpointCount: 1234}, {EndpointCount: 5678},
+			{EndpointCount: [7]uint32{1234, 1234, 1234, 1234, 1234, 1234, 1234}}, {EndpointCount: [7]uint32{5678, 5678, 5678, 5678, 5678, 5678, 5678}},
 		}
 		_, err = bpfMaps.KmeshService.BatchUpdate(testServiceKeys, testServiceVals, nil)
 		assert.Nil(t, err)


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

~This PR is not ready to be merged; some features are not working properly.~
~1. The priority of the service Pod written to the BPF map is observed to be correct in user space, but the behavior of locality load balancing in kernel space is random. (This issue does not exist in the test version of the code at [this link](https://github.com/derekwin/kmesh/tree/lb-dev-user-bak).)~
~2. The code for the workload has undergone significant changes in the past one to two months. The current PR's code attempts to adapt to the new logic of the workload as much as possible. However, a lot of redundant deletion behaviors have been observed. These parts of the code need to be optimized in conjunction with the existing workload logic.~

This pr is ok.

But i find a bug in new version kubectl and istio work with kmesh(https://github.com/kmesh-net/kmesh/issues/910).
> this pr's enhancement need new version kubectl and istio.