### PR TITLE
Enhanced kernel: Build 2 series of eBPF objects(kernel ver. <5.13 & >=5.13) and load eBPF dynamically when Kmesh starts up

### DIFF
--- a/pkg/bpf/bpf_kmesh.go
+++ b/pkg/bpf/bpf_kmesh.go
@@ -33,6 +33,7 @@ import (
 
 	"kmesh.net/kmesh/bpf/kmesh/bpf2go"
 	"kmesh.net/kmesh/daemon/options"
+	"kmesh.net/kmesh/pkg/utils"
 )
 
 type BpfTracePoint struct {
@@ -103,7 +104,11 @@ func (sc *BpfTracePoint) loadKmeshTracePointObjects() (*ebpf.CollectionSpec, err
 		opts ebpf.CollectionOptions
 	)
 
-	spec, err = bpf2go.LoadKmeshTracePoint()
+	if utils.KernelVersionLowerThan5_13() {
+		spec, err = bpf2go.LoadKmeshTracePointCompat()
+	} else {
+		spec, err = bpf2go.LoadKmeshTracePoint()
+	}
 	if err != nil || spec == nil {
 		return nil, err
 	}
@@ -137,7 +142,11 @@ func (sc *BpfSockOps) loadKmeshSockopsObjects() (*ebpf.CollectionSpec, error) {
 
 	opts.Maps.PinPath = sc.Info.MapPath
 
-	spec, err = bpf2go.LoadKmeshSockops()
+	if utils.KernelVersionLowerThan5_13() {
+		spec, err = bpf2go.LoadKmeshSockopsCompat()
+	} else {
+		spec, err = bpf2go.LoadKmeshSockops()
+	}
 
 	if err != nil || spec == nil {
 		return nil, err


### PR DESCRIPTION
Enhanced kernel: Build 2 series of eBPF objects(kernel ver. <5.13 & >=5.13) and load eBPF dynamically when Kmesh starts up

**What type of PR is this?**
/kind enhancement
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
