### PR TITLE
fix cannot get RDS after grpc reconnect

### DIFF
--- a/pkg/controller/ads/ads_controller.go
+++ b/pkg/controller/ads/ads_controller.go
@@ -64,7 +64,7 @@ func (c *Controller) AdsStreamCreateAndSend(client service_discovery_v3.Aggregat
 		stopCh:       make(chan struct{}),
 	}
 
-	c.Processor = newProcessor()
+	c.Processor.Reset()
 	if err := stream.Send(newAdsRequest(resource_v3.ClusterType, nil, "")); err != nil {
 		return fmt.Errorf("send request failed, %s", err)
 	}

--- a/pkg/controller/ads/ads_controller.go
+++ b/pkg/controller/ads/ads_controller.go
@@ -64,7 +64,7 @@ func (c *Controller) AdsStreamCreateAndSend(client service_discovery_v3.Aggregat
 		stopCh:       make(chan struct{}),
 	}
 
-	c.Processor.Reset()
+	c.Processor = newProcessor()
 	if err := stream.Send(newAdsRequest(resource_v3.ClusterType, nil, "")); err != nil {
 		return fmt.Errorf("send request failed, %s", err)
 	}

--- a/pkg/controller/ads/ads_processor.go
+++ b/pkg/controller/ads/ads_processor.go
@@ -320,6 +320,7 @@ func (p *processor) Reset() {
 		return
 	}
 	p.lastNonce = &lastNonce{}
+	p.Cache = NewAdsCache()
 }
 
 func ConfigResourcesIsEmpty(resources *admin_v2.ConfigResources) bool {

--- a/pkg/controller/ads/ads_processor.go
+++ b/pkg/controller/ads/ads_processor.go
@@ -320,7 +320,8 @@ func (p *processor) Reset() {
 		return
 	}
 	p.lastNonce = &lastNonce{}
-	p.Cache = NewAdsCache()
+	p.Cache.routeNames = nil
+	p.Cache.edsClusterNames = nil
 }
 
 func ConfigResourcesIsEmpty(resources *admin_v2.ConfigResources) bool {

--- a/pkg/controller/ads/ads_processor.go
+++ b/pkg/controller/ads/ads_processor.go
@@ -184,12 +184,6 @@ func (p *processor) handleCdsResponse(resp *service_discovery_v3.DiscoveryRespon
 	// Note eds typed cluster, we do not flush to bpf map here, we need to wait for eds update.
 	p.Cache.ClusterCache.Flush()
 
-	if p.lastNonce.edsNonce == "" {
-		// initial subscribe to eds
-		p.req = newAdsRequest(resource_v3.EndpointType, p.Cache.edsClusterNames, "")
-		return nil
-	}
-
 	// when the list of eds typed clusters subscribed changed, we should resubscrbe to new eds.
 	if !slices.EqualUnordered(p.Cache.edsClusterNames, lastEdsClusterNames) {
 		// we cannot set the nonce here.

--- a/pkg/controller/ads/ads_processor_test.go
+++ b/pkg/controller/ads/ads_processor_test.go
@@ -101,7 +101,7 @@ func TestHandleCdsResponse(t *testing.T) {
 		wantHash := hash.Sum64String(anyCluster.String())
 		actualHash := p.Cache.ClusterCache.GetCdsHash(cluster.GetName())
 		assert.Equal(t, wantHash, actualHash)
-		assert.NotNil(t, p.req)
+		assert.Nil(t, p.req)
 		// dns cluster is waiting
 		assert.Equal(t, p.Cache.ClusterCache.GetApiCluster(cluster.Name).ApiStatus, core_v2.ApiStatus_WAITING)
 	})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
fix cannot get RDS after grpc reconnect
after grpc reconnect,we did not clear the cache, and we forget to compare lastNonce in RDS,  so the judgment logic in the subsequent process believes that RDS does not need to be updated. 
**Which issue(s) this PR fixes**:
Fixes #964 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
