### PR TITLE
fix format error of `kmeshctl waypoint status --help`

### DIFF
--- a/ctl/waypoint/waypoint.go
+++ b/ctl/waypoint/waypoint.go
@@ -310,7 +310,7 @@ func NewCmd() *cobra.Command {
   kmeshctl waypoint status
 
   # Show the status of the waypoint in a specific namespace
-  kmeshctl waypoint status --namespace default`,
+  kmeshctl waypoint status --namespace foo`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				return fmt.Errorf("unknown subcommand %q", args[0])

--- a/ctl/waypoint/waypoint.go
+++ b/ctl/waypoint/waypoint.go
@@ -307,10 +307,10 @@ func NewCmd() *cobra.Command {
 		Short: "Show the status of waypoints in a namespace",
 		Long:  "Show the status of waypoints for the namespace provided or default namespace if none is provided",
 		Example: `  # Show the status of the waypoint in the default namespace
-		 kmeshctl waypoint status
-		  
-		 # Show the status of the waypoint in a specific namespace
-  		 kmeshctl waypoint status --namespace default`,
+  kmeshctl waypoint status
+
+  # Show the status of the waypoint in a specific namespace
+  kmeshctl waypoint status --namespace default`,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 0 {
 				return fmt.Errorf("unknown subcommand %q", args[0])


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Before this fix:

```bash
root@dev:~/kmesh# kmeshctl waypoint status --help
Show the status of waypoints for the namespace provided or default namespace if none is provided

Usage:
  kmeshctl waypoint status [flags]

Examples:
  # Show the status of the waypoint in the default namespace
                 kmeshctl waypoint status
                  
                 # Show the status of the waypoint in a specific namespace
                 kmeshctl waypoint status --namespace default

Flags:
  -h, --help   help for status
```

After this fix:

```bash
root@dev:~/kmesh# ./kmeshctl waypoint status --help
Show the status of waypoints for the namespace provided or default namespace if none is provided

Usage:
  kmeshctl waypoint status [flags]

Examples:
  # Show the status of the waypoint in the default namespace
  kmeshctl waypoint status

  # Show the status of the waypoint in a specific namespace
  kmeshctl waypoint status --namespace default

Flags:
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
