### PR TITLE
feat: reduce binary size of kmeshctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ include ./mk/bpf.print.mk
 CC=clang
 CXX=clang++
 GOFLAGS := $(EXTRA_GOFLAGS)
+GOGCFLAGS := ""
+GOLDFLAGS := ""
 EXTLDFLAGS := '-fPIE -pie -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack'
 LDFLAGS := "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy=warn \
 			-X kmesh.net/kmesh/pkg/version.gitVersion=$(VERSION) \
@@ -47,6 +49,16 @@ GOLDFLAGS := "-X google.golang.org/protobuf/reflect/protoregistry.conflictPolicy
 			-X kmesh.net/kmesh/pkg/version.gitTreeState=$(GIT_TREESTATE) \
 			-X kmesh.net/kmesh/pkg/version.buildDate=$(BUILD_DATE) \
 			-extldflags '-static'"
+
+# Debug flags
+ifeq ($(DEBUG),1)
+	# Debugging - disable optimizations and inlining
+	GOGCFLAGS := "all=-N -l"
+else
+	# Release build - disable symbols and DWARF, trim embedded paths
+	GOLDFLAGS := '-s -w'
+	GOFLAGS += -trimpath
+endif
 
 # target
 APPS1 := kmesh-daemon
@@ -116,7 +128,7 @@ OUT ?= kmeshctl
 kmeshctl:
 	$(call printlog, BUILD, $(APPS4))
 	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-		$(GO) build -o $(OUT) $(GOFLAGS) ./ctl/main.go)
+		CGO_ENABLED=0 $(GO) build -gcflags $(GOGCFLAGS) -ldflags $(GOLDFLAGS) -o $(OUT) $(GOFLAGS) ./ctl/main.go)
 
 .PHONY: gen-proto
 gen-proto:

--- a/ctl/accesslog/accesslog.go
+++ b/ctl/accesslog/accesslog.go
@@ -23,9 +23,9 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"istio.io/istio/pkg/kube"
 
 	"kmesh.net/kmesh/ctl/utils"
+	"kmesh.net/kmesh/pkg/kube"
 	"kmesh.net/kmesh/pkg/logger"
 )
 

--- a/ctl/utils/utils.go
+++ b/ctl/utils/utils.go
@@ -19,7 +19,7 @@ package utils
 import (
 	"fmt"
 
-	"istio.io/istio/pkg/kube"
+	"kmesh.net/kmesh/pkg/kube"
 )
 
 const (
@@ -29,12 +29,7 @@ const (
 )
 
 func CreateKubeClient() (kube.CLIClient, error) {
-	rc, err := kube.DefaultRestConfig("", "")
-	if err != nil {
-		return nil, fmt.Errorf("failed to get rest.Config for given kube config file and context: %v", err)
-	}
-
-	cli, err := kube.NewCLIClient(kube.NewClientConfigForRestConfig(rc))
+	cli, err := kube.NewCLIClient()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kube client: %v", err)
 	}
@@ -42,7 +37,7 @@ func CreateKubeClient() (kube.CLIClient, error) {
 	return cli, nil
 }
 
-// Create a new PortForwarder configured for the given Kmesh daemon pod.
+// CreateKmeshPortForwarder Create a new PortForwarder configured for the given Kmesh daemon pod.
 func CreateKmeshPortForwarder(cliClient kube.CLIClient, podName string) (kube.PortForwarder, error) {
 	fw, err := cliClient.NewPortForwarder(podName, KmeshNamespace, "", 0, KmeshAdminPort)
 	if err != nil {

--- a/ctl/waypoint/waypoint.go
+++ b/ctl/waypoint/waypoint.go
@@ -37,7 +37,7 @@ import (
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
-	"istio.io/istio/pkg/kube"
+
 	"istio.io/istio/pkg/util/sets"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -46,6 +46,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"kmesh.net/kmesh/ctl/utils"
+	"kmesh.net/kmesh/pkg/kube"
 	"kmesh.net/kmesh/pkg/version"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,10 @@ require (
 	istio.io/pkg v0.0.0-20231221211216-7635388a563e
 	k8s.io/api v0.31.2
 	k8s.io/apimachinery v0.31.2
+	k8s.io/cli-runtime v0.31.2
 	k8s.io/client-go v0.31.2
+	k8s.io/kubectl v0.31.2
+	k8s.io/utils v0.0.0-20240921022957-49e7df575cb6
 	sigs.k8s.io/gateway-api v1.2.0
 	sigs.k8s.io/yaml v1.4.0
 )
@@ -224,12 +227,9 @@ require (
 	istio.io/client-go v1.24.0-alpha.0.0.20241028180353-8402bc51af81 // indirect
 	k8s.io/apiextensions-apiserver v0.31.2 // indirect
 	k8s.io/apiserver v0.31.2 // indirect
-	k8s.io/cli-runtime v0.31.2 // indirect
 	k8s.io/component-base v0.31.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240423202451-8948a665c108 // indirect
-	k8s.io/kubectl v0.31.2 // indirect
-	k8s.io/utils v0.0.0-20240921022957-49e7df575cb6 // indirect
 	sigs.k8s.io/controller-runtime v0.19.1 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/kustomize/api v0.17.2 // indirect

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -1,0 +1,160 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kube
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+	gatewayapiclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+)
+
+const (
+	DefaultLocalAddress      = "localhost"
+	DefaultPodRunningTimeout = 30 * time.Second
+	KmeshNamespace           = "kmesh-system"
+)
+
+// Client defines the interface for accessing Kubernetes clients and resources.
+type Client interface {
+	// Kube returns the core kube client
+	Kube() kubernetes.Interface
+
+	// GatewayAPI returns the gateway-api kube client.
+	GatewayAPI() gatewayapiclient.Interface
+}
+
+// CLIClient extends the Client interface with additional functionality for CLI operations.
+type CLIClient interface {
+	Client
+
+	// PodsForSelector finds pods matching selector.
+	PodsForSelector(ctx context.Context, namespace string, labelSelectors ...string) (*v1.PodList, error)
+
+	// NewPortForwarder creates a new PortForwarder configured for the given pod. If localPort=0, a port will be
+	// dynamically selected. If localAddress is empty, "localhost" is used.
+	NewPortForwarder(podName string, ns string, localAddress string, localPort int, podPort int) (PortForwarder, error)
+}
+
+func NewCLIClient(opts ...ClientOption) (CLIClient, error) {
+	return newClientInternal(opts...)
+}
+
+type ClientOption func(CLIClient) CLIClient
+
+type client struct {
+	config *rest.Config
+
+	kube          kubernetes.Interface
+	gatewayapi    gatewayapiclient.Interface
+	clientFactory *genericclioptions.ConfigFlags
+}
+
+func (c *client) NewPortForwarder(podName string, ns string, localAddress string, localPort int, podPort int) (PortForwarder, error) {
+	return newPortForwarder(c, podName, ns, localAddress, localPort, podPort)
+}
+
+func newPortForwarder(cliClient *client, podName string, ns string, localAddress string, localPort int, podPort int) (PortForwarder, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	if localAddress == "" {
+		localAddress = DefaultLocalAddress
+	}
+
+	if localPort == 0 {
+		var err error
+		localPort, err = getAvailablePort()
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("failed to find an available port: %v", err)
+		}
+	}
+
+	cmd := &cobra.Command{}
+	cmd.Flags().Duration("pod-running-timeout", DefaultPodRunningTimeout, "Timeout for waiting for pod to be running")
+	cmd.Flags().String("namespace", KmeshNamespace, "Specify the namespace to use")
+	cmd.Flags().StringSlice("address", []string{DefaultLocalAddress}, "Specify the addresses to bind")
+	return &portForwarder{
+		cmd:              cmd,
+		RESTClientGetter: cliClient.clientFactory,
+		ctx:              ctx,
+		cancel:           cancel,
+		podName:          podName,
+		ns:               ns,
+		localAddress:     localAddress,
+		localPort:        localPort,
+		podPort:          podPort,
+		errCh:            make(chan error, 1),
+	}, nil
+}
+
+func newClientInternal(opts ...ClientOption) (*client, error) {
+	var c client
+	var err error
+
+	// Initialize config flags with namespace
+	configFlags := genericclioptions.NewConfigFlags(true).
+		WithDeprecatedPasswordFlag().
+		WithDiscoveryBurst(300).
+		WithDiscoveryQPS(50.0)
+	configFlags.Namespace = ptr.To(KmeshNamespace)
+	c.clientFactory = configFlags
+
+	c.config, err = configFlags.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, opt := range opts {
+		opt(&c)
+	}
+
+	c.kube, err = kubernetes.NewForConfig(c.config)
+	if err != nil {
+		return nil, err
+	}
+
+	c.gatewayapi, err = gatewayapiclient.NewForConfig(c.config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &c, nil
+}
+
+func (c *client) Kube() kubernetes.Interface {
+	return c.kube
+}
+
+func (c *client) GatewayAPI() gatewayapiclient.Interface {
+	return c.gatewayapi
+}
+
+func (c *client) PodsForSelector(ctx context.Context, namespace string, labelSelectors ...string) (*v1.PodList, error) {
+	return c.kube.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: strings.Join(labelSelectors, ","),
+	})
+}

--- a/pkg/kube/portforwarder.go
+++ b/pkg/kube/portforwarder.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kube
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/genericiooptions"
+	"k8s.io/kubectl/pkg/cmd/portforward"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+// PortForwarder manages the forwarding of a single port.
+type PortForwarder interface {
+	// Start runs this forwarder.
+	Start() error
+
+	// Address returns the local forwarded address. Only valid while the forwarder is running.
+	Address() string
+
+	// Close this forwarder and release an resources.
+	Close()
+}
+
+var _ PortForwarder = &portForwarder{}
+
+type portForwarder struct {
+	cmd *cobra.Command
+	genericclioptions.RESTClientGetter
+	ctx          context.Context
+	cancel       context.CancelFunc
+	podName      string
+	ns           string
+	localAddress string
+	localPort    int
+	podPort      int
+	errCh        chan error
+}
+
+// getAvailablePort returns an available port by binding a listener to a port in the ephemeral range.
+func getAvailablePort() (int, error) {
+	listener, err := net.Listen("tcp", ":0") // ":0" will assign a random available port
+	if err != nil {
+		return 0, err
+	}
+	defer listener.Close()
+	addr := listener.Addr().(*net.TCPAddr)
+	return addr.Port, nil
+}
+
+func (p *portForwarder) Start() error {
+	address, err := p.cmd.Flags().GetStringSlice("address")
+	if err != nil {
+		return err
+	}
+
+	ports := fmt.Sprintf("%d:%d", p.localPort, p.podPort)
+	ioStreams := genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+	pfOptions := portforward.NewDefaultPortForwardOptions(ioStreams)
+	pfOptions.Address = address
+
+	f := cmdutil.NewFactory(p.RESTClientGetter)
+	if err := pfOptions.Complete(f, p.cmd, []string{p.podName, ports}); err != nil {
+		return fmt.Errorf("complete failed: %v", err)
+	}
+
+	go func() {
+		if err := pfOptions.RunPortForwardContext(p.ctx); err != nil {
+			p.errCh <- fmt.Errorf("error running port forward: %v", err)
+			return
+		}
+	}()
+
+	select {
+	case <-pfOptions.ReadyChannel:
+		return nil
+	case err := <-p.errCh:
+		return fmt.Errorf("failure running port forward process: %v", err)
+	}
+}
+
+func (p *portForwarder) Address() string {
+	return net.JoinHostPort(p.localAddress, strconv.Itoa(p.localPort))
+}
+
+func (p *portForwarder) Close() {
+	if p.cancel != nil {
+		p.cancel()
+	}
+}


### PR DESCRIPTION

**What type of PR is this?**
/kind enhancement

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
This PR reduces the binary size of `kmeshctl` by replacing the dependency on `istio.io/istio/pkg/kube` and applying build flags to strip debugging symbols. 

**Which issue(s) this PR fixes**:
Closes #946

**Special notes for your reviewer**:
I noticed that `test/e2e/main_test.go` uses `istio.io/istio/pkg/kube`. Do I need to do anything about it?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
