### PR TITLE
Use bpf map to pass node IP and pod sub gateway. Skip kubelet probe traffic management from ebpf

### DIFF
--- a/bpf/include/bpf_log.h
+++ b/bpf/include/bpf_log.h
@@ -99,7 +99,7 @@ static inline int map_lookup_log_level()
 
 #define BPF_LOG(l, t, f, ...)                                                                                          \
     do {                                                                                                               \
-        int level = map_lookup_log_level();                                                                         \
+        int level = map_lookup_log_level();                                                                            \
         int loglevel = BPF_MIN((int)level, ((int)BPF_LOG_DEBUG + (int)(BPF_LOGTYPE_##t)));                             \
         if ((int)(BPF_LOG_##l) <= loglevel) {                                                                          \
             static const char fmt[] = "[" #t "] " #l ": " f "";                                                        \

--- a/bpf/include/bpf_log.h
+++ b/bpf/include/bpf_log.h
@@ -90,16 +90,16 @@ lower than 22.09, compile would report an error of bpf_snprintf dont exist */
 static inline int map_lookup_log_level()
 {
     int zero = 0;
-    int *value = NULL;
+    struct kmesh_config *value = {0};
     value = kmesh_map_lookup_elem(&kmesh_config_map, &zero);
     if (!value)
         return BPF_LOG_INFO;
-    return *value;
+    return value->bpf_log_level;
 }
 
 #define BPF_LOG(l, t, f, ...)                                                                                          \
     do {                                                                                                               \
-        int level = map_lookup_log_level();                                                                            \
+        int level = map_lookup_log_level();                                                                         \
         int loglevel = BPF_MIN((int)level, ((int)BPF_LOG_DEBUG + (int)(BPF_LOGTYPE_##t)));                             \
         if ((int)(BPF_LOG_##l) <= loglevel) {                                                                          \
             static const char fmt[] = "[" #t "] " #l ": " f "";                                                        \

--- a/bpf/include/common.h
+++ b/bpf/include/common.h
@@ -63,6 +63,12 @@ struct kmesh_context {
     bool via_waypoint;
 };
 
+struct kmesh_config {
+    __u32 bpf_log_level;
+    __u32 node_ip[4];
+    __u32 pod_gateway[4];
+};
+
 static inline void *kmesh_map_lookup_elem(void *map, const void *key)
 {
     return bpf_map_lookup_elem(map, key);
@@ -134,8 +140,8 @@ struct {
 struct {
     __uint(type, BPF_MAP_TYPE_ARRAY);
     __uint(max_entries, 1);
-    __uint(key_size, sizeof(__u32));
-    __uint(value_size, sizeof(__u32));
+    __type(key, int);
+    __type(value, struct kmesh_config);
 } kmesh_config_map SEC(".maps");
 
 #if KERNEL_VERSION_HIGHER_5_13_0

--- a/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkload_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkload_bpfeb.go
@@ -24,6 +24,12 @@ type KmeshCgroupSockWorkloadBpfSockTuple struct {
 
 type KmeshCgroupSockWorkloadBuf struct{ Data [40]int8 }
 
+type KmeshCgroupSockWorkloadKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshCgroupSockWorkloadLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkload_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkload_bpfel.go
@@ -24,6 +24,12 @@ type KmeshCgroupSockWorkloadBpfSockTuple struct {
 
 type KmeshCgroupSockWorkloadBuf struct{ Data [40]int8 }
 
+type KmeshCgroupSockWorkloadKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshCgroupSockWorkloadLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkloadcompat_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkloadcompat_bpfeb.go
@@ -24,6 +24,12 @@ type KmeshCgroupSockWorkloadCompatBpfSockTuple struct {
 
 type KmeshCgroupSockWorkloadCompatBuf struct{ Data [40]int8 }
 
+type KmeshCgroupSockWorkloadCompatKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshCgroupSockWorkloadCompatLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkloadcompat_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkloadcompat_bpfel.go
@@ -24,6 +24,12 @@ type KmeshCgroupSockWorkloadCompatBpfSockTuple struct {
 
 type KmeshCgroupSockWorkloadCompatBuf struct{ Data [40]int8 }
 
+type KmeshCgroupSockWorkloadCompatKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshCgroupSockWorkloadCompatLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/dualengine/kmeshsendmsg_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshsendmsg_bpfeb.go
@@ -24,6 +24,12 @@ type KmeshSendmsgBpfSockTuple struct {
 
 type KmeshSendmsgBuf struct{ Data [40]int8 }
 
+type KmeshSendmsgKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshSendmsgLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/dualengine/kmeshsendmsg_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshsendmsg_bpfel.go
@@ -24,6 +24,12 @@ type KmeshSendmsgBpfSockTuple struct {
 
 type KmeshSendmsgBuf struct{ Data [40]int8 }
 
+type KmeshSendmsgKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshSendmsgLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/dualengine/kmeshsendmsgcompat_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshsendmsgcompat_bpfeb.go
@@ -24,6 +24,12 @@ type KmeshSendmsgCompatBpfSockTuple struct {
 
 type KmeshSendmsgCompatBuf struct{ Data [40]int8 }
 
+type KmeshSendmsgCompatKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshSendmsgCompatLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/dualengine/kmeshsendmsgcompat_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshsendmsgcompat_bpfel.go
@@ -24,6 +24,12 @@ type KmeshSendmsgCompatBpfSockTuple struct {
 
 type KmeshSendmsgCompatBuf struct{ Data [40]int8 }
 
+type KmeshSendmsgCompatKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshSendmsgCompatLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkload_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkload_bpfeb.go
@@ -24,6 +24,12 @@ type KmeshSockopsWorkloadBpfSockTuple struct {
 
 type KmeshSockopsWorkloadBuf struct{ Data [40]int8 }
 
+type KmeshSockopsWorkloadKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshSockopsWorkloadLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkload_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkload_bpfel.go
@@ -24,6 +24,12 @@ type KmeshSockopsWorkloadBpfSockTuple struct {
 
 type KmeshSockopsWorkloadBuf struct{ Data [40]int8 }
 
+type KmeshSockopsWorkloadKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshSockopsWorkloadLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkloadcompat_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkloadcompat_bpfeb.go
@@ -24,6 +24,12 @@ type KmeshSockopsWorkloadCompatBpfSockTuple struct {
 
 type KmeshSockopsWorkloadCompatBuf struct{ Data [40]int8 }
 
+type KmeshSockopsWorkloadCompatKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshSockopsWorkloadCompatLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkloadcompat_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkloadcompat_bpfel.go
@@ -24,6 +24,12 @@ type KmeshSockopsWorkloadCompatBpfSockTuple struct {
 
 type KmeshSockopsWorkloadCompatBuf struct{ Data [40]int8 }
 
+type KmeshSockopsWorkloadCompatKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshSockopsWorkloadCompatLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/dualengine/kmeshxdpauth_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshxdpauth_bpfeb.go
@@ -24,6 +24,12 @@ type KmeshXDPAuthBpfSockTuple struct {
 
 type KmeshXDPAuthBuf struct{ Data [40]int8 }
 
+type KmeshXDPAuthKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshXDPAuthLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/dualengine/kmeshxdpauth_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshxdpauth_bpfel.go
@@ -24,6 +24,12 @@ type KmeshXDPAuthBpfSockTuple struct {
 
 type KmeshXDPAuthBuf struct{ Data [40]int8 }
 
+type KmeshXDPAuthKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshXDPAuthLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/dualengine/kmeshxdpauthcompat_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshxdpauthcompat_bpfeb.go
@@ -24,6 +24,12 @@ type KmeshXDPAuthCompatBpfSockTuple struct {
 
 type KmeshXDPAuthCompatBuf struct{ Data [40]int8 }
 
+type KmeshXDPAuthCompatKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshXDPAuthCompatLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/dualengine/kmeshxdpauthcompat_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshxdpauthcompat_bpfel.go
@@ -24,6 +24,12 @@ type KmeshXDPAuthCompatBpfSockTuple struct {
 
 type KmeshXDPAuthCompatBuf struct{ Data [40]int8 }
 
+type KmeshXDPAuthCompatKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshXDPAuthCompatLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsock_bpfeb.go
+++ b/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsock_bpfeb.go
@@ -16,6 +16,12 @@ type KmeshCgroupSockBuf struct{ Data [40]int8 }
 
 type KmeshCgroupSockClusterSockData struct{ ClusterId uint32 }
 
+type KmeshCgroupSockKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshCgroupSockLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsock_bpfel.go
+++ b/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsock_bpfel.go
@@ -16,6 +16,12 @@ type KmeshCgroupSockBuf struct{ Data [40]int8 }
 
 type KmeshCgroupSockClusterSockData struct{ ClusterId uint32 }
 
+type KmeshCgroupSockKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshCgroupSockLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsockcompat_bpfeb.go
+++ b/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsockcompat_bpfeb.go
@@ -16,6 +16,12 @@ type KmeshCgroupSockCompatBuf struct{ Data [40]int8 }
 
 type KmeshCgroupSockCompatClusterSockData struct{ ClusterId uint32 }
 
+type KmeshCgroupSockCompatKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshCgroupSockCompatLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsockcompat_bpfel.go
+++ b/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsockcompat_bpfel.go
@@ -16,6 +16,12 @@ type KmeshCgroupSockCompatBuf struct{ Data [40]int8 }
 
 type KmeshCgroupSockCompatClusterSockData struct{ ClusterId uint32 }
 
+type KmeshCgroupSockCompatKmeshConfig struct {
+	BpfLogLevel uint32
+	NodeIp      [4]uint32
+	PodGateway  [4]uint32
+}
+
 type KmeshCgroupSockCompatLogEvent struct {
 	Ret uint32
 	Msg [255]int8

--- a/bpf/kmesh/workload/sockops.c
+++ b/bpf/kmesh/workload/sockops.c
@@ -56,12 +56,6 @@ static inline bool skip_specific_probe(struct bpf_sock_ops *skops)
         return false;
     }
 
-    BPF_LOG(ERR, SOCKOPS, "node ip is %u.%u", data->node_ip[0], data->node_ip[1]);
-    BPF_LOG(ERR, SOCKOPS, "node ip is %u.%u", data->node_ip[2], data->node_ip[3]);
-    BPF_LOG(ERR, SOCKOPS, "pod gateway is %u.%u", data->pod_gateway[0], data->pod_gateway[1]);
-    BPF_LOG(ERR, SOCKOPS, "pod gateway is %u.%u", data->pod_gateway[2], data->pod_gateway[3]);
-    BPF_LOG(ERR, SOCKOPS, "remote ip is %u", skops->remote_ip4);
-
     if (skops->family ==  AF_INET) {
         if (data->node_ip[3] == skops->remote_ip4) {
             return true;
@@ -71,7 +65,20 @@ static inline bool skip_specific_probe(struct bpf_sock_ops *skops)
         }
     }
 
-    if (skops->family == AF_INET6) {}
+    if (skops->family == AF_INET6) {
+        if (data->node_ip[0] == skops->remote_ip6[0] && 
+        data->node_ip[1] == skops->remote_ip6[1] && 
+        data->node_ip[2] == skops->remote_ip6[2] && 
+        data->node_ip[3] == skops->remote_ip6[3]) {
+            return true;
+        }
+        if (data->pod_gateway[0] == skops-> remote_ip6[0] &&
+        data->pod_gateway[1] == skops-> remote_ip6[1] &&
+        data->pod_gateway[2] == skops-> remote_ip6[2] &&
+        data->pod_gateway[3] == skops-> remote_ip6[3]) {
+            return true;
+        }
+    }
 
     return false;
 }

--- a/bpf/kmesh/workload/sockops.c
+++ b/bpf/kmesh/workload/sockops.c
@@ -52,7 +52,7 @@ static inline bool skip_specific_probe(struct bpf_sock_ops *skops)
     int key_of_kmesh_config = 0;
     data = kmesh_map_lookup_elem(&kmesh_config_map, &key_of_kmesh_config);
     if (!data) {
-        BPF_LOG(ERR, SOCKOPS, "get kmesh congfig failed");
+        BPF_LOG(ERR, SOCKOPS, "get kmesh config failed");
         return false;
     }
 

--- a/bpf/kmesh/workload/sockops.c
+++ b/bpf/kmesh/workload/sockops.c
@@ -47,7 +47,7 @@ static inline bool is_managed_by_kmesh(struct bpf_sock_ops *skops)
 }
 
 static inline bool skip_specific_probe(struct bpf_sock_ops *skops)
-{   
+{
     struct kmesh_config *data = {0};
     int key_of_kmesh_config = 0;
     data = kmesh_map_lookup_elem(&kmesh_config_map, &key_of_kmesh_config);
@@ -56,7 +56,7 @@ static inline bool skip_specific_probe(struct bpf_sock_ops *skops)
         return false;
     }
 
-    if (skops->family ==  AF_INET) {
+    if (skops->family == AF_INET) {
         if (data->node_ip[3] == skops->remote_ip4) {
             return true;
         }
@@ -66,16 +66,12 @@ static inline bool skip_specific_probe(struct bpf_sock_ops *skops)
     }
 
     if (skops->family == AF_INET6) {
-        if (data->node_ip[0] == skops->remote_ip6[0] && 
-        data->node_ip[1] == skops->remote_ip6[1] && 
-        data->node_ip[2] == skops->remote_ip6[2] && 
-        data->node_ip[3] == skops->remote_ip6[3]) {
+        if (data->node_ip[0] == skops->remote_ip6[0] && data->node_ip[1] == skops->remote_ip6[1]
+            && data->node_ip[2] == skops->remote_ip6[2] && data->node_ip[3] == skops->remote_ip6[3]) {
             return true;
         }
-        if (data->pod_gateway[0] == skops-> remote_ip6[0] &&
-        data->pod_gateway[1] == skops-> remote_ip6[1] &&
-        data->pod_gateway[2] == skops-> remote_ip6[2] &&
-        data->pod_gateway[3] == skops-> remote_ip6[3]) {
+        if (data->pod_gateway[0] == skops->remote_ip6[0] && data->pod_gateway[1] == skops->remote_ip6[1]
+            && data->pod_gateway[2] == skops->remote_ip6[2] && data->pod_gateway[3] == skops->remote_ip6[3]) {
             return true;
         }
     }

--- a/deploy/yaml/clusterrole.yaml
+++ b/deploy/yaml/clusterrole.yaml
@@ -6,7 +6,7 @@ metadata:
     app: kmesh
 rules:
 - apiGroups: [""]
-  resources: ["pods","services","namespaces"]
+  resources: ["pods","services","namespaces","nodes"]
   verbs: ["get", "update", "patch", "list", "watch"]
 - apiGroups: ["apps"]
   resources: ["daemonsets"]

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -21,7 +21,6 @@ package bpf
 import "C"
 import (
 	"context"
-	"fmt"
 	"hash/fnv"
 	"net"
 	"os"
@@ -294,8 +293,6 @@ func (l *BpfLoader) UpdateBpfProgOptions() {
 	nodeIP := getNodeIPAddress(nodeName, node)
 	gateway := getNodePodSubGateway(nodeName, node)
 
-	fmt.Printf("-------- nodeip: %v, pod gateway: %v\n", nodeIP, gateway)
-
 	keyOfKmeshBpfConfig := uint32(0)
 	ValueOfKmeshBpfConfig := constants.KmeshBpfConfig{
 		// Write this map only when the kmesh daemon starts, so set bpfloglevel to the default value.
@@ -338,17 +335,11 @@ func getNodePodSubGateway(nodeName string, node *corev1.Node) [4]uint32 {
 	}
 
 	podGateway := IPToUint32(ip)
-	if isIPv6(ip) {
-		podGateway[0] = podGateway[0] + 1<<24
-	} else {
-		podGateway[3] = podGateway[3] + 1<<24
-	}
-
+	podGateway[3] = podGateway[3] + 1<<24
 	return podGateway
 }
 
 func IPToUint32(ip net.IP) [4]uint32 {
-	fmt.Printf("======== %v, %v ==========", ip, len(ip))
 	ipToUint32 := [4]uint32{0, 0, 0, 0}
 	if isIPv6(ip) {
 		ipToUint32[0] = binaryToUint32(ip[:4])
@@ -385,16 +376,6 @@ func isIPv6(ip net.IP) bool {
 	}
 	return false
 }
-
-// func calculateGateway(ipnet *net.IPNet) uint32 {
-// 	if ipnet == nil {
-// 		log.Errorf("failed to calculate pod sub gateway: %s", "*ipNet is empty")
-// 		return uint32(0)
-// 	}
-
-// 	networkInt := binaryToUint32(ipnet.IP.Mask(ipnet.Mask))
-// 	return networkInt + 1<<24
-// }
 
 func binaryToUint32(ip net.IP) uint32 {
 	return uint32(ip[3])<<24 + uint32(ip[2])<<16 + uint32(ip[1])<<8 + uint32(ip[0])

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -281,6 +281,7 @@ func (l *BpfLoader) UpdateBpfProgOptions() {
 	clientSet, err := utils.GetK8sclient()
 	if err != nil {
 		log.Errorf("get kubernetest client for getting node IP error: %v", err)
+		return
 	}
 
 	node, err := clientSet.CoreV1().Nodes().Get(context.TODO(), nodeName, metav1.GetOptions{})

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -61,3 +61,9 @@ const (
 	VersionPath         = "/bpf_kmesh/map/"
 	WorkloadVersionPath = "/bpf_kmesh_workload/map/"
 )
+
+type KmeshBpfConfig struct {
+	BpfLogLevel uint32
+	NodeIP      [4]uint32
+	PodGateway  [4]uint32
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -61,9 +61,3 @@ const (
 	VersionPath         = "/bpf_kmesh/map/"
 	WorkloadVersionPath = "/bpf_kmesh_workload/map/"
 )
-
-type KmeshBpfConfig struct {
-	BpfLogLevel uint32
-	NodeIP      [4]uint32
-	PodGateway  [4]uint32
-}

--- a/pkg/controller/telemetry/metric_test.go
+++ b/pkg/controller/telemetry/metric_test.go
@@ -500,7 +500,7 @@ func TestBuildworkloadMetric(t *testing.T) {
 			}
 			m.workloadCache.AddOrUpdateWorkload(dstWorkload)
 			m.workloadCache.AddOrUpdateWorkload(srcWorkload)
-			got, _ := m.buildWorkloadMetric(tt.args.data)
+			got := m.buildWorkloadMetric(tt.args.data)
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Metric.buildMetric() = %v, want %v", got, tt.want)
 			}

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -407,10 +407,11 @@ func (s *Server) readyProbe(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) getBpfLogLevel() (*LoggerInfo, error) {
 	key := uint32(0)
-	value := uint32(0)
+	value := constants.KmeshBpfConfig{}
 	if err := s.kmeshConfigMap.Lookup(&key, &value); err != nil {
 		return nil, fmt.Errorf("get log level error: %v", err)
 	}
+	logLevel := value.BpfLogLevel
 
 	logLevelMap := map[int]string{
 		constants.BPF_LOG_ERR:   "error",
@@ -419,7 +420,7 @@ func (s *Server) getBpfLogLevel() (*LoggerInfo, error) {
 		constants.BPF_LOG_DEBUG: "debug",
 	}
 
-	loggerLevel, exists := logLevelMap[int(value)]
+	loggerLevel, exists := logLevelMap[int(logLevel)]
 	if !exists {
 		return nil, fmt.Errorf("unexpected invalid log level: %d", value)
 	}

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -450,7 +450,6 @@ func (s *Server) setBpfLogLevel(w http.ResponseWriter, levelStr string) {
 		return
 	}
 	key := uint32(0)
-	// value := uint32(level)
 	value := constants.KmeshBpfConfig{}
 	if s.kmeshConfigMap == nil {
 		http.Error(w, fmt.Sprintf("update log level error: %v", "kmeshConfigMap is nil"), http.StatusBadRequest)

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -33,6 +33,7 @@ import (
 	adminv2 "kmesh.net/kmesh/api/v2/admin"
 	"kmesh.net/kmesh/api/v2/workloadapi/security"
 	"kmesh.net/kmesh/daemon/options"
+	"kmesh.net/kmesh/pkg/bpf"
 	bpfads "kmesh.net/kmesh/pkg/bpf/ads"
 	maps_v2 "kmesh.net/kmesh/pkg/cache/v2/maps"
 	"kmesh.net/kmesh/pkg/constants"
@@ -407,7 +408,7 @@ func (s *Server) readyProbe(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) getBpfLogLevel() (*LoggerInfo, error) {
 	key := uint32(0)
-	value := constants.KmeshBpfConfig{}
+	value := bpf.KmeshBpfConfig{}
 	if err := s.kmeshConfigMap.Lookup(&key, &value); err != nil {
 		return nil, fmt.Errorf("get log level error: %v", err)
 	}
@@ -451,7 +452,7 @@ func (s *Server) setBpfLogLevel(w http.ResponseWriter, levelStr string) {
 		return
 	}
 	key := uint32(0)
-	value := constants.KmeshBpfConfig{}
+	value := bpf.KmeshBpfConfig{}
 	if s.kmeshConfigMap == nil {
 		http.Error(w, fmt.Sprintf("update log level error: %v", "kmeshConfigMap is nil"), http.StatusBadRequest)
 		return


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #961 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
