### PR TITLE
optimize xDS bpf map

### DIFF
--- a/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.c
+++ b/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.c
@@ -453,6 +453,7 @@ static int repeat_field_handle(struct op_context *ctx, const ProtobufCFieldDescr
 {
     int ret, ret1;
     unsigned int i;
+    int field_len;
     int inner_fd, key = 0;
     unsigned int outer_key;
     struct bpf_map_info *inner_info = NULL;
@@ -485,7 +486,11 @@ static int repeat_field_handle(struct op_context *ctx, const ProtobufCFieldDescr
     case PROTOBUF_C_TYPE_MESSAGE:
     case PROTOBUF_C_TYPE_STRING:
         for (i = 0; i < *(unsigned int *)n; i++) {
-            outer_key = alloc_outer_key(ctx, get_string_or_msg_field_size(ctx, field));
+            if (field->type == PROTOBUF_C_TYPE_STRING)
+                field_len = strlen((char *)origin_value[i]) + 1;
+            else
+                field_len = ((ProtobufCMessageDescriptor *)(field->descriptor))->sizeof_message;
+            outer_key = alloc_outer_key(ctx, field_len);
             if (outer_key < 0)
                 goto end;
 

--- a/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.c
+++ b/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.c
@@ -9,6 +9,8 @@
 #include <securec.h>
 #include <pthread.h>
 #include <semaphore.h>
+#include <time.h>
+#include <sys/time.h>
 
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
@@ -19,41 +21,38 @@
 
 #include "deserialization_to_bpf_map.h"
 #include "../../config/kmesh_marcos_def.h"
+#include "../include/inner_map_defs.h"
 
 #define PRINTF(fmt, args...)                                                                                           \
     do {                                                                                                               \
-        printf(fmt, ##args);                                                                                           \
+        struct timeval tv;                                                                                             \
+        struct timezone tz;                                                                                            \
+        gettimeofday(&tv, &tz);                                                                                        \
+        long ms = tv.tv_usec / 1000;                                                                                   \
+        char time_str[30];                                                                                             \
+        strftime(time_str, sizeof(time_str), "%Y-%m-%d %H:%M:%S", localtime(&tv.tv_sec));                              \
+        printf("%s.%03ld " fmt "\n", time_str, ms, ##args);                                                            \
         fflush(stdout);                                                                                                \
     } while (0)
 
-#define LOG_ERR(fmt, args...)  PRINTF(fmt, ##args)
-#define LOG_WARN(fmt, args...) PRINTF(fmt, ##args)
-#define LOG_INFO(fmt, args...) PRINTF(fmt, ##args)
+#define LOG_ERR(fmt, args...)  PRINTF("[ERROR] " fmt, ##args)
+#define LOG_WARN(fmt, args...) PRINTF("[WARN] " fmt, ##args)
+#define LOG_INFO(fmt, args...) PRINTF("[INFO] " fmt, ##args)
 
 struct op_context {
     void *key;
     void *value;
-    int outter_fd;
-    int map_fd;
     int curr_fd;
-    struct bpf_map_info *outter_info;
-    struct bpf_map_info *inner_info;
-    struct bpf_map_info *info;
     struct bpf_map_info *curr_info;
-    char *inner_map_object;
+    char *map_object;
     const ProtobufCMessageDescriptor *desc;
 };
 
-#define init_op_context(context, k, v, desc, o_fd, fd, o_info, i_info, m_info)                                         \
+#define init_op_context(context, k, v, desc, fd, m_info)                                                               \
     do {                                                                                                               \
         (context).key = (k);                                                                                           \
         (context).value = (v);                                                                                         \
         (context).desc = (desc);                                                                                       \
-        (context).outter_fd = (o_fd);                                                                                  \
-        (context).map_fd = (fd);                                                                                       \
-        (context).outter_info = (o_info);                                                                              \
-        (context).inner_info = (i_info);                                                                               \
-        (context).info = (m_info);                                                                                     \
         (context).curr_info = (m_info);                                                                                \
         (context).curr_fd = (fd);                                                                                      \
     } while (0)
@@ -75,43 +74,19 @@ struct inner_map_stat {
     unsigned int resv : 30;
 };
 
-struct inner_map_mng {
-    int inner_fd;
-    int outter_fd;
-    struct bpf_map_info inner_info;
-    struct bpf_map_info outter_info;
-    struct inner_map_stat inner_maps[MAX_OUTTER_MAP_ENTRIES];
-    int elastic_slots[ELASTIC_SLOTS_NUM];
-    int used_cnt;          // real used count
-    int allocated_cnt;     // real allocated count
-    int max_allocated_idx; // max allocated index, there may be holes.
-    int init;
-    sem_t fin_tasks;
-    int elastic_task_exit; // elastic scaling thread exit flag
+#define MIM_BITMAP_SIZE (MAP_MAX_ENTRIES / 8)
+struct map_mng {
+    int inner_fds[MAP_TYPE_MAX];
+    struct bpf_map_info inner_infos[MAP_TYPE_MAX];
+    unsigned char mim_used_bitmap[MAP_TYPE_MAX][MIM_BITMAP_SIZE];
 };
 
-struct task_contex {
-    int outter_fd;
-    int task_id;
-    bool scaleup;
-};
-
-#define MAP_IN_MAP_MNG_PERSIST_FILE_PATH "/mnt/mim_mng_persist"
-#define MAGIC_NUMBER                     0xb809b8c3
-struct persist_info {
-    unsigned int magic;
-    int used_cnt;          // real used count
-    int allocated_cnt;     // real allocated count
-    int max_allocated_idx; // max allocated index, there may be holes.
-    struct inner_map_stat inner_map_stat[0];
-};
-
-struct inner_map_mng g_inner_map_mng = {0};
+struct map_mng g_map_mng = {0};
 
 static int update_bpf_map(struct op_context *ctx);
 static void *create_struct(struct op_context *ctx, int *err);
-static int del_bpf_map(struct op_context *ctx, int is_inner);
-static int free_outter_map_entry(struct op_context *ctx, void *outter_key);
+static int del_bpf_map(struct op_context *ctx);
+static int free_outter_map_entry(struct op_context *ctx, unsigned int *outer_key);
 
 static int normalize_key(struct op_context *ctx, void *key, const char *map_name)
 {
@@ -132,7 +107,7 @@ static int normalize_key(struct op_context *ctx, void *key, const char *map_name
 
 static inline int selected_oneof_field(void *value, const ProtobufCFieldDescriptor *field)
 {
-    uint32_t n = *(uint32_t *)((char *)value + field->quantifier_offset);
+    unsigned int n = *(unsigned int *)((char *)value + field->quantifier_offset);
 
     if ((field->flags & PROTOBUF_C_FIELD_FLAG_ONEOF) && field->id != n)
         return 0;
@@ -142,7 +117,7 @@ static inline int selected_oneof_field(void *value, const ProtobufCFieldDescript
 
 static inline int valid_field_value(void *value, const ProtobufCFieldDescriptor *field)
 {
-    uint32_t val = *(uint32_t *)((char *)value + field->offset);
+    unsigned int val = *(unsigned int *)((char *)value + field->offset);
 
     if (val == 0) {
         switch (field->type) {
@@ -196,9 +171,11 @@ static inline size_t sizeof_elt_in_repeated_array(ProtobufCType type)
     return 0;
 }
 
-static inline int valid_outter_key(struct op_context *ctx, unsigned int outter_key)
+static inline int valid_outer_key(struct op_context *ctx, unsigned int outer_key)
 {
-    if (outter_key < 0 || outter_key >= MAX_OUTTER_MAP_ENTRIES)
+    unsigned char type = MAP_GET_TYPE(outer_key);
+    unsigned int inner_idx = MAP_GET_INDEX(outer_key);
+    if (type >= MAP_TYPE_MAX || inner_idx >= MAP_MAX_ENTRIES)
         return 0;
 
     return 1;
@@ -206,7 +183,7 @@ static inline int valid_outter_key(struct op_context *ctx, unsigned int outter_k
 
 static void free_elem(void *ptr)
 {
-    if ((uintptr_t)ptr < MAX_OUTTER_MAP_ENTRIES)
+    if ((uintptr_t)ptr < UINT32_MAX)
         return;
 
     free(ptr);
@@ -225,43 +202,18 @@ static void free_keys(struct op_context *ctx, void *keys, int n)
     }
 }
 
-static unsigned int get_map_id(const char *name)
+static int get_map_id(const char *name, unsigned int *id)
 {
-    char *ptr = NULL;
-    char *map_id = getenv(name);
-    if (!map_id)
-        return 0;
-    return (unsigned int)strtol(map_id, &ptr, 10);
-}
-
-static int get_map_ids(const char *name, unsigned int *id, unsigned int *outter_id, unsigned int *inner_id)
-{
-    char *ptr = NULL;
     char *map_id;
+    char *ptr = NULL;
 
-    map_id = (name == NULL) ? getenv("MAP_ID") : getenv(name);
+    map_id = getenv(name);
     if (!map_id) {
-        LOG_ERR("%s is not set\n", ((name == NULL) ? "MAP_ID" : name));
+        LOG_ERR("%s is not set, errno:%d", name, errno);
         return -EINVAL;
     }
-
-    errno = 0;
-
     *id = (unsigned int)strtol(map_id, &ptr, 10);
-    if (!ptr[0]) {
-        *outter_id = get_map_id("OUTTER_MAP_ID");
-        if (*outter_id == 0)
-            return -EINVAL;
-    }
-
-    if (!ptr[0]) {
-        *inner_id = get_map_id("INNER_MAP_ID");
-        if (*inner_id == 0) {
-            LOG_ERR("INNER_MAP_ID is not set\n");
-            return -EINVAL;
-        }
-    }
-    return -errno;
+    return 0;
 }
 
 static int get_map_fd_info(unsigned int id, int *map_fd, struct bpf_map_info *info)
@@ -278,168 +230,186 @@ static int get_map_fd_info(unsigned int id, int *map_fd, struct bpf_map_info *in
     return ret;
 }
 
-static int bpf_get_map_id_by_fd(int map_fd)
+static int free_outter_map_entry(struct op_context *ctx, unsigned int *outer_key)
 {
-    struct bpf_map_info info = {};
-    __u32 info_len = sizeof(info);
+    unsigned char type = MAP_GET_TYPE(*outer_key);
+    unsigned int inner_idx = MAP_GET_INDEX(*outer_key);
 
-    int ret = bpf_obj_get_info_by_fd(map_fd, &info, &info_len);
-    if (ret < 0) {
-        LOG_ERR("bpf_obj_get_info_by_fd failed, map_fd:%d ret:%d ERRNO:%d\n", map_fd, ret, errno);
-        return ret;
-    }
-    return info.id;
-}
-
-static int free_outter_map_entry(struct op_context *ctx, void *outter_key)
-{
-    int key = *(int *)outter_key;
-    if (key <= 0 || key >= MAX_OUTTER_MAP_ENTRIES)
+    if (type >= MAP_TYPE_MAX || inner_idx >= MAP_MAX_ENTRIES)
         return -1;
 
-    if (g_inner_map_mng.inner_maps[key].used) {
-        g_inner_map_mng.inner_maps[key].used = 0;
-        g_inner_map_mng.used_cnt--;
-    }
+    CLEAR_BIT(g_map_mng.mim_used_bitmap[type], inner_idx);
+    *outer_key = 0;
     return 0;
 }
 
-static int alloc_outter_map_entry(struct op_context *ctx)
+static int bitmap_find_first_clear(unsigned char *bitmap, int len)
 {
-    int i;
-    if (!g_inner_map_mng.init || g_inner_map_mng.used_cnt >= g_inner_map_mng.allocated_cnt) {
-        LOG_ERR(
-            "[%d %d %d]alloc_outter_map_entry failed\n",
-            g_inner_map_mng.init,
-            g_inner_map_mng.used_cnt,
-            g_inner_map_mng.allocated_cnt);
+    int i, j;
+    unsigned char bmp;
+
+    for (i = 0; i < len; i++) {
+        bmp = bitmap[i];
+        for (j = 0; j < 8; j++) {
+            if (i == 0 && j == 0)
+                continue;
+            if (!(bmp & (1U << j)))
+                return (i * 8 + j);
+        }
+    }
+    return -1;
+}
+
+static unsigned int alloc_outer_key(struct op_context *ctx, int size)
+{
+    int i, j;
+    if (size <= 0)
+        return -1;
+    for (i = 0; i < MAP_TYPE_MAX; i++) {
+        if (size > g_map_mng.inner_infos[i].value_size)
+            continue;
+
+        j = bitmap_find_first_clear(&g_map_mng.mim_used_bitmap[i][0], MIM_BITMAP_SIZE);
+        if (j > 0 && j < MAP_MAX_ENTRIES)
+            break;
+    }
+
+    if (i == MAP_TYPE_MAX) {
+        LOG_ERR("alloc_map_in_map_entry failed, size:%d", size);
         return -1;
     }
 
-    for (i = 1; i <= g_inner_map_mng.max_allocated_idx; i++) {
-        if (g_inner_map_mng.inner_maps[i].used == 0 && g_inner_map_mng.inner_maps[i].allocated) {
-            g_inner_map_mng.inner_maps[i].used = 1;
-            g_inner_map_mng.used_cnt++;
-            return i;
-        }
+    SET_BIT(g_map_mng.mim_used_bitmap[i], j);
+    return MAP_GEN_OUTER_KEY(i, j);
+}
+
+static int
+outer_key_to_inner_map_index(unsigned int outer_key, int *inner_fd, struct bpf_map_info **map_info, int *inner_idx)
+{
+    unsigned char type = MAP_GET_TYPE(outer_key);
+    unsigned int idx = MAP_GET_INDEX(outer_key);
+
+    if (type >= MAP_TYPE_MAX || idx >= MAP_MAX_ENTRIES) {
+        LOG_ERR("outer_key_to_inner_map_index outer_key(%u) invalid.", outer_key);
+        return -1;
     }
 
-    LOG_ERR(
-        "alloc_outter_map_entry all inner_maps in used:%d-%d-%d\n",
-        g_inner_map_mng.used_cnt,
-        g_inner_map_mng.allocated_cnt,
-        g_inner_map_mng.max_allocated_idx);
-    return -1;
+    *inner_idx = idx;
+    *inner_fd = g_map_mng.inner_fds[type];
+    if (map_info)
+        *map_info = &g_map_mng.inner_infos[type];
+    return 0;
 }
 
-static int outter_key_to_inner_fd(struct op_context *ctx, unsigned int key)
-{
-    if (g_inner_map_mng.inner_maps[key].allocated)
-        return g_inner_map_mng.inner_maps[key].map_fd;
-    return -1;
-}
-
-static int copy_sfield_to_map(struct op_context *ctx, int o_index, const ProtobufCFieldDescriptor *field)
+static int copy_sfield_to_map(struct op_context *ctx, unsigned int outer_key, const ProtobufCFieldDescriptor *field)
 {
     int ret;
     int key = 0;
     int inner_fd;
+    struct bpf_map_info *inner_info;
     char **value = (char **)((char *)ctx->value + field->offset);
     char *save_value = *value;
 
-    *(uintptr_t *)value = (size_t)o_index;
+    *(uintptr_t *)value = (size_t)outer_key;
     ret = bpf_map_update_elem(ctx->curr_fd, ctx->key, ctx->value, BPF_ANY);
     if (ret) {
-        LOG_ERR("copy_sfield_to_map bpf_map_update_elem failed, ret:%d ERRNO:%d\n", ret, errno);
-        free_outter_map_entry(ctx, &o_index);
+        LOG_ERR("copy_sfield_to_map bpf_map_update_elem failed, ret:%d ERRNO:%d", ret, errno);
         return ret;
     }
 
-    inner_fd = outter_key_to_inner_fd(ctx, o_index);
-    if (inner_fd < 0) {
-        LOG_ERR("copy_sfield_to_map outter_key_to_inner_fd failed, inner_fd:%d ERRNO:%d\n", inner_fd, errno);
-        return inner_fd;
-    }
+    ret = outer_key_to_inner_map_index(outer_key, &inner_fd, &inner_info, &key);
+    if (ret)
+        return ret;
 
-    strcpy_s(ctx->inner_map_object, ctx->inner_info->value_size, save_value);
-    ret = bpf_map_update_elem(inner_fd, &key, ctx->inner_map_object, BPF_ANY);
+    strcpy_s(ctx->map_object, inner_info->value_size, save_value);
+    ret = bpf_map_update_elem(inner_fd, &key, ctx->map_object, BPF_ANY);
     return ret;
 }
 
-static int copy_msg_field_to_map(struct op_context *ctx, int o_index, const ProtobufCFieldDescriptor *field)
+static int copy_msg_field_to_map(struct op_context *ctx, unsigned int outer_key, const ProtobufCFieldDescriptor *field)
 {
     int ret;
     int key = 0;
     int inner_fd;
+    struct bpf_map_info *inner_info = NULL;
     void **value = (void **)((char *)ctx->value + field->offset);
     void *msg = *value;
     struct op_context new_ctx;
-    const ProtobufCMessageDescriptor *desc;
+    const ProtobufCMessageDescriptor *desc = ((ProtobufCMessage *)msg)->descriptor;
 
-    *(uintptr_t *)value = (size_t)o_index;
-    ret = bpf_map_update_elem(ctx->curr_fd, ctx->key, ctx->value, BPF_ANY);
-    if (ret) {
-        LOG_ERR("copy_msg_field_to_map bpf_map_update_elem failed, ret:%d ERRNO:%d\n", ret, errno);
-        free_outter_map_entry(ctx, &o_index);
-        return ret;
-    }
-
-    inner_fd = outter_key_to_inner_fd(ctx, o_index);
-    if (inner_fd < 0) {
-        LOG_ERR("copy_msg_field_to_map outter_key_to_inner_fd failed, inner_fd:%d ERRNO:%d\n", inner_fd, errno);
-        return inner_fd;
-    }
-
-    memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
-
-    new_ctx.curr_fd = inner_fd;
-    new_ctx.key = (void *)&key;
-    new_ctx.value = msg;
-    new_ctx.curr_info = ctx->inner_info;
-
-    desc = ((ProtobufCMessage *)new_ctx.value)->descriptor;
     if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
         return -EINVAL;
     }
 
-    new_ctx.desc = desc;
+    *(uintptr_t *)value = (size_t)outer_key;
+    ret = bpf_map_update_elem(ctx->curr_fd, ctx->key, ctx->value, BPF_ANY);
+    if (ret) {
+        LOG_ERR("copy_msg_field_to_map bpf_map_update_elem failed, ret:%d ERRNO:%d", ret, errno);
+        return ret;
+    }
 
-    ret = update_bpf_map(&new_ctx);
-    return ret;
+    ret = outer_key_to_inner_map_index(outer_key, &inner_fd, &inner_info, &key);
+    if (ret)
+        return ret;
+
+    memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
+    new_ctx.curr_fd = inner_fd;
+    new_ctx.key = (void *)&key;
+    new_ctx.value = msg;
+    new_ctx.curr_info = inner_info;
+    new_ctx.desc = desc;
+    return update_bpf_map(&new_ctx);
+}
+
+static int get_string_or_msg_field_size(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
+{
+    int real_len;
+    char *value = *(char **)((char *)ctx->value + field->offset);
+
+    if (field->type == PROTOBUF_C_TYPE_MESSAGE)
+        return ((ProtobufCMessageDescriptor *)(field->descriptor))->sizeof_message;
+
+    real_len = strlen(value) + 1;
+    if (real_len > MAP_VAL_STR_SIZE) {
+        LOG_ERR(
+            "fieldName:%s, id:%d, len:%d over str_max_len(%d).", field->name, field->id, real_len, MAP_VAL_STR_SIZE);
+        return -1;
+    }
+    return MAP_VAL_STR_SIZE;
 }
 
 static int field_handle(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
 {
-    int key = 0;
+    int ret;
+    unsigned int key;
 
-    if (field->type == PROTOBUF_C_TYPE_MESSAGE || field->type == PROTOBUF_C_TYPE_STRING) {
-        key = alloc_outter_map_entry(ctx);
-        if (key < 0)
-            return key;
-    }
+    if (field->type != PROTOBUF_C_TYPE_MESSAGE && field->type != PROTOBUF_C_TYPE_STRING)
+        return 0;
 
-    switch (field->type) {
-    case PROTOBUF_C_TYPE_MESSAGE:
-        return copy_msg_field_to_map(ctx, key, field);
-    case PROTOBUF_C_TYPE_STRING:
-        return copy_sfield_to_map(ctx, key, field);
-    default:
-        break;
-    }
+    key = alloc_outer_key(ctx, get_string_or_msg_field_size(ctx, field));
+    if (key < 0)
+        return key;
 
-    return 0;
+    if (field->type == PROTOBUF_C_TYPE_MESSAGE)
+        ret = copy_msg_field_to_map(ctx, key, field);
+    else
+        ret = copy_sfield_to_map(ctx, key, field);
+    if (ret)
+        free_outter_map_entry(ctx, &key);
+    return ret;
 }
 
-static int copy_indirect_data_to_map(struct op_context *ctx, int outter_key, void *value, ProtobufCType type)
+static int copy_indirect_data_to_map(struct op_context *ctx, unsigned int outer_key, void *value, ProtobufCType type)
 {
     int ret = 0;
     int inner_fd, key = 0;
     struct op_context new_ctx;
+    struct bpf_map_info *inner_info;
     const ProtobufCMessageDescriptor *desc;
 
-    inner_fd = outter_key_to_inner_fd(ctx, outter_key);
-    if (inner_fd < 0)
-        return inner_fd;
+    ret = outer_key_to_inner_map_index(outer_key, &inner_fd, &inner_info, &key);
+    if (ret)
+        return ret;
 
     switch (type) {
     case PROTOBUF_C_TYPE_MESSAGE:
@@ -447,7 +417,7 @@ static int copy_indirect_data_to_map(struct op_context *ctx, int outter_key, voi
         new_ctx.curr_fd = inner_fd;
         new_ctx.key = (void *)&key;
         new_ctx.value = value;
-        new_ctx.curr_info = ctx->inner_info;
+        new_ctx.curr_info = inner_info;
 
         desc = ((ProtobufCMessage *)value)->descriptor;
         if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
@@ -458,8 +428,8 @@ static int copy_indirect_data_to_map(struct op_context *ctx, int outter_key, voi
         ret = update_bpf_map(&new_ctx);
         break;
     case PROTOBUF_C_TYPE_STRING:
-        strcpy_s(ctx->inner_map_object, ctx->inner_info->value_size, (char *)value);
-        ret = bpf_map_update_elem(inner_fd, &key, ctx->inner_map_object, BPF_ANY);
+        strcpy_s(ctx->map_object, inner_info->value_size, (char *)value);
+        ret = bpf_map_update_elem(inner_fd, &key, ctx->map_object, BPF_ANY);
         break;
     default:
         break;
@@ -483,29 +453,31 @@ static int repeat_field_handle(struct op_context *ctx, const ProtobufCFieldDescr
 {
     int ret, ret1;
     unsigned int i;
-    int outter_key, inner_fd, key = 0;
+    int inner_fd, key = 0;
+    unsigned int outer_key;
+    struct bpf_map_info *inner_info = NULL;
     void *n = ((char *)ctx->value) + field->quantifier_offset;
     void ***value = (void ***)((char *)ctx->value + field->offset);
     void **origin_value = *value;
-    char *inner_map_object;
+    char *map_object;
 
-    outter_key = alloc_outter_map_entry(ctx);
-    if (outter_key < 0)
-        return outter_key;
-    *(uintptr_t *)value = (size_t)outter_key;
+    outer_key = alloc_outer_key(ctx, MAP_VAL_REPEAT_SIZE);
+    if (outer_key < 0)
+        return outer_key;
+    *(uintptr_t *)value = (size_t)outer_key;
     ret = bpf_map_update_elem(ctx->curr_fd, ctx->key, ctx->value, BPF_ANY);
     if (ret) {
-        LOG_ERR("repeat_field_handle bpf_map_update_elem failed, ret:%d ERRNO:%d\n", ret, errno);
-        free_outter_map_entry(ctx, &outter_key);
+        LOG_ERR("repeat_field_handle bpf_map_update_elem failed, ret:%d ERRNO:%d", ret, errno);
+        free_outter_map_entry(ctx, &outer_key);
         return ret;
     }
 
-    inner_fd = outter_key_to_inner_fd(ctx, outter_key);
-    if (inner_fd < 0)
-        return inner_fd;
+    ret = outer_key_to_inner_map_index(outer_key, &inner_fd, &inner_info, &key);
+    if (ret)
+        return ret;
 
-    inner_map_object = calloc(1, ctx->inner_info->value_size);
-    if (!inner_map_object) {
+    map_object = calloc(1, inner_info->value_size);
+    if (!map_object) {
         return -ENOMEM;
     }
 
@@ -513,34 +485,34 @@ static int repeat_field_handle(struct op_context *ctx, const ProtobufCFieldDescr
     case PROTOBUF_C_TYPE_MESSAGE:
     case PROTOBUF_C_TYPE_STRING:
         for (i = 0; i < *(unsigned int *)n; i++) {
-            outter_key = alloc_outter_map_entry(ctx);
-            if (outter_key < 0)
+            outer_key = alloc_outer_key(ctx, get_string_or_msg_field_size(ctx, field));
+            if (outer_key < 0)
                 goto end;
 
-            *((uintptr_t *)inner_map_object + i) = (size_t)outter_key;
-            ret = copy_indirect_data_to_map(ctx, outter_key, origin_value[i], field->type);
+            *((uintptr_t *)map_object + i) = (size_t)outer_key;
+            ret = copy_indirect_data_to_map(ctx, outer_key, origin_value[i], field->type);
             if (ret)
                 goto end;
         }
         break;
     default:
         memcpy_s(
-            inner_map_object,
-            ctx->inner_info->value_size,
+            map_object,
+            inner_info->value_size,
             (void *)origin_value,
             *(size_t *)n * sizeof_elt_in_repeated_array(field->type));
         break;
     }
 
 end:
-    ret1 = bpf_map_update_elem(inner_fd, &key, inner_map_object, BPF_ANY);
+    ret1 = bpf_map_update_elem(inner_fd, &key, map_object, BPF_ANY);
     if (ret1) {
         ret = ret1;
         if (indirect_data_type(field->type))
-            free_keys(ctx, inner_map_object, *(size_t *)n);
+            free_keys(ctx, map_object, *(size_t *)n);
     }
 
-    free(inner_map_object);
+    free(map_object);
     return ret;
 }
 
@@ -552,7 +524,7 @@ static int update_bpf_map(struct op_context *ctx)
     const ProtobufCMessageDescriptor *desc = ctx->desc;
 
     if (desc->sizeof_message > ctx->curr_info->value_size) {
-        LOG_ERR("map entry size is too small\n");
+        LOG_ERR("map entry size is too small");
         return -EINVAL;
     }
 
@@ -560,7 +532,7 @@ static int update_bpf_map(struct op_context *ctx)
     if (!temp_val)
         return -ENOMEM;
 
-    memcpy_s(temp_val, ctx->curr_info->value_size, ctx->value, ctx->curr_info->value_size);
+    memcpy_s(temp_val, ctx->curr_info->value_size, ctx->value, desc->sizeof_message);
     ctx->value = temp_val;
 
     for (i = 0; i < desc->n_fields; i++) {
@@ -580,7 +552,7 @@ static int update_bpf_map(struct op_context *ctx)
 
         if (ret) {
             LOG_INFO(
-                "desc.name:%s field[%d - %s] handle failed:%d, errno:%d\n",
+                "desc.name:%s field[%d - %s] handle failed:%d, errno:%d",
                 desc->short_name,
                 i,
                 desc->fields[i].name,
@@ -596,29 +568,15 @@ static int update_bpf_map(struct op_context *ctx)
     return ret;
 }
 
-static int map_info_check(struct bpf_map_info *outter_info, struct bpf_map_info *inner_info)
-{
-    if (outter_info->type != BPF_MAP_TYPE_ARRAY_OF_MAPS) {
-        LOG_ERR("outter map type must be BPF_MAP_TYPE_ARRAY_OF_MAPS\n");
-        return -EINVAL;
-    }
-
-    if (outter_info->max_entries < 2 || outter_info->max_entries > MAX_OUTTER_MAP_ENTRIES) {
-        LOG_ERR("outter map max_entries must be in[2,%d]\n", MAX_OUTTER_MAP_ENTRIES);
-        return -EINVAL;
-    }
-    return 0;
-}
-
 int deserial_update_elem(void *key, void *value)
 {
     int ret;
     const char *map_name = NULL;
-    struct op_context context = {.inner_map_object = NULL};
+    struct op_context context = {.map_object = NULL};
     const ProtobufCMessageDescriptor *desc;
-    struct bpf_map_info outter_info = {0}, inner_info = {0}, info = {0};
-    int map_fd, outter_fd = 0, inner_fd = 0;
-    unsigned int id, outter_id = 0, inner_id = 0;
+    struct bpf_map_info info = {0};
+    int map_fd = 0;
+    unsigned int id;
 
     if (!key || !value)
         return -EINVAL;
@@ -627,13 +585,13 @@ int deserial_update_elem(void *key, void *value)
     if (desc && desc->magic == PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC)
         map_name = desc->short_name;
 
-    ret = get_map_ids(map_name, &id, &outter_id, &inner_id);
+    ret = get_map_id(map_name, &id);
     if (ret)
         return ret;
 
     ret = get_map_fd_info(id, &map_fd, &info);
     if (ret < 0) {
-        LOG_ERR("invalid MAP_ID: %d, errno:%d\n", id, errno);
+        LOG_ERR("invalid MAP_ID: %d, errno:%d", id, errno);
         return ret;
     }
 
@@ -642,17 +600,12 @@ int deserial_update_elem(void *key, void *value)
         goto end;
     }
 
-    ret = get_map_fd_info(inner_id, &inner_fd, &inner_info);
-    ret |= get_map_fd_info(outter_id, &outter_fd, &outter_info);
-    if (ret < 0 || map_info_check(&outter_info, &inner_info))
-        goto end;
-
     deserial_delete_elem(key, desc);
 
-    init_op_context(context, key, value, desc, outter_fd, map_fd, &outter_info, &inner_info, &info);
+    init_op_context(context, key, value, desc, map_fd, &info);
 
-    context.inner_map_object = calloc(1, context.inner_info->value_size);
-    if (context.inner_map_object == NULL) {
+    context.map_object = calloc(1, g_map_mng.inner_infos[MAP_TYPE_MAX - 1].value_size);
+    if (context.map_object == NULL) {
         ret = -errno;
         goto end;
     }
@@ -666,35 +619,31 @@ int deserial_update_elem(void *key, void *value)
 end:
     if (context.key != NULL)
         free(context.key);
-    if (context.inner_map_object != NULL)
-        free(context.inner_map_object);
+    if (context.map_object != NULL)
+        free(context.map_object);
     if (map_fd > 0)
         close(map_fd);
-    if (outter_fd > 0)
-        close(outter_fd);
-    if (inner_fd > 0)
-        close(inner_fd);
     return ret;
 }
 
 static int query_string_field(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
 {
-    int key = 0, ret;
-    int inner_fd;
+    int ret;
+    int inner_fd, key;
     void *string;
-    void *outter_key = (void *)((char *)ctx->value + field->offset);
+    struct bpf_map_info *map_info = NULL;
+    void *outer_key = (void *)((char *)ctx->value + field->offset);
 
-    inner_fd = outter_key_to_inner_fd(ctx, *(int *)outter_key);
-    if (inner_fd < 0)
-        return inner_fd;
+    ret = outer_key_to_inner_map_index(*(unsigned int *)outer_key, &inner_fd, &map_info, &key);
+    if (ret)
+        return ret;
 
-    string = malloc(ctx->inner_info->value_size);
+    string = calloc(1, map_info->value_size);
     if (!string) {
         return -ENOMEM;
     }
 
-    (*(uintptr_t *)outter_key) = (uintptr_t)string;
-
+    (*(uintptr_t *)outer_key) = (uintptr_t)string;
     ret = bpf_map_lookup_elem(inner_fd, &key, string);
     return ret;
 }
@@ -706,17 +655,18 @@ static int query_message_field(struct op_context *ctx, const ProtobufCFieldDescr
     int inner_fd;
     void *message;
     struct op_context new_ctx;
+    struct bpf_map_info *map_info = NULL;
     const ProtobufCMessageDescriptor *desc;
-    uintptr_t *outter_key = (uintptr_t *)((char *)ctx->value + field->offset);
+    uintptr_t *outer_key = (uintptr_t *)((char *)ctx->value + field->offset);
 
-    inner_fd = outter_key_to_inner_fd(ctx, *outter_key);
-    if (inner_fd < 0)
-        return inner_fd;
+    ret = outer_key_to_inner_map_index(*(unsigned int *)outer_key, &inner_fd, &map_info, &key);
+    if (ret)
+        return ret;
 
     memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
     new_ctx.curr_fd = inner_fd;
     new_ctx.key = (void *)&key;
-    new_ctx.curr_info = ctx->inner_info;
+    new_ctx.curr_info = map_info;
 
     desc = (ProtobufCMessageDescriptor *)field->descriptor;
     if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
@@ -724,9 +674,8 @@ static int query_message_field(struct op_context *ctx, const ProtobufCFieldDescr
     }
 
     new_ctx.desc = desc;
-
     message = create_struct(&new_ctx, &ret);
-    *outter_key = (uintptr_t)message;
+    *outer_key = (uintptr_t)message;
     return ret;
 }
 
@@ -744,26 +693,25 @@ static int field_query(struct op_context *ctx, const ProtobufCFieldDescriptor *f
     return 0;
 }
 
-static void *create_indirect_struct(
-    struct op_context *ctx, unsigned long outter_key, const ProtobufCFieldDescriptor *field, int *err)
+static void *
+create_indirect_struct(struct op_context *ctx, unsigned long outer_key, const ProtobufCFieldDescriptor *field, int *err)
 {
-    int inner_fd, key = 0;
-    void *value;
+    int ret, inner_fd, key = 0;
+    void *value = NULL;
     struct op_context new_ctx;
+    struct bpf_map_info *map_info = NULL;
     const ProtobufCMessageDescriptor *desc;
 
-    inner_fd = outter_key_to_inner_fd(ctx, outter_key);
-    if (inner_fd < 0) {
-        *err = inner_fd;
+    ret = outer_key_to_inner_map_index((unsigned int)outer_key, &inner_fd, &map_info, &key);
+    if (ret)
         return NULL;
-    }
 
     switch (field->type) {
     case PROTOBUF_C_TYPE_MESSAGE:
         memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
         new_ctx.curr_fd = inner_fd;
         new_ctx.key = (void *)&key;
-        new_ctx.curr_info = ctx->inner_info;
+        new_ctx.curr_info = map_info;
 
         desc = (ProtobufCMessageDescriptor *)field->descriptor;
         if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
@@ -775,7 +723,7 @@ static void *create_indirect_struct(
         value = create_struct(&new_ctx, err);
         return value;
     default:
-        value = malloc(ctx->inner_info->value_size);
+        value = calloc(1, map_info->value_size);
         if (!value) {
             *err = -ENOMEM;
             return NULL;
@@ -785,7 +733,6 @@ static void *create_indirect_struct(
         if (*err < 0) {
             return value;
         }
-
         break;
     }
 
@@ -800,19 +747,20 @@ static int repeat_field_query(struct op_context *ctx, const ProtobufCFieldDescri
     int inner_fd;
     void *array;
     unsigned int i;
+    struct bpf_map_info *map_info = NULL;
     void *n = ((char *)ctx->value) + field->quantifier_offset;
-    uintptr_t *outter_key = (uintptr_t *)((char *)ctx->value + field->offset);
+    uintptr_t *outer_key = (uintptr_t *)((char *)ctx->value + field->offset);
 
-    inner_fd = outter_key_to_inner_fd(ctx, *outter_key);
-    if (inner_fd < 0)
-        return inner_fd;
+    ret = outer_key_to_inner_map_index(*(unsigned int *)outer_key, &inner_fd, &map_info, &key);
+    if (ret)
+        return ret;
 
-    array = calloc(1, ctx->inner_info->value_size);
+    array = calloc(1, map_info->value_size);
     if (!array) {
         return -ENOMEM;
     }
 
-    *outter_key = (uintptr_t)array;
+    *outer_key = (uintptr_t)array;
     ret = bpf_map_lookup_elem(inner_fd, &key, array);
     if (ret < 0) {
         return ret;
@@ -822,8 +770,8 @@ static int repeat_field_query(struct op_context *ctx, const ProtobufCFieldDescri
     case PROTOBUF_C_TYPE_MESSAGE:
     case PROTOBUF_C_TYPE_STRING:
         for (i = 0; i < *(unsigned int *)n; i++) {
-            outter_key = (uintptr_t *)array + i;
-            *outter_key = (uintptr_t)create_indirect_struct(ctx, *outter_key, field, &ret);
+            outer_key = (uintptr_t *)array + i;
+            *outer_key = (uintptr_t)create_indirect_struct(ctx, *outer_key, field, &ret);
             if (ret)
                 break;
         }
@@ -859,7 +807,7 @@ static void *create_struct_list(struct op_context *ctx, int *err)
 
         value = create_struct(ctx, err);
         if (*err) {
-            LOG_ERR("create_struct failed, err = %d\n", err);
+            LOG_ERR("create_struct failed, err = %d", err);
             break;
         }
 
@@ -894,7 +842,7 @@ static void *create_struct(struct op_context *ctx, int *err)
     *err = 0;
 
     if (desc->sizeof_message > ctx->curr_info->value_size) {
-        LOG_ERR("map entry size is too small\n");
+        LOG_ERR("map entry size is too small");
         return NULL;
     }
 
@@ -925,7 +873,7 @@ static void *create_struct(struct op_context *ctx, int *err)
         }
 
         if (ret) {
-            LOG_INFO("field[%d] query fail\n", i);
+            LOG_INFO("field[%d] query fail", i);
             *err = 1;
             break;
         }
@@ -944,11 +892,11 @@ struct element_list_node *deserial_lookup_all_elems(const void *msg_desciptor)
     int ret, err;
     struct element_list_node *value_list_head = NULL;
     const char *map_name = NULL;
-    struct op_context context = {.inner_map_object = NULL};
+    struct op_context context = {.map_object = NULL};
     const ProtobufCMessageDescriptor *desc;
-    struct bpf_map_info outter_info = {0}, inner_info = {0}, info = {0};
-    int map_fd, outter_fd = 0, inner_fd = 0;
-    unsigned int id, outter_id = 0, inner_id = 0;
+    struct bpf_map_info info = {0};
+    int map_fd;
+    unsigned int id;
 
     if (msg_desciptor == NULL)
         return NULL;
@@ -958,37 +906,27 @@ struct element_list_node *deserial_lookup_all_elems(const void *msg_desciptor)
         return NULL;
 
     map_name = desc->short_name;
-    ret = get_map_ids(map_name, &id, &outter_id, &inner_id);
+    ret = get_map_id(map_name, &id);
     if (ret)
         return NULL;
 
     ret = get_map_fd_info(id, &map_fd, &info);
     if (ret < 0) {
-        LOG_ERR("invalid MAP_ID: %d\n", id);
+        LOG_ERR("invalid MAP_ID: %d", id);
         return NULL;
     }
 
-    ret = get_map_fd_info(inner_id, &inner_fd, &inner_info);
-    ret |= get_map_fd_info(outter_id, &outter_fd, &outter_info);
-    if (ret < 0 || map_info_check(&outter_info, &inner_info))
-        goto end;
-
-    init_op_context(context, NULL, NULL, desc, outter_fd, map_fd, &outter_info, &inner_info, &info);
+    init_op_context(context, NULL, NULL, desc, map_fd, &info);
 
     value_list_head = create_struct_list(&context, &err);
     if (err != 0) {
         LOG_ERR("create_struct_list failed, err = %d", err);
     }
 
-end:
     if (context.key != NULL)
         free(context.key);
     if (map_fd > 0)
         close(map_fd);
-    if (outter_fd > 0)
-        close(outter_fd);
-    if (inner_fd > 0)
-        close(inner_fd);
     return value_list_head;
 }
 
@@ -997,11 +935,11 @@ void *deserial_lookup_elem(void *key, const void *msg_desciptor)
     int ret, err;
     void *value = NULL;
     const char *map_name = NULL;
-    struct op_context context = {.inner_map_object = NULL};
+    struct op_context context;
     const ProtobufCMessageDescriptor *desc;
-    struct bpf_map_info outter_info = {0}, inner_info = {0}, info = {0};
-    int map_fd, outter_fd = 0, inner_fd = 0;
-    unsigned int id, outter_id = 0, inner_id = 0;
+    struct bpf_map_info info = {0};
+    int map_fd;
+    unsigned int id;
 
     if (msg_desciptor == NULL || key == NULL)
         return NULL;
@@ -1011,84 +949,73 @@ void *deserial_lookup_elem(void *key, const void *msg_desciptor)
         return NULL;
 
     map_name = desc->short_name;
-    ret = get_map_ids(map_name, &id, &outter_id, &inner_id);
+    ret = get_map_id(map_name, &id);
     if (ret)
         return NULL;
 
     ret = get_map_fd_info(id, &map_fd, &info);
     if (ret < 0) {
-        LOG_ERR("invalid MAP_ID: %d\n", id);
+        LOG_ERR("invalid MAP_ID: %d", id);
         return NULL;
     }
 
-    ret = get_map_fd_info(inner_id, &inner_fd, &inner_info);
-    ret |= get_map_fd_info(outter_id, &outter_fd, &outter_info);
-    if (ret < 0 || map_info_check(&outter_info, &inner_info))
-        goto end;
-
-    init_op_context(context, key, NULL, desc, outter_fd, map_fd, &outter_info, &inner_info, &info);
+    init_op_context(context, key, NULL, desc, map_fd, &info);
 
     normalize_key(&context, key, map_name);
     value = create_struct(&context, &err);
     if (err != 0) {
-        LOG_ERR("create_struct failed, err = %d\n", err);
+        LOG_ERR("create_struct failed, err = %d", err);
     }
 
-end:
     if (context.key != NULL)
         free(context.key);
     if (map_fd > 0)
         close(map_fd);
-    if (outter_fd > 0)
-        close(outter_fd);
-    if (inner_fd > 0)
-        close(inner_fd);
     return value;
 }
 
-static int indirect_field_del(struct op_context *ctx, unsigned int outter_key, const ProtobufCFieldDescriptor *field)
+static int indirect_field_del(struct op_context *ctx, unsigned int outer_key, const ProtobufCFieldDescriptor *field)
 {
-    char *inner_map_object = NULL;
+    char *map_object = NULL;
     int inner_fd, key = 0;
     struct op_context new_ctx;
+    struct bpf_map_info *inner_info;
     const ProtobufCMessageDescriptor *desc;
 
-    if (!valid_outter_key(ctx, outter_key))
+    if (!valid_outer_key(ctx, outer_key))
         return -EINVAL;
 
-    inner_fd = outter_key_to_inner_fd(ctx, (unsigned long)outter_key);
-    if (inner_fd < 0)
-        return inner_fd;
-
-    free_outter_map_entry(ctx, &outter_key);
+    outer_key_to_inner_map_index(outer_key, &inner_fd, &inner_info, &key);
+    free_outter_map_entry(ctx, &outer_key);
 
     switch (field->type) {
     case PROTOBUF_C_TYPE_MESSAGE:
         desc = (ProtobufCMessageDescriptor *)field->descriptor;
         if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC) {
-            return -EINVAL;
+            break;
         }
 
-        inner_map_object = malloc(ctx->inner_info->value_size);
-        if (!inner_map_object) {
-            return -ENOMEM;
+        map_object = malloc(inner_info->value_size);
+        if (!map_object) {
+            LOG_WARN("indirect_field_del malloc failed:%d", errno);
+            break;
         }
 
         memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
         new_ctx.curr_fd = inner_fd;
         new_ctx.key = (void *)&key;
-        new_ctx.curr_info = ctx->inner_info;
-        new_ctx.value = inner_map_object;
+        new_ctx.curr_info = inner_info;
+        new_ctx.value = map_object;
         new_ctx.desc = desc;
 
-        (void)del_bpf_map(&new_ctx, 1);
-        free(inner_map_object);
+        (void)del_bpf_map(&new_ctx);
+        free(map_object);
         break;
-
     default:
         break;
     }
 
+    bpf_map_delete_elem(inner_fd, &key);
     return 0;
 }
 
@@ -1097,25 +1024,20 @@ static int repeat_field_del(struct op_context *ctx, const ProtobufCFieldDescript
     int ret;
     unsigned int i;
     int inner_fd, key = 0;
-    void *inner_map_object = NULL;
+    void *map_object = NULL;
     void *n;
-    uintptr_t *outter_key;
+    unsigned int *outer_key;
+    struct bpf_map_info *inner_info;
 
-    ret = bpf_map_lookup_elem(ctx->curr_fd, ctx->key, ctx->value);
-    if (ret < 0) {
-        LOG_WARN("failed to find map(%d) elem: %d.", ctx->curr_fd, ret);
-        return ret;
-    }
-
-    outter_key = (uintptr_t *)((char *)ctx->value + field->offset);
-    if (!valid_outter_key(ctx, *outter_key))
+    outer_key = (unsigned int *)((char *)ctx->value + field->offset);
+    if (!valid_outer_key(ctx, *outer_key))
         return -EINVAL;
 
-    inner_fd = outter_key_to_inner_fd(ctx, *outter_key);
-    if (inner_fd < 0)
-        return inner_fd;
+    ret = outer_key_to_inner_map_index(*outer_key, &inner_fd, &inner_info, &key);
+    if (ret)
+        return ret;
 
-    ret = free_outter_map_entry(ctx, outter_key);
+    ret = free_outter_map_entry(ctx, outer_key);
     if (ret)
         return ret;
 
@@ -1125,35 +1047,40 @@ static int repeat_field_del(struct op_context *ctx, const ProtobufCFieldDescript
     case PROTOBUF_C_TYPE_MESSAGE:
         // lint -fallthrough
     case PROTOBUF_C_TYPE_STRING:
-        inner_map_object = calloc(1, ctx->inner_info->value_size);
-        if (!inner_map_object) {
+        map_object = calloc(1, inner_info->value_size);
+        if (!map_object) {
             ret = -ENOMEM;
             goto end;
         }
 
-        ret = bpf_map_lookup_elem(inner_fd, &key, inner_map_object);
+        ret = bpf_map_lookup_elem(inner_fd, &key, map_object);
         if (ret < 0)
             goto end;
 
         for (i = 0; i < *(size_t *)n; i++) {
-            outter_key = (uintptr_t *)inner_map_object + i;
-            indirect_field_del(ctx, *outter_key, field);
+            outer_key = (unsigned int *)map_object + i;
+            indirect_field_del(ctx, *outer_key, field);
         }
     default:
         break;
     }
 
 end:
-    if (inner_map_object != NULL)
-        free(inner_map_object);
+    bpf_map_delete_elem(inner_fd, &key);
+    if (map_object != NULL)
+        free(map_object);
     return ret;
 }
 
-static int msg_field_del(struct op_context *ctx, int inner_fd, const ProtobufCFieldDescriptor *field)
+static int msg_field_del(
+    struct op_context *ctx,
+    int inner_fd,
+    struct bpf_map_info *inner_info,
+    int inner_idx,
+    const ProtobufCFieldDescriptor *field)
 {
-    int key = 0;
     int ret;
-    char *inner_map_object = NULL;
+    char *map_object = NULL;
     struct op_context new_ctx;
     const ProtobufCMessageDescriptor *desc;
 
@@ -1161,27 +1088,28 @@ static int msg_field_del(struct op_context *ctx, int inner_fd, const ProtobufCFi
     if (!desc || desc->magic != PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC)
         return -EINVAL;
 
-    inner_map_object = malloc(ctx->inner_info->value_size);
-    if (!inner_map_object)
+    map_object = malloc(inner_info->value_size);
+    if (!map_object)
         return -ENOMEM;
 
     memcpy_s(&new_ctx, sizeof(new_ctx), ctx, sizeof(*ctx));
     new_ctx.curr_fd = inner_fd;
-    new_ctx.key = (void *)&key;
-    new_ctx.curr_info = ctx->inner_info;
-    new_ctx.value = inner_map_object;
+    new_ctx.key = (void *)&inner_idx;
+    new_ctx.curr_info = inner_info;
+    new_ctx.value = map_object;
     new_ctx.desc = desc;
 
-    ret = del_bpf_map(&new_ctx, 1);
-    free(inner_map_object);
+    ret = del_bpf_map(&new_ctx);
+    free(map_object);
     return ret;
 }
 
 static int field_del(struct op_context *ctx, const ProtobufCFieldDescriptor *field)
 {
     int ret;
-    int inner_fd;
-    uintptr_t *outter_key;
+    int inner_fd, inner_idx;
+    unsigned int *outer_key;
+    struct bpf_map_info *inner_info;
 
     switch (field->type) {
     case PROTOBUF_C_TYPE_MESSAGE:
@@ -1190,21 +1118,22 @@ static int field_del(struct op_context *ctx, const ProtobufCFieldDescriptor *fie
         if (ret < 0)
             return ret;
 
-        outter_key = (uintptr_t *)((char *)ctx->value + field->offset);
-        if (!valid_outter_key(ctx, *outter_key))
+        outer_key = (unsigned int *)((char *)ctx->value + field->offset);
+        if (!valid_outer_key(ctx, *outer_key))
             return -EINVAL;
 
-        inner_fd = outter_key_to_inner_fd(ctx, *outter_key);
-        if (inner_fd < 0)
-            return inner_fd;
+        ret = outer_key_to_inner_map_index(*outer_key, &inner_fd, &inner_info, &inner_idx);
+        if (ret)
+            return ret;
 
-        free_outter_map_entry(ctx, outter_key);
+        free_outter_map_entry(ctx, outer_key);
 
         if (field->type == PROTOBUF_C_TYPE_STRING) {
+            bpf_map_delete_elem(inner_fd, &inner_idx);
             break;
         }
 
-        msg_field_del(ctx, inner_fd, field);
+        msg_field_del(ctx, inner_fd, inner_info, inner_idx, field);
         break;
     default:
         break;
@@ -1213,7 +1142,7 @@ static int field_del(struct op_context *ctx, const ProtobufCFieldDescriptor *fie
     return 0;
 }
 
-static int del_bpf_map(struct op_context *ctx, int is_inner)
+static int del_bpf_map(struct op_context *ctx)
 {
     int ret;
     unsigned int i;
@@ -1244,19 +1173,18 @@ static int del_bpf_map(struct op_context *ctx, int is_inner)
     }
 
 end:
-    return (is_inner == 1) ?: bpf_map_delete_elem(ctx->curr_fd, ctx->key);
+    return bpf_map_delete_elem(ctx->curr_fd, ctx->key);
 }
 
 int deserial_delete_elem(void *key, const void *msg_desciptor)
 {
     int ret;
     const char *map_name = NULL;
-    struct op_context context = {.inner_map_object = NULL};
+    struct op_context context;
     const ProtobufCMessageDescriptor *desc;
-    struct bpf_map_info outter_info = {0}, inner_info = {0}, info = {0};
-    int map_fd, outter_fd = 0, inner_fd = 0;
-    unsigned int id, outter_id = 0, inner_id = 0;
-    char *inner_map_object = NULL;
+    struct bpf_map_info info = {0};
+    int map_fd;
+    unsigned int id;
 
     if (!key || !msg_desciptor)
         return -EINVAL;
@@ -1265,13 +1193,13 @@ int deserial_delete_elem(void *key, const void *msg_desciptor)
     if (desc->magic == PROTOBUF_C__MESSAGE_DESCRIPTOR_MAGIC)
         map_name = desc->short_name;
 
-    ret = get_map_ids(map_name, &id, &outter_id, &inner_id);
+    ret = get_map_id(map_name, &id);
     if (ret)
         return ret;
 
     ret = get_map_fd_info(id, &map_fd, &info);
     if (ret < 0) {
-        LOG_ERR("invalid MAP_ID: %d\n", id);
+        LOG_ERR("invalid MAP_ID: %d", id);
         return ret;
     }
 
@@ -1280,38 +1208,23 @@ int deserial_delete_elem(void *key, const void *msg_desciptor)
         goto end;
     }
 
-    ret = get_map_fd_info(inner_id, &inner_fd, &inner_info);
-    ret |= get_map_fd_info(outter_id, &outter_fd, &outter_info);
-    if (ret < 0 || map_info_check(&outter_info, &inner_info))
-        goto end;
-
-    init_op_context(context, key, NULL, desc, outter_fd, map_fd, &outter_info, &inner_info, &info);
-
-    context.inner_map_object = calloc(1, context.inner_info->value_size);
+    init_op_context(context, key, NULL, desc, map_fd, &info);
     context.value = calloc(1, context.curr_info->value_size);
-    if (!context.inner_map_object || !context.value) {
+    if (!context.value) {
         ret = -errno;
         goto end;
     }
 
-    inner_map_object = context.inner_map_object;
-
     normalize_key(&context, key, map_name);
-    ret = del_bpf_map(&context, 0);
+    ret = del_bpf_map(&context);
 
 end:
     if (context.key != NULL)
         free(context.key);
     if (context.value != NULL)
         free(context.value);
-    if (inner_map_object != NULL)
-        free(inner_map_object);
     if (map_fd > 0)
         close(map_fd);
-    if (outter_fd > 0)
-        close(outter_fd);
-    if (inner_fd > 0)
-        close(inner_fd);
     return ret;
 }
 
@@ -1363,7 +1276,7 @@ void deserial_free_elem(void *value)
     const char *map_name = NULL;
     const ProtobufCMessageDescriptor *desc;
 
-    if (!value || (uintptr_t)value < MAX_OUTTER_MAP_ENTRIES)
+    if (!value || (uintptr_t)value < UINT32_MAX)
         return;
 
     desc = ((ProtobufCMessage *)value)->descriptor;
@@ -1396,494 +1309,87 @@ void deserial_free_elem(void *value)
     return;
 }
 
-int get_outer_inner_map_infos(
-    int *inner_fd, struct bpf_map_info *inner_info, int *outter_fd, struct bpf_map_info *outter_info)
-{
-    int ret;
-    unsigned int outter_id, inner_id;
-
-    outter_id = get_map_id("OUTTER_MAP_ID");
-    inner_id = get_map_id("INNER_MAP_ID");
-    if (!outter_id || !inner_id)
-        return -1;
-
-    ret = get_map_fd_info(inner_id, inner_fd, inner_info);
-    ret |= get_map_fd_info(outter_id, outter_fd, outter_info);
-    if (ret < 0 || map_info_check(outter_info, inner_info))
-        return -1;
-    return 0;
-}
-
-void outter_map_insert(struct task_contex *ctx)
-{
-    int i, end, idx, ret = 0;
-    pthread_t tid = pthread_self();
-
-    i = (ctx->task_id * TASK_SIZE) ? (ctx->task_id * TASK_SIZE) : 1;
-    end = ((i + TASK_SIZE) < MAX_OUTTER_MAP_ENTRIES) ? (i + TASK_SIZE) : MAX_OUTTER_MAP_ENTRIES;
-    for (; i < end; i++) {
-        idx = g_inner_map_mng.elastic_slots[i];
-        if (!g_inner_map_mng.inner_maps[idx].map_fd) {
-            continue;
-        }
-
-        ret = bpf_map_update_elem(ctx->outter_fd, &idx, &g_inner_map_mng.inner_maps[idx].map_fd, BPF_ANY);
-        if (ret)
-            break;
-        g_inner_map_mng.inner_maps[idx].allocated = 1;
-    }
-
-    if (ret)
-        LOG_ERR("[%lu]outter_map_insert %d-%d failed:%d\n", tid, i, idx, ret);
-    return;
-}
-
-void outter_map_delete(struct task_contex *ctx)
-{
-    int i, end, idx, ret = 0;
-    pthread_t tid = pthread_self();
-
-    i = ctx->task_id * TASK_SIZE;
-    end = (i + TASK_SIZE);
-    for (; i < end; i++) {
-        idx = g_inner_map_mng.elastic_slots[i];
-        if (g_inner_map_mng.inner_maps[idx].map_fd) {
-            continue;
-        }
-
-        ret = bpf_map_delete_elem(ctx->outter_fd, &idx);
-        if (ret)
-            break;
-        g_inner_map_mng.inner_maps[idx].allocated = 0;
-    }
-
-    if (ret)
-        LOG_ERR("[%lu]outter_map_delete %d-%d failed:%d, err:%d\n", tid, i, idx, ret, errno);
-    return;
-}
-
-void *outter_map_update_task(void *arg)
-{
-    struct task_contex *ctx = (struct task_contex *)arg;
-    if (!ctx)
-        return NULL;
-
-    if (ctx->scaleup)
-        outter_map_insert(ctx);
-    else
-        outter_map_delete(ctx);
-    free(ctx);
-    sem_post(&g_inner_map_mng.fin_tasks);
-    return NULL;
-}
-
-void wait_sem_value(sem_t *sem, int wait_value)
-{
-    int sem_val;
-    do {
-        sem_getvalue(sem, &sem_val);
-    } while (sem_val < wait_value);
-}
-
-void reset_sem_value(sem_t *sem)
-{
-    int val;
-    while (sem_getvalue(sem, &val) == 0 && val > 0) {
-        if (sem_trywait(sem) != 0) {
-            break;
-        }
-    }
-    return;
-}
-
-int outter_map_update(int outter_fd, bool scaleup)
-{
-    int i, ret = 0;
-    pthread_t tid;
-    struct task_contex *task_ctx = NULL;
-    int threads = OUTTER_MAP_SCALEIN_STEP / TASK_SIZE;
-    if (scaleup)
-        threads = OUTTER_MAP_SCALEUP_STEP / TASK_SIZE;
-
-    reset_sem_value(&g_inner_map_mng.fin_tasks);
-    for (i = 0; i < threads; i++) {
-        task_ctx = (struct task_contex *)malloc(sizeof(struct task_contex));
-        if (!task_ctx)
-            break;
-
-        task_ctx->task_id = i;
-        task_ctx->scaleup = scaleup;
-        task_ctx->outter_fd = outter_fd;
-        ret = pthread_create(&tid, NULL, outter_map_update_task, task_ctx);
-        if (ret) {
-            free(task_ctx);
-            break;
-        }
-    }
-
-    if (ret) {
-        LOG_ERR("outter_map_update failed:%d\n", ret);
-        return ret;
-    }
-
-    wait_sem_value(&g_inner_map_mng.fin_tasks, threads);
-    return ret;
-}
-
-int inner_map_create(struct bpf_map_info *inner_info)
-{
-    int fd;
-#if LIBBPF_HIGHER_0_6_0_VERSION
-    LIBBPF_OPTS(bpf_map_create_opts, opts, .map_flags = inner_info->map_flags);
-
-    fd = bpf_map_create(
-        inner_info->type, NULL, inner_info->key_size, inner_info->value_size, inner_info->max_entries, &opts);
-#else
-    fd = bpf_create_map_name(
-        inner_info->type,
-        NULL,
-        inner_info->key_size,
-        inner_info->value_size,
-        inner_info->max_entries,
-        inner_info->map_flags);
-#endif
-    return fd;
-}
-
-void collect_outter_map_scaleup_slots()
-{
-    int i = 0, j = 0;
-    memset(g_inner_map_mng.elastic_slots, 0, sizeof(int) * ELASTIC_SLOTS_NUM);
-    for (; i < MAX_OUTTER_MAP_ENTRIES; i++) {
-        if (g_inner_map_mng.inner_maps[i].allocated == 0) {
-            g_inner_map_mng.elastic_slots[j++] = i;
-            if (j >= OUTTER_MAP_SCALEUP_STEP)
-                break;
-        }
-    }
-    LOG_WARN("collect_outter_map_scaleup_slots:%d-%d-%d\n", i, j, g_inner_map_mng.elastic_slots[j - 1]);
-    return;
-}
-
-void collect_outter_map_scalein_slots()
-{
-    int i, j = 0;
-    memset(g_inner_map_mng.elastic_slots, 0, sizeof(int) * ELASTIC_SLOTS_NUM);
-    for (i = g_inner_map_mng.max_allocated_idx; i >= 0; i--) {
-        if (g_inner_map_mng.inner_maps[i].used == 0 && g_inner_map_mng.inner_maps[i].allocated == 1) {
-            g_inner_map_mng.elastic_slots[j++] = i;
-            if (j >= OUTTER_MAP_SCALEIN_STEP)
-                break;
-        }
-    }
-    LOG_WARN("collect_outter_map_scalein_slots:%d-%d-%d\n", i, j, g_inner_map_mng.elastic_slots[j - 1]);
-    return;
-}
-
-int inner_map_batch_create(struct bpf_map_info *inner_info)
-{
-    int i, fd;
-
-    collect_outter_map_scaleup_slots();
-    for (i = 1; i < OUTTER_MAP_SCALEUP_STEP; i++) {
-        fd = inner_map_create(inner_info);
-        if (fd < 0)
-            break;
-
-        g_inner_map_mng.inner_maps[g_inner_map_mng.elastic_slots[i]].map_fd = fd;
-    }
-
-    if (i < OUTTER_MAP_SCALEUP_STEP)
-        LOG_WARN("[warning]inner_map_create (%d->%d) failed:%d, errno:%d\n", i, MAX_OUTTER_MAP_ENTRIES, fd, errno);
-    return 0;
-}
-
-void inner_map_batch_delete()
-{
-    int i, idx;
-
-    collect_outter_map_scalein_slots();
-    for (i = 0; i < OUTTER_MAP_SCALEIN_STEP; i++) {
-        idx = g_inner_map_mng.elastic_slots[i];
-        if (g_inner_map_mng.inner_maps[idx].used == 0 && g_inner_map_mng.inner_maps[idx].map_fd) {
-            close(g_inner_map_mng.inner_maps[idx].map_fd);
-            g_inner_map_mng.inner_maps[idx].map_fd = 0;
-        }
-    }
-    return;
-}
-
-int deserial_uninit(bool persist)
-{
-    int ret = 0;
-    remove(MAP_IN_MAP_MNG_PERSIST_FILE_PATH);
-    if (persist)
-        ret = inner_map_mng_persist();
-
-    for (int i = 1; i <= g_inner_map_mng.max_allocated_idx; i++) {
-        g_inner_map_mng.inner_maps[i].allocated = 0;
-        g_inner_map_mng.inner_maps[i].used = 0;
-        if (g_inner_map_mng.inner_maps[i].map_fd)
-            close(g_inner_map_mng.inner_maps[i].map_fd);
-    }
-
-    (void)sem_destroy(&g_inner_map_mng.fin_tasks);
-    g_inner_map_mng.elastic_task_exit = 1;
-    g_inner_map_mng.used_cnt = 0;
-    g_inner_map_mng.allocated_cnt = 0;
-    g_inner_map_mng.max_allocated_idx = 0;
-    g_inner_map_mng.init = 0;
-
-    close(g_inner_map_mng.inner_fd);
-    close(g_inner_map_mng.outter_fd);
-    return ret;
-}
-
-int inner_map_scaleup()
-{
-    int ret;
-    float percent = 1;
-
-    if (g_inner_map_mng.allocated_cnt)
-        percent = ((float)g_inner_map_mng.used_cnt) / ((float)g_inner_map_mng.allocated_cnt);
-    if (percent < OUTTER_MAP_USAGE_HIGH_PERCENT)
-        return 0;
-
-    LOG_WARN(
-        "Remaining resources are insufficient(%d/%d), and capacity expansion is required.\n",
-        g_inner_map_mng.used_cnt,
-        g_inner_map_mng.allocated_cnt);
-
-    do {
-        ret = inner_map_batch_create(&g_inner_map_mng.inner_info);
-        if (ret)
-            break;
-
-        ret = outter_map_update(g_inner_map_mng.outter_fd, true);
-        if (ret)
-            break;
-
-        g_inner_map_mng.allocated_cnt += OUTTER_MAP_SCALEUP_STEP;
-        if (g_inner_map_mng.elastic_slots[OUTTER_MAP_SCALEUP_STEP - 1] > g_inner_map_mng.max_allocated_idx)
-            g_inner_map_mng.max_allocated_idx = g_inner_map_mng.elastic_slots[OUTTER_MAP_SCALEUP_STEP - 1];
-    } while (0);
-
-    if (ret) {
-        LOG_ERR("inner_map_scaleup failed:%d\n", ret);
-    }
-    return ret;
-}
-
-int inner_map_scalein()
+int get_map_infos()
 {
     int i, ret;
-    float percent = 1;
+    unsigned int inner_id;
+    char *map_names[] = {
+        "Map64",
+        "Map192",
+        "Map296",
+        "Map1600",
+    };
 
-    if (g_inner_map_mng.allocated_cnt > OUTTER_MAP_SCALEUP_STEP)
-        percent = ((float)g_inner_map_mng.used_cnt) / ((float)g_inner_map_mng.allocated_cnt);
-    if (percent > OUTTER_MAP_USAGE_LOW_PERCENT)
-        return 0;
+    for (i = 0; i < MAP_TYPE_MAX; i++) {
+        ret = get_map_id(map_names[i], &inner_id);
+        if (ret)
+            return -1;
 
-    LOG_WARN(
-        "The remaining resources are sufficient(%d/%d) and scale-in is required.\n",
-        g_inner_map_mng.used_cnt,
-        g_inner_map_mng.allocated_cnt);
-
-    inner_map_batch_delete();
-    ret = outter_map_update(g_inner_map_mng.outter_fd, false);
-    if (ret) {
-        LOG_ERR("inner_map_scalein failed:%d\n", ret);
-        return ret;
+        ret = get_map_fd_info(inner_id, &g_map_mng.inner_fds[i], &g_map_mng.inner_infos[i]);
+        if (ret < 0)
+            return ret;
     }
+    return 0;
+}
 
-    g_inner_map_mng.allocated_cnt -= OUTTER_MAP_SCALEIN_STEP;
-    for (i = g_inner_map_mng.max_allocated_idx; i >= 0; i--) {
-        if (g_inner_map_mng.inner_maps[i].allocated) {
-            g_inner_map_mng.max_allocated_idx = i;
+void deserial_uninit()
+{
+    int i;
+    for (i = 0; i < MAP_TYPE_MAX; i++) {
+        close(g_map_mng.inner_fds[i]);
+    }
+    return;
+}
+
+int map_restore(int map_fd, struct bpf_map_info *map_info, unsigned char *bitmap)
+{
+    void *prev_key;
+    unsigned int key;
+
+    while (!bpf_map_get_next_key(map_fd, prev_key, &key)) {
+        if (MAP_GET_TYPE(key) >= MAP_TYPE_MAX || MAP_GET_INDEX(key) >= MAP_MAX_ENTRIES) {
+            LOG_ERR("bpf_map_get_next_key key:%u invalid.", key);
+            return -1;
+        }
+
+        SET_BIT(bitmap, key);
+        prev_key = &key;
+    }
+    return 0;
+}
+
+int maps_restore()
+{
+    // restore from bpf map
+    int i, ret = 0;
+
+    for (i = 0; i < MAP_TYPE_MAX; i++) {
+        ret = map_restore(g_map_mng.inner_fds[i], &g_map_mng.inner_infos[i], g_map_mng.mim_used_bitmap[i]);
+        if (ret) {
+            LOG_ERR("map_restore %d failed:%d", i, ret);
             break;
         }
     }
     return ret;
 }
 
-void *inner_map_elastic_scaling_task(void *arg)
-{
-    for (;;) {
-        if (g_inner_map_mng.elastic_task_exit) {
-            LOG_WARN("Receive exit signal for inner-map elastic scaling task.\n");
-            break;
-        }
-
-        inner_map_scaleup();
-        inner_map_scalein();
-        usleep(1000);
-    }
-    return NULL;
-}
-
-int inner_map_elastic_scaling()
-{
-    pthread_t tid;
-    return pthread_create(&tid, NULL, inner_map_elastic_scaling_task, NULL);
-}
-
-int inner_map_mng_persist()
-{
-    int i, size, map_fd;
-    FILE *f = NULL;
-    struct persist_info *p = NULL;
-
-    if (g_inner_map_mng.init == 0)
-        return 0;
-
-    size = sizeof(struct persist_info) + sizeof(struct inner_map_stat) * (g_inner_map_mng.max_allocated_idx + 1);
-    p = (struct persist_info *)malloc(size);
-    if (!p) {
-        LOG_ERR("inner_map_mng_persist malloc failed.\n");
-        return -1;
-    }
-
-    p->magic = MAGIC_NUMBER;
-    p->allocated_cnt = g_inner_map_mng.allocated_cnt;
-    p->used_cnt = g_inner_map_mng.used_cnt;
-    p->max_allocated_idx = g_inner_map_mng.max_allocated_idx;
-
-    /* Since map_fd cannot be used universally in different processes,
-    map_fd needs to be converted into map_id and stored, and then
-    converted into map_fd in the corresponding process when the
-    configuration is restored.
-    When storing map_fd into outer_map, the kernel update interface will
-    perform special processing on maps of types BPF_MAP_TYPE_ARRAY_OF_MAPS
-    and BPF_MAP_TYPE_HASH_OF_MAPS. The input parameter is map_fd, but the
-    kernel will convert it into a bpf_map pointer for storage, so it will
-    not be affected.*/
-    for (i = 0; i <= g_inner_map_mng.max_allocated_idx; i++) {
-        if (g_inner_map_mng.inner_maps[i].allocated) {
-            map_fd = bpf_get_map_id_by_fd(g_inner_map_mng.inner_maps[i].map_fd);
-            if (map_fd < 0) {
-                return map_fd;
-            }
-            p->inner_map_stat[i].map_fd = map_fd;
-            p->inner_map_stat[i].used = g_inner_map_mng.inner_maps[i].used;
-            p->inner_map_stat[i].allocated = g_inner_map_mng.inner_maps[i].allocated;
-        }
-    }
-
-    f = fopen(MAP_IN_MAP_MNG_PERSIST_FILE_PATH, "wb");
-    if (f == NULL) {
-        LOG_ERR("inner_map_mng_persist fopen failed:%d.\n", errno);
-        free(p);
-        return -1;
-    }
-
-    (void)fwrite(p, sizeof(unsigned char), size, f);
-    fclose(f);
-    LOG_INFO("inner_map_mng_persist succeed.\n");
-    return 0;
-}
-
-int inner_map_mng_restore_by_persist_stat(struct persist_info *p, struct inner_map_stat *stat)
-{
-    memcpy(g_inner_map_mng.inner_maps, stat, sizeof(struct inner_map_stat) * (p->max_allocated_idx + 1));
-
-    // What is recorded in g_inner_map_mng.inner_maps[i].map_fd is map_id.
-    // Use map_id to get the fd of the inner_map in this process and refresh
-    // it to inner_maps for use.
-    for (int i = 0; i < p->max_allocated_idx; i++) {
-        if (g_inner_map_mng.inner_maps[i].allocated) {
-            int map_fd = bpf_map_get_fd_by_id(g_inner_map_mng.inner_maps[i].map_fd);
-            if (map_fd < 0) {
-                LOG_ERR("restore_by_persist_stat bpf_map_get_fd_by_id failed, i:[%d] map_fd:[%d]\n", i, map_fd);
-                return map_fd;
-            }
-            g_inner_map_mng.inner_maps[i].map_fd = map_fd;
-        }
-    }
-
-    g_inner_map_mng.used_cnt = p->used_cnt;
-    g_inner_map_mng.allocated_cnt = p->allocated_cnt;
-    g_inner_map_mng.max_allocated_idx = p->max_allocated_idx;
-    return 0;
-}
-
-int inner_map_restore(bool restore)
-{
-    int size;
-    int read_size;
-    int ret;
-    FILE *f = NULL;
-    struct persist_info p;
-    struct inner_map_stat *stat = NULL;
-
-    if (!restore) {
-        remove(MAP_IN_MAP_MNG_PERSIST_FILE_PATH);
-        return 0;
-    }
-
-    f = fopen(MAP_IN_MAP_MNG_PERSIST_FILE_PATH, "rb");
-    if (f == NULL)
-        return 0;
-
-    read_size = (int)fread(&p, sizeof(unsigned char), sizeof(struct persist_info), f);
-    if (read_size != sizeof(struct persist_info) || p.magic != MAGIC_NUMBER) {
-        LOG_WARN("inner_map_restore invalid size:%d/%lu\n", read_size, sizeof(struct persist_info));
-        fclose(f);
-        return 0;
-    }
-
-    size = sizeof(struct inner_map_stat) * (p.max_allocated_idx + 1);
-    stat = (struct inner_map_stat *)malloc(size);
-    if (!stat) {
-        LOG_ERR("inner_map_restore alloc failed.\n");
-        fclose(f);
-        return -1;
-    }
-
-    read_size = (int)fread(stat, sizeof(unsigned char), size, f);
-    if (read_size != size) {
-        LOG_WARN("inner_map_restore persist_stat invalid size:%d/%d\n", read_size, size);
-        fclose(f);
-        free(stat);
-        return 0;
-    }
-
-    ret = inner_map_mng_restore_by_persist_stat(&p, stat);
-    free(stat);
-    fclose(f);
-    return ret;
-}
-
-int deserial_init(bool restore)
+int deserial_init()
 {
     int ret = 0;
 
     do {
-        sem_init(&g_inner_map_mng.fin_tasks, 0, 0);
-        ret = get_outer_inner_map_infos(
-            &g_inner_map_mng.inner_fd,
-            &g_inner_map_mng.inner_info,
-            &g_inner_map_mng.outter_fd,
-            &g_inner_map_mng.outter_info);
+        ret = get_map_infos();
         if (ret)
             break;
 
-        ret = inner_map_restore(restore);
-        if (ret)
-            break;
-
-        ret = inner_map_scaleup();
-        if (ret)
-            break;
-
-        ret = inner_map_elastic_scaling();
+        ret = maps_restore();
         if (ret)
             break;
     } while (0);
 
     if (ret) {
-        deserial_uninit(false);
+        deserial_uninit();
         return ret;
     }
-    g_inner_map_mng.init = 1;
     return 0;
 }

--- a/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.c
+++ b/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.c
@@ -1319,10 +1319,10 @@ int get_map_infos()
     int i, ret;
     unsigned int inner_id;
     char *map_names[] = {
-        "Map64",
-        "Map192",
-        "Map296",
-        "Map1600",
+        "KmeshMap64",
+        "KmeshMap192",
+        "KmeshMap296",
+        "KmeshMap1600",
     };
 
     for (i = 0; i < MAP_TYPE_MAX; i++) {

--- a/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.h
+++ b/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.h
@@ -6,20 +6,6 @@
 
 #include <stdbool.h>
 
-/* equal MAP_SIZE_OF_OUTTER_MAP */
-#define MAX_OUTTER_MAP_ENTRIES        (1 << 20)
-#define OUTTER_MAP_USAGE_HIGH_PERCENT (0.7)
-#define OUTTER_MAP_USAGE_LOW_PERCENT  (0.3)
-#define TASK_SIZE                     (512)
-
-// 32,768
-#define OUTTER_MAP_SCALEUP_STEP (1 << 15)
-// 8,192
-#define OUTTER_MAP_SCALEIN_STEP (1 << 13)
-
-#define ELASTIC_SLOTS_NUM                                                                                              \
-    ((OUTTER_MAP_SCALEUP_STEP > OUTTER_MAP_SCALEIN_STEP) ? OUTTER_MAP_SCALEUP_STEP : OUTTER_MAP_SCALEIN_STEP)
-
 struct element_list_node {
     void *elem;
     struct element_list_node *next;
@@ -32,8 +18,7 @@ void deserial_free_elem(void *value);
 void deserial_free_elem_list(struct element_list_node *head);
 int deserial_delete_elem(void *key, const void *msg_desciptor);
 
-int deserial_init(bool restore);
-int deserial_uninit(bool persist);
-int inner_map_mng_persist();
+int deserial_init();
+void deserial_uninit();
 
 #endif /* __DESERIALIZATION_TO_BPF_MAP_H__ */

--- a/bpf/include/bpf_common.h
+++ b/bpf/include/bpf_common.h
@@ -70,6 +70,7 @@ struct {
     __uint(max_entries, MAP_MAX_ENTRIES);
     __uint(map_flags, BPF_F_NO_PREALLOC);
 } kmesh_map192 SEC(".maps");
+
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(key_size, sizeof(__u32));
@@ -77,6 +78,7 @@ struct {
     __uint(max_entries, MAP_MAX_ENTRIES);
     __uint(map_flags, BPF_F_NO_PREALLOC);
 } kmesh_map296 SEC(".maps");
+
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(key_size, sizeof(__u32));

--- a/bpf/include/bpf_common.h
+++ b/bpf/include/bpf_common.h
@@ -56,20 +56,34 @@ struct {
 } map_of_sock_storage SEC(".maps");
 
 struct {
-    __uint(type, BPF_MAP_TYPE_ARRAY_OF_MAPS);
+    __uint(type, BPF_MAP_TYPE_HASH);
     __uint(key_size, sizeof(__u32));
-    __uint(value_size, sizeof(__u32));
-    __uint(max_entries, MAP_SIZE_OF_OUTTER_MAP);
-    __uint(map_flags, 0);
-} outer_map SEC(".maps");
+    __uint(value_size, MAP_VAL_SIZE_64);
+    __uint(max_entries, MAP_MAX_ENTRIES);
+    __uint(map_flags, BPF_F_NO_PREALLOC);
+} map64 SEC(".maps");
 
 struct {
-    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(type, BPF_MAP_TYPE_HASH);
     __uint(key_size, sizeof(__u32));
-    __uint(value_size, BPF_INNER_MAP_DATA_LEN);
-    __uint(max_entries, 1);
-    __uint(map_flags, 0);
-} inner_map SEC(".maps");
+    __uint(value_size, MAP_VAL_SIZE_192);
+    __uint(max_entries, MAP_MAX_ENTRIES);
+    __uint(map_flags, BPF_F_NO_PREALLOC);
+} map192 SEC(".maps");
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(key_size, sizeof(__u32));
+    __uint(value_size, MAP_VAL_SIZE_296);
+    __uint(max_entries, MAP_MAX_ENTRIES);
+    __uint(map_flags, BPF_F_NO_PREALLOC);
+} map296 SEC(".maps");
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(key_size, sizeof(__u32));
+    __uint(value_size, MAP_VAL_SIZE_1600);
+    __uint(max_entries, MAP_MAX_ENTRIES);
+    __uint(map_flags, BPF_F_NO_PREALLOC);
+} map1600 SEC(".maps");
 
 /*
  * From v5.4, bpf_get_netns_cookie can be called for bpf cgroup hooks, from v5.15, it can be called for bpf sockops
@@ -160,31 +174,49 @@ static inline bool handle_kmesh_manage_process(struct kmesh_context *kmesh_ctx)
     return false;
 }
 
-static inline void *kmesh_get_ptr_val(const void *ptr)
+static inline void kmesh_parse_outer_key(__u32 outer_key, __u8 *type, __u32 *inner_idx)
 {
-    /*
-        map_in_map -- outer_map:
-        key		value
-        idx1	inner_map_fd1	// point to inner map1
-        idx2	 inner_map_fd2	// point to inner map2
-
-        structA.ptr_member1 = idx1;	// store idx in outer_map
-    */
-    void *inner_map_instance = NULL;
-    __u32 inner_idx = 0;
-    __u32 idx = (__u32)(uintptr_t)ptr;
-
-    if (!ptr) {
-        return NULL;
-    }
-
-    /* get inner_map_instance by idx */
-    inner_map_instance = kmesh_map_lookup_elem(&outer_map, &idx);
-    if (!inner_map_instance) {
-        return NULL;
-    }
-
-    /* get inner_map_instance value */
-    return kmesh_map_lookup_elem(inner_map_instance, &inner_idx);
+    *type = MAP_GET_TYPE(outer_key);
+    *inner_idx = MAP_GET_INDEX(outer_key);
+    return;
 }
+
+static inline void *get_ptr_val_from_map(void *map, __u8 map_type, const void *ptr)
+{
+    __u8 type;
+    __u32 inner_idx;
+    __u32 outer_key = (__u32)(uintptr_t)ptr;
+
+    kmesh_parse_outer_key(outer_key, &type, &inner_idx);
+    if (type != map_type)
+        return NULL;
+
+    return kmesh_map_lookup_elem(map, &inner_idx);
+}
+
+#define KMESH_GET_PTR_VAL(ptr, type)                                                                                   \
+    ({                                                                                                                 \
+        void *val_tmp = NULL;                                                                                          \
+        if (sizeof(type) == sizeof(void *)) {                                                                          \
+            if (__builtin_types_compatible_p(type, char *))                                                            \
+                val_tmp = get_ptr_val_from_map(&map192, MAP_TYPE_192, ptr);                                            \
+            else if (__builtin_types_compatible_p(type, void *))                                                       \
+                val_tmp = get_ptr_val_from_map(&map1600, MAP_TYPE_1600, ptr);                                          \
+            else if (__builtin_types_compatible_p(type, void **))                                                      \
+                val_tmp = get_ptr_val_from_map(&map1600, MAP_TYPE_1600, ptr);                                          \
+            else                                                                                                       \
+                val_tmp = get_ptr_val_from_map(&map64, MAP_TYPE_64, ptr);                                              \
+        } else if (sizeof(type) <= MAP_VAL_SIZE_64)                                                                    \
+            val_tmp = get_ptr_val_from_map(&map64, MAP_TYPE_64, ptr);                                                  \
+        else if (sizeof(type) <= MAP_VAL_SIZE_192)                                                                     \
+            val_tmp = get_ptr_val_from_map(&map192, MAP_TYPE_192, ptr);                                                \
+        else if (sizeof(type) <= MAP_VAL_SIZE_296)                                                                     \
+            val_tmp = get_ptr_val_from_map(&map296, MAP_TYPE_296, ptr);                                                \
+        else if (sizeof(type) <= MAP_VAL_SIZE_1600)                                                                    \
+            val_tmp = get_ptr_val_from_map(&map1600, MAP_TYPE_1600, ptr);                                              \
+        else                                                                                                           \
+            val_tmp = NULL;                                                                                            \
+        val_tmp;                                                                                                       \
+    })
+
 #endif

--- a/bpf/include/bpf_common.h
+++ b/bpf/include/bpf_common.h
@@ -61,7 +61,7 @@ struct {
     __uint(value_size, MAP_VAL_SIZE_64);
     __uint(max_entries, MAP_MAX_ENTRIES);
     __uint(map_flags, BPF_F_NO_PREALLOC);
-} map64 SEC(".maps");
+} kmesh_map64 SEC(".maps");
 
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
@@ -69,21 +69,21 @@ struct {
     __uint(value_size, MAP_VAL_SIZE_192);
     __uint(max_entries, MAP_MAX_ENTRIES);
     __uint(map_flags, BPF_F_NO_PREALLOC);
-} map192 SEC(".maps");
+} kmesh_map192 SEC(".maps");
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(key_size, sizeof(__u32));
     __uint(value_size, MAP_VAL_SIZE_296);
     __uint(max_entries, MAP_MAX_ENTRIES);
     __uint(map_flags, BPF_F_NO_PREALLOC);
-} map296 SEC(".maps");
+} kmesh_map296 SEC(".maps");
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(key_size, sizeof(__u32));
     __uint(value_size, MAP_VAL_SIZE_1600);
     __uint(max_entries, MAP_MAX_ENTRIES);
     __uint(map_flags, BPF_F_NO_PREALLOC);
-} map1600 SEC(".maps");
+} kmesh_map1600 SEC(".maps");
 
 /*
  * From v5.4, bpf_get_netns_cookie can be called for bpf cgroup hooks, from v5.15, it can be called for bpf sockops
@@ -188,8 +188,10 @@ static inline void *get_ptr_val_from_map(void *map, __u8 map_type, const void *p
     __u32 outer_key = (__u32)(uintptr_t)ptr;
 
     kmesh_parse_outer_key(outer_key, &type, &inner_idx);
-    if (type != map_type)
+    if (type != map_type) {
+        BPF_LOG(ERR, KMESH, "get_ptr_val: invalid map type(%u %u)\n", type, map_type);
         return NULL;
+    }
 
     return kmesh_map_lookup_elem(map, &inner_idx);
 }
@@ -199,21 +201,21 @@ static inline void *get_ptr_val_from_map(void *map, __u8 map_type, const void *p
         void *val_tmp = NULL;                                                                                          \
         if (sizeof(type) == sizeof(void *)) {                                                                          \
             if (__builtin_types_compatible_p(type, char *))                                                            \
-                val_tmp = get_ptr_val_from_map(&map192, MAP_TYPE_192, ptr);                                            \
+                val_tmp = get_ptr_val_from_map(&kmesh_map192, MAP_TYPE_192, ptr);                                      \
             else if (__builtin_types_compatible_p(type, void *))                                                       \
-                val_tmp = get_ptr_val_from_map(&map1600, MAP_TYPE_1600, ptr);                                          \
+                val_tmp = get_ptr_val_from_map(&kmesh_map1600, MAP_TYPE_1600, ptr);                                    \
             else if (__builtin_types_compatible_p(type, void **))                                                      \
-                val_tmp = get_ptr_val_from_map(&map1600, MAP_TYPE_1600, ptr);                                          \
+                val_tmp = get_ptr_val_from_map(&kmesh_map1600, MAP_TYPE_1600, ptr);                                    \
             else                                                                                                       \
-                val_tmp = get_ptr_val_from_map(&map64, MAP_TYPE_64, ptr);                                              \
+                val_tmp = get_ptr_val_from_map(&kmesh_map64, MAP_TYPE_64, ptr);                                        \
         } else if (sizeof(type) <= MAP_VAL_SIZE_64)                                                                    \
-            val_tmp = get_ptr_val_from_map(&map64, MAP_TYPE_64, ptr);                                                  \
+            val_tmp = get_ptr_val_from_map(&kmesh_map64, MAP_TYPE_64, ptr);                                            \
         else if (sizeof(type) <= MAP_VAL_SIZE_192)                                                                     \
-            val_tmp = get_ptr_val_from_map(&map192, MAP_TYPE_192, ptr);                                                \
+            val_tmp = get_ptr_val_from_map(&kmesh_map192, MAP_TYPE_192, ptr);                                          \
         else if (sizeof(type) <= MAP_VAL_SIZE_296)                                                                     \
-            val_tmp = get_ptr_val_from_map(&map296, MAP_TYPE_296, ptr);                                                \
+            val_tmp = get_ptr_val_from_map(&kmesh_map296, MAP_TYPE_296, ptr);                                          \
         else if (sizeof(type) <= MAP_VAL_SIZE_1600)                                                                    \
-            val_tmp = get_ptr_val_from_map(&map1600, MAP_TYPE_1600, ptr);                                              \
+            val_tmp = get_ptr_val_from_map(&kmesh_map1600, MAP_TYPE_1600, ptr);                                        \
         else                                                                                                           \
             val_tmp = NULL;                                                                                            \
         val_tmp;                                                                                                       \

--- a/bpf/include/inner_map_defs.h
+++ b/bpf/include/inner_map_defs.h
@@ -4,6 +4,32 @@
 #ifndef __INNER_MAP_H__
 #define __INNER_MAP_H__
 
-#define BPF_INNER_MAP_DATA_LEN 1300
+// outer key:
+// map_type(1 byte) + inner_index(3 bytes)
+
+typedef enum { MAP_TYPE_64, MAP_TYPE_192, MAP_TYPE_296, MAP_TYPE_1600, MAP_TYPE_MAX } map_in_map_type;
+
+#define MAP_GET_TYPE(idx)                (__u8)((__u32)(idx) >> 24)
+#define MAP_GET_INDEX(idx)               (__u32)((__u32)(idx)&0xFFFFFF)
+#define MAP_GEN_OUTER_KEY(map_type, pos) ((__u32)((((__u8)(map_type)&0xFF) << 24) + ((__u32)(pos)&0xFFFFFF)))
+
+#define MAP_VAL_SIZE_64   64
+#define MAP_VAL_SIZE_192  192
+#define MAP_VAL_SIZE_296  296
+#define MAP_VAL_SIZE_1600 1600
+#define MAP_MAX_ENTRIES   1000000
+
+#define MAP_VAL_STR_SIZE    MAP_VAL_SIZE_192
+#define MAP_VAL_REPEAT_SIZE MAP_VAL_SIZE_1600
+
+#define SET_BIT(bitmap, n) ((bitmap)[(n) / 8] |= (1U << ((n) % 8)))
+
+#define CLEAR_BIT(bitmap, n) ((bitmap)[(n) / 8] &= ~(1U << ((n) % 8)))
+
+#define IS_SET(bitmap, n) (((bitmap)[(n) / 8] & (1U << ((n) % 8))) != 0)
+
+#define IS_CLEAR(bitmap, n) (((bitmap)[(n) / 8] & (1U << ((n) % 8))) == 0)
+
+#define FLIP_BIT(bitmap, n) ((bitmap)[(n) / 8] ^= (1U << ((n) % 8)))
 
 #endif // __INNER_MAP_H__

--- a/bpf/kmesh/ads/include/circuit_breaker.h
+++ b/bpf/kmesh/ads/include/circuit_breaker.h
@@ -86,7 +86,7 @@ static inline int on_cluster_sock_bind(ctx_buff_t *ctx, const Cluster__Cluster *
 
     if (stats != NULL) {
         Cluster__CircuitBreakers *cbs = NULL;
-        cbs = kmesh_get_ptr_val(cluster->circuit_breakers);
+        cbs = KMESH_GET_PTR_VAL(cluster->circuit_breakers, Cluster__CircuitBreakers);
         if (cbs != NULL && stats->active_connections >= cbs->max_connections) {
             BPF_LOG(
                 DEBUG,

--- a/bpf/kmesh/ads/include/cluster.h
+++ b/bpf/kmesh/ads/include/cluster.h
@@ -93,7 +93,7 @@ cluster_add_endpoints(const Endpoint__LocalityLbEndpoints *lb_ep, struct cluster
     __u32 i;
     void *ep_ptrs = NULL;
 
-    ep_ptrs = kmesh_get_ptr_val(lb_ep->lb_endpoints);
+    ep_ptrs = KMESH_GET_PTR_VAL(lb_ep->lb_endpoints, void *);
     if (!ep_ptrs)
         return -1;
 
@@ -115,7 +115,7 @@ static inline __u32 cluster_get_endpoints_num(const Endpoint__ClusterLoadAssignm
     void *ptrs = NULL;
     Endpoint__LocalityLbEndpoints *lb_ep = NULL;
 
-    ptrs = kmesh_get_ptr_val(cla->endpoints);
+    ptrs = KMESH_GET_PTR_VAL(cla->endpoints, void *);
     if (!ptrs)
         return 0;
 
@@ -125,7 +125,8 @@ static inline __u32 cluster_get_endpoints_num(const Endpoint__ClusterLoadAssignm
             break;
         }
 
-        lb_ep = (Endpoint__LocalityLbEndpoints *)kmesh_get_ptr_val((void *)*((__u64 *)ptrs + i));
+        lb_ep = (Endpoint__LocalityLbEndpoints *)KMESH_GET_PTR_VAL(
+            (void *)*((__u64 *)ptrs + i), Endpoint__LocalityLbEndpoints);
         if (!lb_ep)
             continue;
 
@@ -152,7 +153,7 @@ static inline int cluster_init_endpoints(const char *cluster_name, const Endpoin
     }
     cluster_eps->ep_num = 0;
 
-    ptrs = kmesh_get_ptr_val(cla->endpoints);
+    ptrs = KMESH_GET_PTR_VAL(cla->endpoints, void *);
     if (!ptrs) {
         BPF_LOG(ERR, CLUSTER, "failed to get cla endpoints ptrs\n");
         return -1;
@@ -163,7 +164,8 @@ static inline int cluster_init_endpoints(const char *cluster_name, const Endpoin
         if (i >= cla->n_endpoints)
             break;
 
-        ep = (Endpoint__LocalityLbEndpoints *)kmesh_get_ptr_val((void *)*((__u64 *)ptrs + i));
+        ep = (Endpoint__LocalityLbEndpoints *)KMESH_GET_PTR_VAL(
+            (void *)*((__u64 *)ptrs + i), Endpoint__LocalityLbEndpoints);
         if (!ep)
             continue;
 
@@ -186,7 +188,7 @@ cluster_check_endpoints(const struct cluster_endpoints *eps, const Endpoint__Clu
     if (!eps || eps->ep_num != lb_num)
         return 0;
 
-    ptrs = kmesh_get_ptr_val(cla->endpoints);
+    ptrs = KMESH_GET_PTR_VAL(cla->endpoints, void *);
     if (!ptrs)
         return 0;
 
@@ -207,7 +209,7 @@ static inline struct cluster_endpoints *cluster_refresh_endpoints(const Cluster_
     struct cluster_endpoints *eps = NULL;
     Endpoint__ClusterLoadAssignment *cla = NULL;
 
-    cla = kmesh_get_ptr_val(cluster->load_assignment);
+    cla = KMESH_GET_PTR_VAL(cluster->load_assignment, Endpoint__ClusterLoadAssignment);
     if (!cla) {
         BPF_LOG(ERR, CLUSTER, "get load_assignment failed\n");
         return NULL;
@@ -264,13 +266,13 @@ static inline Core__SocketAddress *cluster_get_ep_sock_addr(const void *ep_ident
     Endpoint__Endpoint *ep = NULL;
     Core__SocketAddress *sock_addr = NULL;
 
-    ep = kmesh_get_ptr_val(ep_identity);
+    ep = KMESH_GET_PTR_VAL(ep_identity, Endpoint__Endpoint);
     if (!ep) {
         BPF_LOG(ERR, CLUSTER, "cluster get ep failed\n");
         return NULL;
     }
 
-    sock_addr = kmesh_get_ptr_val(ep->address);
+    sock_addr = KMESH_GET_PTR_VAL(ep->address, Core__SocketAddress);
     if (!sock_addr) {
         BPF_LOG(ERR, CLUSTER, "ep get sock addr failed\n");
         return NULL;
@@ -285,7 +287,7 @@ static inline int cluster_handle_loadbalance(Cluster__Cluster *cluster, address_
     Core__SocketAddress *sock_addr = NULL;
     struct cluster_endpoints *eps = NULL;
 
-    name = kmesh_get_ptr_val(cluster->name);
+    name = KMESH_GET_PTR_VAL(cluster->name, char *);
     if (!name) {
         BPF_LOG(ERR, CLUSTER, "failed to get cluster\n");
         return -EAGAIN;

--- a/bpf/kmesh/ads/include/filter.h
+++ b/bpf/kmesh/ads/include/filter.h
@@ -50,7 +50,7 @@ static inline int filter_chain_filter_match(
     }
 
     /* filter match */
-    ptrs = kmesh_get_ptr_val(filter_chain->filters);
+    ptrs = KMESH_GET_PTR_VAL(filter_chain->filters, void *);
     if (!ptrs) {
         BPF_LOG(ERR, FILTER, "failed to get filter ptrs\n");
         return -1;
@@ -63,7 +63,7 @@ static inline int filter_chain_filter_match(
             break;
         }
 
-        filter = (Listener__Filter *)kmesh_get_ptr_val((void *)*((__u64 *)ptrs + i));
+        filter = (Listener__Filter *)KMESH_GET_PTR_VAL((void *)*((__u64 *)ptrs + i), Listener__Filter);
         if (!filter) {
             continue;
         }
@@ -86,7 +86,7 @@ static inline int handle_http_connection_manager(
     ctx_key_t ctx_key = {0};
     ctx_val_t ctx_val = {0};
 
-    route_name = kmesh_get_ptr_val((http_conn->route_config_name));
+    route_name = KMESH_GET_PTR_VAL((http_conn->route_config_name), char *);
     if (!route_name) {
         BPF_LOG(ERR, FILTER, "failed to get http conn route name\n");
         return -1;
@@ -117,7 +117,7 @@ int filter_manager(ctx_buff_t *ctx)
         return KMESH_TAIL_CALL_RET(-1);
     }
 
-    filter = (Listener__Filter *)kmesh_get_ptr_val((void *)ctx_val->val);
+    filter = (Listener__Filter *)KMESH_GET_PTR_VAL((void *)ctx_val->val, Listener__Filter);
     if (!filter) {
         BPF_LOG(ERR, FILTER, "failed to get filter\n");
         return KMESH_TAIL_CALL_RET(-1);
@@ -127,7 +127,7 @@ int filter_manager(ctx_buff_t *ctx)
     switch (filter->config_type_case) {
 #ifndef CGROUP_SOCK_MANAGE
     case LISTENER__FILTER__CONFIG_TYPE_HTTP_CONNECTION_MANAGER:
-        http_conn = kmesh_get_ptr_val(filter->http_connection_manager);
+        http_conn = KMESH_GET_PTR_VAL(filter->http_connection_manager, Filter__HttpConnectionManager);
         ret = bpf_parse_header_msg(ctx_val->msg);
         if (GET_RET_PROTO_TYPE(ret) != PROTO_HTTP_1_1) {
             BPF_LOG(DEBUG, FILTER, "http filter manager,only support http1.1 this version");
@@ -143,7 +143,7 @@ int filter_manager(ctx_buff_t *ctx)
         break;
 #endif
     case LISTENER__FILTER__CONFIG_TYPE_TCP_PROXY:
-        tcp_proxy = kmesh_get_ptr_val(filter->tcp_proxy);
+        tcp_proxy = KMESH_GET_PTR_VAL(filter->tcp_proxy, Filter__TcpProxy);
         if (!tcp_proxy) {
             BPF_LOG(ERR, FILTER, "get tcp_prxoy failed\n");
             ret = -1;
@@ -178,7 +178,7 @@ int filter_chain_manager(ctx_buff_t *ctx)
     }
     kmesh_tail_delete_ctx(&ctx_key);
 
-    filter_chain = (Listener__FilterChain *)kmesh_get_ptr_val((void *)ctx_val_ptr->val);
+    filter_chain = (Listener__FilterChain *)KMESH_GET_PTR_VAL((void *)ctx_val_ptr->val, Listener__FilterChain);
     if (filter_chain == NULL) {
         return KMESH_TAIL_CALL_RET(-1);
     }

--- a/bpf/kmesh/ads/include/listener.h
+++ b/bpf/kmesh/ads/include/listener.h
@@ -27,14 +27,15 @@ static inline bool listener_filter_chain_match_check(
     char *transport_protocol;
     const char buf[] = "raw_buffer";
 
-    Listener__FilterChainMatch *filter_chain_match = kmesh_get_ptr_val(filter_chain->filter_chain_match);
+    Listener__FilterChainMatch *filter_chain_match =
+        KMESH_GET_PTR_VAL(filter_chain->filter_chain_match, Listener__FilterChainMatch);
     if (!filter_chain_match)
         return false;
 
     if (filter_chain_match->destination_port != 0 && filter_chain_match->destination_port != addr->port)
         return false;
 
-    transport_protocol = kmesh_get_ptr_val(filter_chain_match->transport_protocol);
+    transport_protocol = KMESH_GET_PTR_VAL(filter_chain_match->transport_protocol, char *);
     if (!transport_protocol) {
         BPF_LOG(WARN, LISTENER, "transport_protocol is NULL\n");
         return false;
@@ -45,7 +46,8 @@ static inline bool listener_filter_chain_match_check(
 
     // TODO: application_protocols
 
-    BPF_LOG(DEBUG, LISTENER, "match filter_chain, name=\"%s\"\n", (char *)kmesh_get_ptr_val(filter_chain->name));
+    BPF_LOG(
+        DEBUG, LISTENER, "match filter_chain, name=\"%s\"\n", (char *)KMESH_GET_PTR_VAL(filter_chain->name, char *));
     return true;
 }
 
@@ -65,7 +67,7 @@ static inline int listener_filter_chain_match(
         return -1;
     }
 
-    ptrs = kmesh_get_ptr_val(listener->filter_chains);
+    ptrs = KMESH_GET_PTR_VAL(listener->filter_chains, void *);
     if (!ptrs) {
         BPF_LOG(ERR, LISTENER, "failed to get filter chain ptrs\n");
         return -1;
@@ -77,7 +79,7 @@ static inline int listener_filter_chain_match(
             break;
         }
 
-        filter_chain = (Listener__FilterChain *)kmesh_get_ptr_val((void *)*((__u64 *)ptrs + i));
+        filter_chain = (Listener__FilterChain *)KMESH_GET_PTR_VAL((void *)*((__u64 *)ptrs + i), Listener__FilterChain);
         if (!filter_chain) {
             continue;
         }

--- a/bpf/kmesh/ads/include/local_ratelimit.h
+++ b/bpf/kmesh/ads/include/local_ratelimit.h
@@ -124,10 +124,9 @@ Local_rate_limit__check_and_take(const Listener__FilterChain *filter_chain, addr
         return -1;
     }
 
-    struct ratelimit_key key = {
-        .key.sk_skb.ipv4 = addr->ipv4,
-        .key.sk_skb.port = addr->port,
-    };
+    struct ratelimit_key key = {0};
+    key.key.sk_skb.ipv4 = addr->ipv4;
+    key.key.sk_skb.port = addr->port;
     key.key.sk_skb.netns = bpf_get_netns_cookie((void *)ctx);
 
     struct ratelimit_settings settings = {

--- a/bpf/kmesh/ads/include/local_ratelimit.h
+++ b/bpf/kmesh/ads/include/local_ratelimit.h
@@ -113,12 +113,12 @@ Local_rate_limit__check_and_take(const Listener__FilterChain *filter_chain, addr
     }
     BPF_LOG(INFO, FILTER, "local rate limit rule matched\n");
 
-    rate_limit = kmesh_get_ptr_val(filter->local_rate_limit);
+    rate_limit = KMESH_GET_PTR_VAL(filter->local_rate_limit, Filter__LocalRateLimit);
     if (!rate_limit) {
         BPF_LOG(ERR, FILTERCHAIN, "get rate_limit failed\n");
         return -1;
     }
-    token_bucket = kmesh_get_ptr_val(rate_limit->token_bucket);
+    token_bucket = KMESH_GET_PTR_VAL(rate_limit->token_bucket, Filter__TokenBucket);
     if (!token_bucket) {
         BPF_LOG(ERR, FILTERCHAIN, "get token_bucket failed\n");
         return -1;
@@ -174,7 +174,7 @@ Local_rate_limit__filter_chain__match(const Listener__FilterChain *filter_chain,
         return -1;
     }
 
-    ptrs = kmesh_get_ptr_val(filter_chain->filters);
+    ptrs = KMESH_GET_PTR_VAL(filter_chain->filters, void *);
     if (!ptrs) {
         BPF_LOG(ERR, FILTER, "failed to get filter ptrs\n");
         return -1;
@@ -186,7 +186,7 @@ Local_rate_limit__filter_chain__match(const Listener__FilterChain *filter_chain,
             break;
         }
 
-        filter = (Listener__Filter *)kmesh_get_ptr_val((void *)*((__u64 *)ptrs + i));
+        filter = (Listener__Filter *)KMESH_GET_PTR_VAL((void *)*((__u64 *)ptrs + i), Listener__Filter);
         if (!filter) {
             continue;
         }

--- a/bpf/kmesh/ads/include/tcp_proxy.h
+++ b/bpf/kmesh/ads/include/tcp_proxy.h
@@ -16,11 +16,12 @@ static inline char *select_tcp_weight_cluster(const Filter__TcpProxy *tcpProxy)
     int32_t select_value;
     void *cluster_name = NULL;
 
-    weightedClusters = (Filter__TcpProxy__WeightedCluster *)kmesh_get_ptr_val((tcpProxy->weighted_clusters));
+    weightedClusters = (Filter__TcpProxy__WeightedCluster *)KMESH_GET_PTR_VAL(
+        (tcpProxy->weighted_clusters), Filter__TcpProxy__WeightedCluster);
     if (!weightedClusters) {
         return NULL;
     }
-    clusters = kmesh_get_ptr_val(weightedClusters->clusters);
+    clusters = KMESH_GET_PTR_VAL(weightedClusters->clusters, void *);
     if (!clusters) {
         return NULL;
     }
@@ -32,14 +33,14 @@ static inline char *select_tcp_weight_cluster(const Filter__TcpProxy *tcpProxy)
         if (i >= weightedClusters->n_clusters) {
             break;
         }
-        cluster_weight =
-            (Filter__TcpProxy__WeightedCluster__ClusterWeight *)kmesh_get_ptr_val((void *)*((__u64 *)clusters + i));
+        cluster_weight = (Filter__TcpProxy__WeightedCluster__ClusterWeight *)KMESH_GET_PTR_VAL(
+            (void *)*((__u64 *)clusters + i), Filter__TcpProxy__WeightedCluster__ClusterWeight);
         if (!cluster_weight) {
             return NULL;
         }
         select_value = select_value - (int)cluster_weight->weight;
         if (select_value <= 0) {
-            cluster_name = kmesh_get_ptr_val(cluster_weight->name);
+            cluster_name = KMESH_GET_PTR_VAL(cluster_weight->name, char *);
             BPF_LOG(DEBUG, FILTER, "select cluster, %s:%d\n", cluster_name, cluster_weight->weight);
             return (char *)cluster_name;
         }
@@ -53,7 +54,7 @@ static inline char *tcp_proxy_get_cluster(const Filter__TcpProxy *tcpProxy)
         return select_tcp_weight_cluster(tcpProxy);
     }
 
-    return (char *)kmesh_get_ptr_val(tcpProxy->cluster);
+    return (char *)KMESH_GET_PTR_VAL(tcpProxy->cluster, char *);
 }
 
 static inline int tcp_proxy_manager(const Filter__TcpProxy *tcpProxy, ctx_buff_t *ctx)

--- a/bpf/kmesh/ads/sockops.c
+++ b/bpf/kmesh/ads/sockops.c
@@ -37,7 +37,7 @@ static int sockops_traffic_control(struct bpf_sock_ops *skops, struct bpf_mem_pt
         DEBUG,
         SOCKOPS,
         "sockops_traffic_control listener=\"%s\", addr=[%s:%u]\n",
-        (char *)kmesh_get_ptr_val(listener->name),
+        (char *)KMESH_GET_PTR_VAL(listener->name, char *),
         ip2str(&ip, 1),
         bpf_ntohs(skops->remote_port));
     return listener_manager(skops, listener, msg);

--- a/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkload_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkload_bpfeb.go
@@ -111,13 +111,13 @@ type KmeshCgroupSockWorkloadMapSpecs struct {
 	KmeshEvents       *ebpf.MapSpec `ebpf:"kmesh_events"`
 	KmeshFrontend     *ebpf.MapSpec `ebpf:"kmesh_frontend"`
 	KmeshManage       *ebpf.MapSpec `ebpf:"kmesh_manage"`
+	KmeshMap1600      *ebpf.MapSpec `ebpf:"kmesh_map1600"`
+	KmeshMap192       *ebpf.MapSpec `ebpf:"kmesh_map192"`
+	KmeshMap296       *ebpf.MapSpec `ebpf:"kmesh_map296"`
+	KmeshMap64        *ebpf.MapSpec `ebpf:"kmesh_map64"`
 	KmeshPerfInfo     *ebpf.MapSpec `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap      *ebpf.MapSpec `ebpf:"kmesh_perf_map"`
 	KmeshService      *ebpf.MapSpec `ebpf:"kmesh_service"`
-	Map1600           *ebpf.MapSpec `ebpf:"map1600"`
-	Map192            *ebpf.MapSpec `ebpf:"map192"`
-	Map296            *ebpf.MapSpec `ebpf:"map296"`
-	Map64             *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth         *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfDstInfo      *ebpf.MapSpec `ebpf:"map_of_dst_info"`
 	MapOfSockStorage  *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
@@ -154,13 +154,13 @@ type KmeshCgroupSockWorkloadMaps struct {
 	KmeshEvents       *ebpf.Map `ebpf:"kmesh_events"`
 	KmeshFrontend     *ebpf.Map `ebpf:"kmesh_frontend"`
 	KmeshManage       *ebpf.Map `ebpf:"kmesh_manage"`
+	KmeshMap1600      *ebpf.Map `ebpf:"kmesh_map1600"`
+	KmeshMap192       *ebpf.Map `ebpf:"kmesh_map192"`
+	KmeshMap296       *ebpf.Map `ebpf:"kmesh_map296"`
+	KmeshMap64        *ebpf.Map `ebpf:"kmesh_map64"`
 	KmeshPerfInfo     *ebpf.Map `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap      *ebpf.Map `ebpf:"kmesh_perf_map"`
 	KmeshService      *ebpf.Map `ebpf:"kmesh_service"`
-	Map1600           *ebpf.Map `ebpf:"map1600"`
-	Map192            *ebpf.Map `ebpf:"map192"`
-	Map296            *ebpf.Map `ebpf:"map296"`
-	Map64             *ebpf.Map `ebpf:"map64"`
 	MapOfAuth         *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfDstInfo      *ebpf.Map `ebpf:"map_of_dst_info"`
 	MapOfSockStorage  *ebpf.Map `ebpf:"map_of_sock_storage"`
@@ -180,13 +180,13 @@ func (m *KmeshCgroupSockWorkloadMaps) Close() error {
 		m.KmeshEvents,
 		m.KmeshFrontend,
 		m.KmeshManage,
+		m.KmeshMap1600,
+		m.KmeshMap192,
+		m.KmeshMap296,
+		m.KmeshMap64,
 		m.KmeshPerfInfo,
 		m.KmeshPerfMap,
 		m.KmeshService,
-		m.Map1600,
-		m.Map192,
-		m.Map296,
-		m.Map64,
 		m.MapOfAuth,
 		m.MapOfDstInfo,
 		m.MapOfSockStorage,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkload_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkload_bpfeb.go
@@ -105,7 +105,6 @@ type KmeshCgroupSockWorkloadProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type KmeshCgroupSockWorkloadMapSpecs struct {
-	InnerMap          *ebpf.MapSpec `ebpf:"inner_map"`
 	KmeshBackend      *ebpf.MapSpec `ebpf:"kmesh_backend"`
 	KmeshConfigMap    *ebpf.MapSpec `ebpf:"kmesh_config_map"`
 	KmeshEndpoint     *ebpf.MapSpec `ebpf:"kmesh_endpoint"`
@@ -115,6 +114,10 @@ type KmeshCgroupSockWorkloadMapSpecs struct {
 	KmeshPerfInfo     *ebpf.MapSpec `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap      *ebpf.MapSpec `ebpf:"kmesh_perf_map"`
 	KmeshService      *ebpf.MapSpec `ebpf:"kmesh_service"`
+	Map1600           *ebpf.MapSpec `ebpf:"map1600"`
+	Map192            *ebpf.MapSpec `ebpf:"map192"`
+	Map296            *ebpf.MapSpec `ebpf:"map296"`
+	Map64             *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth         *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfDstInfo      *ebpf.MapSpec `ebpf:"map_of_dst_info"`
 	MapOfSockStorage  *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
@@ -122,7 +125,6 @@ type KmeshCgroupSockWorkloadMapSpecs struct {
 	MapOfTcpInfo      *ebpf.MapSpec `ebpf:"map_of_tcp_info"`
 	MapOfTuple        *ebpf.MapSpec `ebpf:"map_of_tuple"`
 	MapOfWlPolicy     *ebpf.MapSpec `ebpf:"map_of_wl_policy"`
-	OuterMap          *ebpf.MapSpec `ebpf:"outer_map"`
 	TmpBuf            *ebpf.MapSpec `ebpf:"tmp_buf"`
 	TmpLogBuf         *ebpf.MapSpec `ebpf:"tmp_log_buf"`
 }
@@ -146,7 +148,6 @@ func (o *KmeshCgroupSockWorkloadObjects) Close() error {
 //
 // It can be passed to LoadKmeshCgroupSockWorkloadObjects or ebpf.CollectionSpec.LoadAndAssign.
 type KmeshCgroupSockWorkloadMaps struct {
-	InnerMap          *ebpf.Map `ebpf:"inner_map"`
 	KmeshBackend      *ebpf.Map `ebpf:"kmesh_backend"`
 	KmeshConfigMap    *ebpf.Map `ebpf:"kmesh_config_map"`
 	KmeshEndpoint     *ebpf.Map `ebpf:"kmesh_endpoint"`
@@ -156,6 +157,10 @@ type KmeshCgroupSockWorkloadMaps struct {
 	KmeshPerfInfo     *ebpf.Map `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap      *ebpf.Map `ebpf:"kmesh_perf_map"`
 	KmeshService      *ebpf.Map `ebpf:"kmesh_service"`
+	Map1600           *ebpf.Map `ebpf:"map1600"`
+	Map192            *ebpf.Map `ebpf:"map192"`
+	Map296            *ebpf.Map `ebpf:"map296"`
+	Map64             *ebpf.Map `ebpf:"map64"`
 	MapOfAuth         *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfDstInfo      *ebpf.Map `ebpf:"map_of_dst_info"`
 	MapOfSockStorage  *ebpf.Map `ebpf:"map_of_sock_storage"`
@@ -163,14 +168,12 @@ type KmeshCgroupSockWorkloadMaps struct {
 	MapOfTcpInfo      *ebpf.Map `ebpf:"map_of_tcp_info"`
 	MapOfTuple        *ebpf.Map `ebpf:"map_of_tuple"`
 	MapOfWlPolicy     *ebpf.Map `ebpf:"map_of_wl_policy"`
-	OuterMap          *ebpf.Map `ebpf:"outer_map"`
 	TmpBuf            *ebpf.Map `ebpf:"tmp_buf"`
 	TmpLogBuf         *ebpf.Map `ebpf:"tmp_log_buf"`
 }
 
 func (m *KmeshCgroupSockWorkloadMaps) Close() error {
 	return _KmeshCgroupSockWorkloadClose(
-		m.InnerMap,
 		m.KmeshBackend,
 		m.KmeshConfigMap,
 		m.KmeshEndpoint,
@@ -180,6 +183,10 @@ func (m *KmeshCgroupSockWorkloadMaps) Close() error {
 		m.KmeshPerfInfo,
 		m.KmeshPerfMap,
 		m.KmeshService,
+		m.Map1600,
+		m.Map192,
+		m.Map296,
+		m.Map64,
 		m.MapOfAuth,
 		m.MapOfDstInfo,
 		m.MapOfSockStorage,
@@ -187,7 +194,6 @@ func (m *KmeshCgroupSockWorkloadMaps) Close() error {
 		m.MapOfTcpInfo,
 		m.MapOfTuple,
 		m.MapOfWlPolicy,
-		m.OuterMap,
 		m.TmpBuf,
 		m.TmpLogBuf,
 	)

--- a/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkload_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkload_bpfel.go
@@ -111,13 +111,13 @@ type KmeshCgroupSockWorkloadMapSpecs struct {
 	KmeshEvents       *ebpf.MapSpec `ebpf:"kmesh_events"`
 	KmeshFrontend     *ebpf.MapSpec `ebpf:"kmesh_frontend"`
 	KmeshManage       *ebpf.MapSpec `ebpf:"kmesh_manage"`
+	KmeshMap1600      *ebpf.MapSpec `ebpf:"kmesh_map1600"`
+	KmeshMap192       *ebpf.MapSpec `ebpf:"kmesh_map192"`
+	KmeshMap296       *ebpf.MapSpec `ebpf:"kmesh_map296"`
+	KmeshMap64        *ebpf.MapSpec `ebpf:"kmesh_map64"`
 	KmeshPerfInfo     *ebpf.MapSpec `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap      *ebpf.MapSpec `ebpf:"kmesh_perf_map"`
 	KmeshService      *ebpf.MapSpec `ebpf:"kmesh_service"`
-	Map1600           *ebpf.MapSpec `ebpf:"map1600"`
-	Map192            *ebpf.MapSpec `ebpf:"map192"`
-	Map296            *ebpf.MapSpec `ebpf:"map296"`
-	Map64             *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth         *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfDstInfo      *ebpf.MapSpec `ebpf:"map_of_dst_info"`
 	MapOfSockStorage  *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
@@ -154,13 +154,13 @@ type KmeshCgroupSockWorkloadMaps struct {
 	KmeshEvents       *ebpf.Map `ebpf:"kmesh_events"`
 	KmeshFrontend     *ebpf.Map `ebpf:"kmesh_frontend"`
 	KmeshManage       *ebpf.Map `ebpf:"kmesh_manage"`
+	KmeshMap1600      *ebpf.Map `ebpf:"kmesh_map1600"`
+	KmeshMap192       *ebpf.Map `ebpf:"kmesh_map192"`
+	KmeshMap296       *ebpf.Map `ebpf:"kmesh_map296"`
+	KmeshMap64        *ebpf.Map `ebpf:"kmesh_map64"`
 	KmeshPerfInfo     *ebpf.Map `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap      *ebpf.Map `ebpf:"kmesh_perf_map"`
 	KmeshService      *ebpf.Map `ebpf:"kmesh_service"`
-	Map1600           *ebpf.Map `ebpf:"map1600"`
-	Map192            *ebpf.Map `ebpf:"map192"`
-	Map296            *ebpf.Map `ebpf:"map296"`
-	Map64             *ebpf.Map `ebpf:"map64"`
 	MapOfAuth         *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfDstInfo      *ebpf.Map `ebpf:"map_of_dst_info"`
 	MapOfSockStorage  *ebpf.Map `ebpf:"map_of_sock_storage"`
@@ -180,13 +180,13 @@ func (m *KmeshCgroupSockWorkloadMaps) Close() error {
 		m.KmeshEvents,
 		m.KmeshFrontend,
 		m.KmeshManage,
+		m.KmeshMap1600,
+		m.KmeshMap192,
+		m.KmeshMap296,
+		m.KmeshMap64,
 		m.KmeshPerfInfo,
 		m.KmeshPerfMap,
 		m.KmeshService,
-		m.Map1600,
-		m.Map192,
-		m.Map296,
-		m.Map64,
 		m.MapOfAuth,
 		m.MapOfDstInfo,
 		m.MapOfSockStorage,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkload_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkload_bpfel.go
@@ -105,7 +105,6 @@ type KmeshCgroupSockWorkloadProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type KmeshCgroupSockWorkloadMapSpecs struct {
-	InnerMap          *ebpf.MapSpec `ebpf:"inner_map"`
 	KmeshBackend      *ebpf.MapSpec `ebpf:"kmesh_backend"`
 	KmeshConfigMap    *ebpf.MapSpec `ebpf:"kmesh_config_map"`
 	KmeshEndpoint     *ebpf.MapSpec `ebpf:"kmesh_endpoint"`
@@ -115,6 +114,10 @@ type KmeshCgroupSockWorkloadMapSpecs struct {
 	KmeshPerfInfo     *ebpf.MapSpec `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap      *ebpf.MapSpec `ebpf:"kmesh_perf_map"`
 	KmeshService      *ebpf.MapSpec `ebpf:"kmesh_service"`
+	Map1600           *ebpf.MapSpec `ebpf:"map1600"`
+	Map192            *ebpf.MapSpec `ebpf:"map192"`
+	Map296            *ebpf.MapSpec `ebpf:"map296"`
+	Map64             *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth         *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfDstInfo      *ebpf.MapSpec `ebpf:"map_of_dst_info"`
 	MapOfSockStorage  *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
@@ -122,7 +125,6 @@ type KmeshCgroupSockWorkloadMapSpecs struct {
 	MapOfTcpInfo      *ebpf.MapSpec `ebpf:"map_of_tcp_info"`
 	MapOfTuple        *ebpf.MapSpec `ebpf:"map_of_tuple"`
 	MapOfWlPolicy     *ebpf.MapSpec `ebpf:"map_of_wl_policy"`
-	OuterMap          *ebpf.MapSpec `ebpf:"outer_map"`
 	TmpBuf            *ebpf.MapSpec `ebpf:"tmp_buf"`
 	TmpLogBuf         *ebpf.MapSpec `ebpf:"tmp_log_buf"`
 }
@@ -146,7 +148,6 @@ func (o *KmeshCgroupSockWorkloadObjects) Close() error {
 //
 // It can be passed to LoadKmeshCgroupSockWorkloadObjects or ebpf.CollectionSpec.LoadAndAssign.
 type KmeshCgroupSockWorkloadMaps struct {
-	InnerMap          *ebpf.Map `ebpf:"inner_map"`
 	KmeshBackend      *ebpf.Map `ebpf:"kmesh_backend"`
 	KmeshConfigMap    *ebpf.Map `ebpf:"kmesh_config_map"`
 	KmeshEndpoint     *ebpf.Map `ebpf:"kmesh_endpoint"`
@@ -156,6 +157,10 @@ type KmeshCgroupSockWorkloadMaps struct {
 	KmeshPerfInfo     *ebpf.Map `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap      *ebpf.Map `ebpf:"kmesh_perf_map"`
 	KmeshService      *ebpf.Map `ebpf:"kmesh_service"`
+	Map1600           *ebpf.Map `ebpf:"map1600"`
+	Map192            *ebpf.Map `ebpf:"map192"`
+	Map296            *ebpf.Map `ebpf:"map296"`
+	Map64             *ebpf.Map `ebpf:"map64"`
 	MapOfAuth         *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfDstInfo      *ebpf.Map `ebpf:"map_of_dst_info"`
 	MapOfSockStorage  *ebpf.Map `ebpf:"map_of_sock_storage"`
@@ -163,14 +168,12 @@ type KmeshCgroupSockWorkloadMaps struct {
 	MapOfTcpInfo      *ebpf.Map `ebpf:"map_of_tcp_info"`
 	MapOfTuple        *ebpf.Map `ebpf:"map_of_tuple"`
 	MapOfWlPolicy     *ebpf.Map `ebpf:"map_of_wl_policy"`
-	OuterMap          *ebpf.Map `ebpf:"outer_map"`
 	TmpBuf            *ebpf.Map `ebpf:"tmp_buf"`
 	TmpLogBuf         *ebpf.Map `ebpf:"tmp_log_buf"`
 }
 
 func (m *KmeshCgroupSockWorkloadMaps) Close() error {
 	return _KmeshCgroupSockWorkloadClose(
-		m.InnerMap,
 		m.KmeshBackend,
 		m.KmeshConfigMap,
 		m.KmeshEndpoint,
@@ -180,6 +183,10 @@ func (m *KmeshCgroupSockWorkloadMaps) Close() error {
 		m.KmeshPerfInfo,
 		m.KmeshPerfMap,
 		m.KmeshService,
+		m.Map1600,
+		m.Map192,
+		m.Map296,
+		m.Map64,
 		m.MapOfAuth,
 		m.MapOfDstInfo,
 		m.MapOfSockStorage,
@@ -187,7 +194,6 @@ func (m *KmeshCgroupSockWorkloadMaps) Close() error {
 		m.MapOfTcpInfo,
 		m.MapOfTuple,
 		m.MapOfWlPolicy,
-		m.OuterMap,
 		m.TmpBuf,
 		m.TmpLogBuf,
 	)

--- a/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkloadcompat_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkloadcompat_bpfeb.go
@@ -105,7 +105,6 @@ type KmeshCgroupSockWorkloadCompatProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type KmeshCgroupSockWorkloadCompatMapSpecs struct {
-	InnerMap          *ebpf.MapSpec `ebpf:"inner_map"`
 	KmeshBackend      *ebpf.MapSpec `ebpf:"kmesh_backend"`
 	KmeshConfigMap    *ebpf.MapSpec `ebpf:"kmesh_config_map"`
 	KmeshEndpoint     *ebpf.MapSpec `ebpf:"kmesh_endpoint"`
@@ -115,6 +114,10 @@ type KmeshCgroupSockWorkloadCompatMapSpecs struct {
 	KmeshPerfInfo     *ebpf.MapSpec `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap      *ebpf.MapSpec `ebpf:"kmesh_perf_map"`
 	KmeshService      *ebpf.MapSpec `ebpf:"kmesh_service"`
+	Map1600           *ebpf.MapSpec `ebpf:"map1600"`
+	Map192            *ebpf.MapSpec `ebpf:"map192"`
+	Map296            *ebpf.MapSpec `ebpf:"map296"`
+	Map64             *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth         *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfDstInfo      *ebpf.MapSpec `ebpf:"map_of_dst_info"`
 	MapOfSockStorage  *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
@@ -122,7 +125,6 @@ type KmeshCgroupSockWorkloadCompatMapSpecs struct {
 	MapOfTcpInfo      *ebpf.MapSpec `ebpf:"map_of_tcp_info"`
 	MapOfTuple        *ebpf.MapSpec `ebpf:"map_of_tuple"`
 	MapOfWlPolicy     *ebpf.MapSpec `ebpf:"map_of_wl_policy"`
-	OuterMap          *ebpf.MapSpec `ebpf:"outer_map"`
 	TmpBuf            *ebpf.MapSpec `ebpf:"tmp_buf"`
 	TmpLogBuf         *ebpf.MapSpec `ebpf:"tmp_log_buf"`
 }
@@ -146,7 +148,6 @@ func (o *KmeshCgroupSockWorkloadCompatObjects) Close() error {
 //
 // It can be passed to LoadKmeshCgroupSockWorkloadCompatObjects or ebpf.CollectionSpec.LoadAndAssign.
 type KmeshCgroupSockWorkloadCompatMaps struct {
-	InnerMap          *ebpf.Map `ebpf:"inner_map"`
 	KmeshBackend      *ebpf.Map `ebpf:"kmesh_backend"`
 	KmeshConfigMap    *ebpf.Map `ebpf:"kmesh_config_map"`
 	KmeshEndpoint     *ebpf.Map `ebpf:"kmesh_endpoint"`
@@ -156,6 +157,10 @@ type KmeshCgroupSockWorkloadCompatMaps struct {
 	KmeshPerfInfo     *ebpf.Map `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap      *ebpf.Map `ebpf:"kmesh_perf_map"`
 	KmeshService      *ebpf.Map `ebpf:"kmesh_service"`
+	Map1600           *ebpf.Map `ebpf:"map1600"`
+	Map192            *ebpf.Map `ebpf:"map192"`
+	Map296            *ebpf.Map `ebpf:"map296"`
+	Map64             *ebpf.Map `ebpf:"map64"`
 	MapOfAuth         *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfDstInfo      *ebpf.Map `ebpf:"map_of_dst_info"`
 	MapOfSockStorage  *ebpf.Map `ebpf:"map_of_sock_storage"`
@@ -163,14 +168,12 @@ type KmeshCgroupSockWorkloadCompatMaps struct {
 	MapOfTcpInfo      *ebpf.Map `ebpf:"map_of_tcp_info"`
 	MapOfTuple        *ebpf.Map `ebpf:"map_of_tuple"`
 	MapOfWlPolicy     *ebpf.Map `ebpf:"map_of_wl_policy"`
-	OuterMap          *ebpf.Map `ebpf:"outer_map"`
 	TmpBuf            *ebpf.Map `ebpf:"tmp_buf"`
 	TmpLogBuf         *ebpf.Map `ebpf:"tmp_log_buf"`
 }
 
 func (m *KmeshCgroupSockWorkloadCompatMaps) Close() error {
 	return _KmeshCgroupSockWorkloadCompatClose(
-		m.InnerMap,
 		m.KmeshBackend,
 		m.KmeshConfigMap,
 		m.KmeshEndpoint,
@@ -180,6 +183,10 @@ func (m *KmeshCgroupSockWorkloadCompatMaps) Close() error {
 		m.KmeshPerfInfo,
 		m.KmeshPerfMap,
 		m.KmeshService,
+		m.Map1600,
+		m.Map192,
+		m.Map296,
+		m.Map64,
 		m.MapOfAuth,
 		m.MapOfDstInfo,
 		m.MapOfSockStorage,
@@ -187,7 +194,6 @@ func (m *KmeshCgroupSockWorkloadCompatMaps) Close() error {
 		m.MapOfTcpInfo,
 		m.MapOfTuple,
 		m.MapOfWlPolicy,
-		m.OuterMap,
 		m.TmpBuf,
 		m.TmpLogBuf,
 	)

--- a/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkloadcompat_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkloadcompat_bpfeb.go
@@ -111,13 +111,13 @@ type KmeshCgroupSockWorkloadCompatMapSpecs struct {
 	KmeshEvents       *ebpf.MapSpec `ebpf:"kmesh_events"`
 	KmeshFrontend     *ebpf.MapSpec `ebpf:"kmesh_frontend"`
 	KmeshManage       *ebpf.MapSpec `ebpf:"kmesh_manage"`
+	KmeshMap1600      *ebpf.MapSpec `ebpf:"kmesh_map1600"`
+	KmeshMap192       *ebpf.MapSpec `ebpf:"kmesh_map192"`
+	KmeshMap296       *ebpf.MapSpec `ebpf:"kmesh_map296"`
+	KmeshMap64        *ebpf.MapSpec `ebpf:"kmesh_map64"`
 	KmeshPerfInfo     *ebpf.MapSpec `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap      *ebpf.MapSpec `ebpf:"kmesh_perf_map"`
 	KmeshService      *ebpf.MapSpec `ebpf:"kmesh_service"`
-	Map1600           *ebpf.MapSpec `ebpf:"map1600"`
-	Map192            *ebpf.MapSpec `ebpf:"map192"`
-	Map296            *ebpf.MapSpec `ebpf:"map296"`
-	Map64             *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth         *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfDstInfo      *ebpf.MapSpec `ebpf:"map_of_dst_info"`
 	MapOfSockStorage  *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
@@ -154,13 +154,13 @@ type KmeshCgroupSockWorkloadCompatMaps struct {
 	KmeshEvents       *ebpf.Map `ebpf:"kmesh_events"`
 	KmeshFrontend     *ebpf.Map `ebpf:"kmesh_frontend"`
 	KmeshManage       *ebpf.Map `ebpf:"kmesh_manage"`
+	KmeshMap1600      *ebpf.Map `ebpf:"kmesh_map1600"`
+	KmeshMap192       *ebpf.Map `ebpf:"kmesh_map192"`
+	KmeshMap296       *ebpf.Map `ebpf:"kmesh_map296"`
+	KmeshMap64        *ebpf.Map `ebpf:"kmesh_map64"`
 	KmeshPerfInfo     *ebpf.Map `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap      *ebpf.Map `ebpf:"kmesh_perf_map"`
 	KmeshService      *ebpf.Map `ebpf:"kmesh_service"`
-	Map1600           *ebpf.Map `ebpf:"map1600"`
-	Map192            *ebpf.Map `ebpf:"map192"`
-	Map296            *ebpf.Map `ebpf:"map296"`
-	Map64             *ebpf.Map `ebpf:"map64"`
 	MapOfAuth         *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfDstInfo      *ebpf.Map `ebpf:"map_of_dst_info"`
 	MapOfSockStorage  *ebpf.Map `ebpf:"map_of_sock_storage"`
@@ -180,13 +180,13 @@ func (m *KmeshCgroupSockWorkloadCompatMaps) Close() error {
 		m.KmeshEvents,
 		m.KmeshFrontend,
 		m.KmeshManage,
+		m.KmeshMap1600,
+		m.KmeshMap192,
+		m.KmeshMap296,
+		m.KmeshMap64,
 		m.KmeshPerfInfo,
 		m.KmeshPerfMap,
 		m.KmeshService,
-		m.Map1600,
-		m.Map192,
-		m.Map296,
-		m.Map64,
 		m.MapOfAuth,
 		m.MapOfDstInfo,
 		m.MapOfSockStorage,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkloadcompat_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkloadcompat_bpfel.go
@@ -105,7 +105,6 @@ type KmeshCgroupSockWorkloadCompatProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type KmeshCgroupSockWorkloadCompatMapSpecs struct {
-	InnerMap          *ebpf.MapSpec `ebpf:"inner_map"`
 	KmeshBackend      *ebpf.MapSpec `ebpf:"kmesh_backend"`
 	KmeshConfigMap    *ebpf.MapSpec `ebpf:"kmesh_config_map"`
 	KmeshEndpoint     *ebpf.MapSpec `ebpf:"kmesh_endpoint"`
@@ -115,6 +114,10 @@ type KmeshCgroupSockWorkloadCompatMapSpecs struct {
 	KmeshPerfInfo     *ebpf.MapSpec `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap      *ebpf.MapSpec `ebpf:"kmesh_perf_map"`
 	KmeshService      *ebpf.MapSpec `ebpf:"kmesh_service"`
+	Map1600           *ebpf.MapSpec `ebpf:"map1600"`
+	Map192            *ebpf.MapSpec `ebpf:"map192"`
+	Map296            *ebpf.MapSpec `ebpf:"map296"`
+	Map64             *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth         *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfDstInfo      *ebpf.MapSpec `ebpf:"map_of_dst_info"`
 	MapOfSockStorage  *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
@@ -122,7 +125,6 @@ type KmeshCgroupSockWorkloadCompatMapSpecs struct {
 	MapOfTcpInfo      *ebpf.MapSpec `ebpf:"map_of_tcp_info"`
 	MapOfTuple        *ebpf.MapSpec `ebpf:"map_of_tuple"`
 	MapOfWlPolicy     *ebpf.MapSpec `ebpf:"map_of_wl_policy"`
-	OuterMap          *ebpf.MapSpec `ebpf:"outer_map"`
 	TmpBuf            *ebpf.MapSpec `ebpf:"tmp_buf"`
 	TmpLogBuf         *ebpf.MapSpec `ebpf:"tmp_log_buf"`
 }
@@ -146,7 +148,6 @@ func (o *KmeshCgroupSockWorkloadCompatObjects) Close() error {
 //
 // It can be passed to LoadKmeshCgroupSockWorkloadCompatObjects or ebpf.CollectionSpec.LoadAndAssign.
 type KmeshCgroupSockWorkloadCompatMaps struct {
-	InnerMap          *ebpf.Map `ebpf:"inner_map"`
 	KmeshBackend      *ebpf.Map `ebpf:"kmesh_backend"`
 	KmeshConfigMap    *ebpf.Map `ebpf:"kmesh_config_map"`
 	KmeshEndpoint     *ebpf.Map `ebpf:"kmesh_endpoint"`
@@ -156,6 +157,10 @@ type KmeshCgroupSockWorkloadCompatMaps struct {
 	KmeshPerfInfo     *ebpf.Map `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap      *ebpf.Map `ebpf:"kmesh_perf_map"`
 	KmeshService      *ebpf.Map `ebpf:"kmesh_service"`
+	Map1600           *ebpf.Map `ebpf:"map1600"`
+	Map192            *ebpf.Map `ebpf:"map192"`
+	Map296            *ebpf.Map `ebpf:"map296"`
+	Map64             *ebpf.Map `ebpf:"map64"`
 	MapOfAuth         *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfDstInfo      *ebpf.Map `ebpf:"map_of_dst_info"`
 	MapOfSockStorage  *ebpf.Map `ebpf:"map_of_sock_storage"`
@@ -163,14 +168,12 @@ type KmeshCgroupSockWorkloadCompatMaps struct {
 	MapOfTcpInfo      *ebpf.Map `ebpf:"map_of_tcp_info"`
 	MapOfTuple        *ebpf.Map `ebpf:"map_of_tuple"`
 	MapOfWlPolicy     *ebpf.Map `ebpf:"map_of_wl_policy"`
-	OuterMap          *ebpf.Map `ebpf:"outer_map"`
 	TmpBuf            *ebpf.Map `ebpf:"tmp_buf"`
 	TmpLogBuf         *ebpf.Map `ebpf:"tmp_log_buf"`
 }
 
 func (m *KmeshCgroupSockWorkloadCompatMaps) Close() error {
 	return _KmeshCgroupSockWorkloadCompatClose(
-		m.InnerMap,
 		m.KmeshBackend,
 		m.KmeshConfigMap,
 		m.KmeshEndpoint,
@@ -180,6 +183,10 @@ func (m *KmeshCgroupSockWorkloadCompatMaps) Close() error {
 		m.KmeshPerfInfo,
 		m.KmeshPerfMap,
 		m.KmeshService,
+		m.Map1600,
+		m.Map192,
+		m.Map296,
+		m.Map64,
 		m.MapOfAuth,
 		m.MapOfDstInfo,
 		m.MapOfSockStorage,
@@ -187,7 +194,6 @@ func (m *KmeshCgroupSockWorkloadCompatMaps) Close() error {
 		m.MapOfTcpInfo,
 		m.MapOfTuple,
 		m.MapOfWlPolicy,
-		m.OuterMap,
 		m.TmpBuf,
 		m.TmpLogBuf,
 	)

--- a/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkloadcompat_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkloadcompat_bpfel.go
@@ -111,13 +111,13 @@ type KmeshCgroupSockWorkloadCompatMapSpecs struct {
 	KmeshEvents       *ebpf.MapSpec `ebpf:"kmesh_events"`
 	KmeshFrontend     *ebpf.MapSpec `ebpf:"kmesh_frontend"`
 	KmeshManage       *ebpf.MapSpec `ebpf:"kmesh_manage"`
+	KmeshMap1600      *ebpf.MapSpec `ebpf:"kmesh_map1600"`
+	KmeshMap192       *ebpf.MapSpec `ebpf:"kmesh_map192"`
+	KmeshMap296       *ebpf.MapSpec `ebpf:"kmesh_map296"`
+	KmeshMap64        *ebpf.MapSpec `ebpf:"kmesh_map64"`
 	KmeshPerfInfo     *ebpf.MapSpec `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap      *ebpf.MapSpec `ebpf:"kmesh_perf_map"`
 	KmeshService      *ebpf.MapSpec `ebpf:"kmesh_service"`
-	Map1600           *ebpf.MapSpec `ebpf:"map1600"`
-	Map192            *ebpf.MapSpec `ebpf:"map192"`
-	Map296            *ebpf.MapSpec `ebpf:"map296"`
-	Map64             *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth         *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfDstInfo      *ebpf.MapSpec `ebpf:"map_of_dst_info"`
 	MapOfSockStorage  *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
@@ -154,13 +154,13 @@ type KmeshCgroupSockWorkloadCompatMaps struct {
 	KmeshEvents       *ebpf.Map `ebpf:"kmesh_events"`
 	KmeshFrontend     *ebpf.Map `ebpf:"kmesh_frontend"`
 	KmeshManage       *ebpf.Map `ebpf:"kmesh_manage"`
+	KmeshMap1600      *ebpf.Map `ebpf:"kmesh_map1600"`
+	KmeshMap192       *ebpf.Map `ebpf:"kmesh_map192"`
+	KmeshMap296       *ebpf.Map `ebpf:"kmesh_map296"`
+	KmeshMap64        *ebpf.Map `ebpf:"kmesh_map64"`
 	KmeshPerfInfo     *ebpf.Map `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap      *ebpf.Map `ebpf:"kmesh_perf_map"`
 	KmeshService      *ebpf.Map `ebpf:"kmesh_service"`
-	Map1600           *ebpf.Map `ebpf:"map1600"`
-	Map192            *ebpf.Map `ebpf:"map192"`
-	Map296            *ebpf.Map `ebpf:"map296"`
-	Map64             *ebpf.Map `ebpf:"map64"`
 	MapOfAuth         *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfDstInfo      *ebpf.Map `ebpf:"map_of_dst_info"`
 	MapOfSockStorage  *ebpf.Map `ebpf:"map_of_sock_storage"`
@@ -180,13 +180,13 @@ func (m *KmeshCgroupSockWorkloadCompatMaps) Close() error {
 		m.KmeshEvents,
 		m.KmeshFrontend,
 		m.KmeshManage,
+		m.KmeshMap1600,
+		m.KmeshMap192,
+		m.KmeshMap296,
+		m.KmeshMap64,
 		m.KmeshPerfInfo,
 		m.KmeshPerfMap,
 		m.KmeshService,
-		m.Map1600,
-		m.Map192,
-		m.Map296,
-		m.Map64,
 		m.MapOfAuth,
 		m.MapOfDstInfo,
 		m.MapOfSockStorage,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkload_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkload_bpfeb.go
@@ -104,7 +104,6 @@ type KmeshSockopsWorkloadProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type KmeshSockopsWorkloadMapSpecs struct {
-	InnerMap         *ebpf.MapSpec `ebpf:"inner_map"`
 	KmeshBackend     *ebpf.MapSpec `ebpf:"kmesh_backend"`
 	KmeshConfigMap   *ebpf.MapSpec `ebpf:"kmesh_config_map"`
 	KmeshEndpoint    *ebpf.MapSpec `ebpf:"kmesh_endpoint"`
@@ -114,6 +113,10 @@ type KmeshSockopsWorkloadMapSpecs struct {
 	KmeshPerfInfo    *ebpf.MapSpec `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap     *ebpf.MapSpec `ebpf:"kmesh_perf_map"`
 	KmeshService     *ebpf.MapSpec `ebpf:"kmesh_service"`
+	Map1600          *ebpf.MapSpec `ebpf:"map1600"`
+	Map192           *ebpf.MapSpec `ebpf:"map192"`
+	Map296           *ebpf.MapSpec `ebpf:"map296"`
+	Map64            *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth        *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfDstInfo     *ebpf.MapSpec `ebpf:"map_of_dst_info"`
 	MapOfKmeshSocket *ebpf.MapSpec `ebpf:"map_of_kmesh_socket"`
@@ -121,7 +124,6 @@ type KmeshSockopsWorkloadMapSpecs struct {
 	MapOfTcpInfo     *ebpf.MapSpec `ebpf:"map_of_tcp_info"`
 	MapOfTuple       *ebpf.MapSpec `ebpf:"map_of_tuple"`
 	MapOfWlPolicy    *ebpf.MapSpec `ebpf:"map_of_wl_policy"`
-	OuterMap         *ebpf.MapSpec `ebpf:"outer_map"`
 	TmpBuf           *ebpf.MapSpec `ebpf:"tmp_buf"`
 	TmpLogBuf        *ebpf.MapSpec `ebpf:"tmp_log_buf"`
 }
@@ -145,7 +147,6 @@ func (o *KmeshSockopsWorkloadObjects) Close() error {
 //
 // It can be passed to LoadKmeshSockopsWorkloadObjects or ebpf.CollectionSpec.LoadAndAssign.
 type KmeshSockopsWorkloadMaps struct {
-	InnerMap         *ebpf.Map `ebpf:"inner_map"`
 	KmeshBackend     *ebpf.Map `ebpf:"kmesh_backend"`
 	KmeshConfigMap   *ebpf.Map `ebpf:"kmesh_config_map"`
 	KmeshEndpoint    *ebpf.Map `ebpf:"kmesh_endpoint"`
@@ -155,6 +156,10 @@ type KmeshSockopsWorkloadMaps struct {
 	KmeshPerfInfo    *ebpf.Map `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap     *ebpf.Map `ebpf:"kmesh_perf_map"`
 	KmeshService     *ebpf.Map `ebpf:"kmesh_service"`
+	Map1600          *ebpf.Map `ebpf:"map1600"`
+	Map192           *ebpf.Map `ebpf:"map192"`
+	Map296           *ebpf.Map `ebpf:"map296"`
+	Map64            *ebpf.Map `ebpf:"map64"`
 	MapOfAuth        *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfDstInfo     *ebpf.Map `ebpf:"map_of_dst_info"`
 	MapOfKmeshSocket *ebpf.Map `ebpf:"map_of_kmesh_socket"`
@@ -162,14 +167,12 @@ type KmeshSockopsWorkloadMaps struct {
 	MapOfTcpInfo     *ebpf.Map `ebpf:"map_of_tcp_info"`
 	MapOfTuple       *ebpf.Map `ebpf:"map_of_tuple"`
 	MapOfWlPolicy    *ebpf.Map `ebpf:"map_of_wl_policy"`
-	OuterMap         *ebpf.Map `ebpf:"outer_map"`
 	TmpBuf           *ebpf.Map `ebpf:"tmp_buf"`
 	TmpLogBuf        *ebpf.Map `ebpf:"tmp_log_buf"`
 }
 
 func (m *KmeshSockopsWorkloadMaps) Close() error {
 	return _KmeshSockopsWorkloadClose(
-		m.InnerMap,
 		m.KmeshBackend,
 		m.KmeshConfigMap,
 		m.KmeshEndpoint,
@@ -179,6 +182,10 @@ func (m *KmeshSockopsWorkloadMaps) Close() error {
 		m.KmeshPerfInfo,
 		m.KmeshPerfMap,
 		m.KmeshService,
+		m.Map1600,
+		m.Map192,
+		m.Map296,
+		m.Map64,
 		m.MapOfAuth,
 		m.MapOfDstInfo,
 		m.MapOfKmeshSocket,
@@ -186,7 +193,6 @@ func (m *KmeshSockopsWorkloadMaps) Close() error {
 		m.MapOfTcpInfo,
 		m.MapOfTuple,
 		m.MapOfWlPolicy,
-		m.OuterMap,
 		m.TmpBuf,
 		m.TmpLogBuf,
 	)

--- a/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkload_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkload_bpfeb.go
@@ -110,13 +110,13 @@ type KmeshSockopsWorkloadMapSpecs struct {
 	KmeshEvents      *ebpf.MapSpec `ebpf:"kmesh_events"`
 	KmeshFrontend    *ebpf.MapSpec `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.MapSpec `ebpf:"kmesh_manage"`
+	KmeshMap1600     *ebpf.MapSpec `ebpf:"kmesh_map1600"`
+	KmeshMap192      *ebpf.MapSpec `ebpf:"kmesh_map192"`
+	KmeshMap296      *ebpf.MapSpec `ebpf:"kmesh_map296"`
+	KmeshMap64       *ebpf.MapSpec `ebpf:"kmesh_map64"`
 	KmeshPerfInfo    *ebpf.MapSpec `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap     *ebpf.MapSpec `ebpf:"kmesh_perf_map"`
 	KmeshService     *ebpf.MapSpec `ebpf:"kmesh_service"`
-	Map1600          *ebpf.MapSpec `ebpf:"map1600"`
-	Map192           *ebpf.MapSpec `ebpf:"map192"`
-	Map296           *ebpf.MapSpec `ebpf:"map296"`
-	Map64            *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth        *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfDstInfo     *ebpf.MapSpec `ebpf:"map_of_dst_info"`
 	MapOfKmeshSocket *ebpf.MapSpec `ebpf:"map_of_kmesh_socket"`
@@ -153,13 +153,13 @@ type KmeshSockopsWorkloadMaps struct {
 	KmeshEvents      *ebpf.Map `ebpf:"kmesh_events"`
 	KmeshFrontend    *ebpf.Map `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.Map `ebpf:"kmesh_manage"`
+	KmeshMap1600     *ebpf.Map `ebpf:"kmesh_map1600"`
+	KmeshMap192      *ebpf.Map `ebpf:"kmesh_map192"`
+	KmeshMap296      *ebpf.Map `ebpf:"kmesh_map296"`
+	KmeshMap64       *ebpf.Map `ebpf:"kmesh_map64"`
 	KmeshPerfInfo    *ebpf.Map `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap     *ebpf.Map `ebpf:"kmesh_perf_map"`
 	KmeshService     *ebpf.Map `ebpf:"kmesh_service"`
-	Map1600          *ebpf.Map `ebpf:"map1600"`
-	Map192           *ebpf.Map `ebpf:"map192"`
-	Map296           *ebpf.Map `ebpf:"map296"`
-	Map64            *ebpf.Map `ebpf:"map64"`
 	MapOfAuth        *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfDstInfo     *ebpf.Map `ebpf:"map_of_dst_info"`
 	MapOfKmeshSocket *ebpf.Map `ebpf:"map_of_kmesh_socket"`
@@ -179,13 +179,13 @@ func (m *KmeshSockopsWorkloadMaps) Close() error {
 		m.KmeshEvents,
 		m.KmeshFrontend,
 		m.KmeshManage,
+		m.KmeshMap1600,
+		m.KmeshMap192,
+		m.KmeshMap296,
+		m.KmeshMap64,
 		m.KmeshPerfInfo,
 		m.KmeshPerfMap,
 		m.KmeshService,
-		m.Map1600,
-		m.Map192,
-		m.Map296,
-		m.Map64,
 		m.MapOfAuth,
 		m.MapOfDstInfo,
 		m.MapOfKmeshSocket,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkload_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkload_bpfel.go
@@ -104,7 +104,6 @@ type KmeshSockopsWorkloadProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type KmeshSockopsWorkloadMapSpecs struct {
-	InnerMap         *ebpf.MapSpec `ebpf:"inner_map"`
 	KmeshBackend     *ebpf.MapSpec `ebpf:"kmesh_backend"`
 	KmeshConfigMap   *ebpf.MapSpec `ebpf:"kmesh_config_map"`
 	KmeshEndpoint    *ebpf.MapSpec `ebpf:"kmesh_endpoint"`
@@ -114,6 +113,10 @@ type KmeshSockopsWorkloadMapSpecs struct {
 	KmeshPerfInfo    *ebpf.MapSpec `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap     *ebpf.MapSpec `ebpf:"kmesh_perf_map"`
 	KmeshService     *ebpf.MapSpec `ebpf:"kmesh_service"`
+	Map1600          *ebpf.MapSpec `ebpf:"map1600"`
+	Map192           *ebpf.MapSpec `ebpf:"map192"`
+	Map296           *ebpf.MapSpec `ebpf:"map296"`
+	Map64            *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth        *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfDstInfo     *ebpf.MapSpec `ebpf:"map_of_dst_info"`
 	MapOfKmeshSocket *ebpf.MapSpec `ebpf:"map_of_kmesh_socket"`
@@ -121,7 +124,6 @@ type KmeshSockopsWorkloadMapSpecs struct {
 	MapOfTcpInfo     *ebpf.MapSpec `ebpf:"map_of_tcp_info"`
 	MapOfTuple       *ebpf.MapSpec `ebpf:"map_of_tuple"`
 	MapOfWlPolicy    *ebpf.MapSpec `ebpf:"map_of_wl_policy"`
-	OuterMap         *ebpf.MapSpec `ebpf:"outer_map"`
 	TmpBuf           *ebpf.MapSpec `ebpf:"tmp_buf"`
 	TmpLogBuf        *ebpf.MapSpec `ebpf:"tmp_log_buf"`
 }
@@ -145,7 +147,6 @@ func (o *KmeshSockopsWorkloadObjects) Close() error {
 //
 // It can be passed to LoadKmeshSockopsWorkloadObjects or ebpf.CollectionSpec.LoadAndAssign.
 type KmeshSockopsWorkloadMaps struct {
-	InnerMap         *ebpf.Map `ebpf:"inner_map"`
 	KmeshBackend     *ebpf.Map `ebpf:"kmesh_backend"`
 	KmeshConfigMap   *ebpf.Map `ebpf:"kmesh_config_map"`
 	KmeshEndpoint    *ebpf.Map `ebpf:"kmesh_endpoint"`
@@ -155,6 +156,10 @@ type KmeshSockopsWorkloadMaps struct {
 	KmeshPerfInfo    *ebpf.Map `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap     *ebpf.Map `ebpf:"kmesh_perf_map"`
 	KmeshService     *ebpf.Map `ebpf:"kmesh_service"`
+	Map1600          *ebpf.Map `ebpf:"map1600"`
+	Map192           *ebpf.Map `ebpf:"map192"`
+	Map296           *ebpf.Map `ebpf:"map296"`
+	Map64            *ebpf.Map `ebpf:"map64"`
 	MapOfAuth        *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfDstInfo     *ebpf.Map `ebpf:"map_of_dst_info"`
 	MapOfKmeshSocket *ebpf.Map `ebpf:"map_of_kmesh_socket"`
@@ -162,14 +167,12 @@ type KmeshSockopsWorkloadMaps struct {
 	MapOfTcpInfo     *ebpf.Map `ebpf:"map_of_tcp_info"`
 	MapOfTuple       *ebpf.Map `ebpf:"map_of_tuple"`
 	MapOfWlPolicy    *ebpf.Map `ebpf:"map_of_wl_policy"`
-	OuterMap         *ebpf.Map `ebpf:"outer_map"`
 	TmpBuf           *ebpf.Map `ebpf:"tmp_buf"`
 	TmpLogBuf        *ebpf.Map `ebpf:"tmp_log_buf"`
 }
 
 func (m *KmeshSockopsWorkloadMaps) Close() error {
 	return _KmeshSockopsWorkloadClose(
-		m.InnerMap,
 		m.KmeshBackend,
 		m.KmeshConfigMap,
 		m.KmeshEndpoint,
@@ -179,6 +182,10 @@ func (m *KmeshSockopsWorkloadMaps) Close() error {
 		m.KmeshPerfInfo,
 		m.KmeshPerfMap,
 		m.KmeshService,
+		m.Map1600,
+		m.Map192,
+		m.Map296,
+		m.Map64,
 		m.MapOfAuth,
 		m.MapOfDstInfo,
 		m.MapOfKmeshSocket,
@@ -186,7 +193,6 @@ func (m *KmeshSockopsWorkloadMaps) Close() error {
 		m.MapOfTcpInfo,
 		m.MapOfTuple,
 		m.MapOfWlPolicy,
-		m.OuterMap,
 		m.TmpBuf,
 		m.TmpLogBuf,
 	)

--- a/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkload_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkload_bpfel.go
@@ -110,13 +110,13 @@ type KmeshSockopsWorkloadMapSpecs struct {
 	KmeshEvents      *ebpf.MapSpec `ebpf:"kmesh_events"`
 	KmeshFrontend    *ebpf.MapSpec `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.MapSpec `ebpf:"kmesh_manage"`
+	KmeshMap1600     *ebpf.MapSpec `ebpf:"kmesh_map1600"`
+	KmeshMap192      *ebpf.MapSpec `ebpf:"kmesh_map192"`
+	KmeshMap296      *ebpf.MapSpec `ebpf:"kmesh_map296"`
+	KmeshMap64       *ebpf.MapSpec `ebpf:"kmesh_map64"`
 	KmeshPerfInfo    *ebpf.MapSpec `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap     *ebpf.MapSpec `ebpf:"kmesh_perf_map"`
 	KmeshService     *ebpf.MapSpec `ebpf:"kmesh_service"`
-	Map1600          *ebpf.MapSpec `ebpf:"map1600"`
-	Map192           *ebpf.MapSpec `ebpf:"map192"`
-	Map296           *ebpf.MapSpec `ebpf:"map296"`
-	Map64            *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth        *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfDstInfo     *ebpf.MapSpec `ebpf:"map_of_dst_info"`
 	MapOfKmeshSocket *ebpf.MapSpec `ebpf:"map_of_kmesh_socket"`
@@ -153,13 +153,13 @@ type KmeshSockopsWorkloadMaps struct {
 	KmeshEvents      *ebpf.Map `ebpf:"kmesh_events"`
 	KmeshFrontend    *ebpf.Map `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.Map `ebpf:"kmesh_manage"`
+	KmeshMap1600     *ebpf.Map `ebpf:"kmesh_map1600"`
+	KmeshMap192      *ebpf.Map `ebpf:"kmesh_map192"`
+	KmeshMap296      *ebpf.Map `ebpf:"kmesh_map296"`
+	KmeshMap64       *ebpf.Map `ebpf:"kmesh_map64"`
 	KmeshPerfInfo    *ebpf.Map `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap     *ebpf.Map `ebpf:"kmesh_perf_map"`
 	KmeshService     *ebpf.Map `ebpf:"kmesh_service"`
-	Map1600          *ebpf.Map `ebpf:"map1600"`
-	Map192           *ebpf.Map `ebpf:"map192"`
-	Map296           *ebpf.Map `ebpf:"map296"`
-	Map64            *ebpf.Map `ebpf:"map64"`
 	MapOfAuth        *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfDstInfo     *ebpf.Map `ebpf:"map_of_dst_info"`
 	MapOfKmeshSocket *ebpf.Map `ebpf:"map_of_kmesh_socket"`
@@ -179,13 +179,13 @@ func (m *KmeshSockopsWorkloadMaps) Close() error {
 		m.KmeshEvents,
 		m.KmeshFrontend,
 		m.KmeshManage,
+		m.KmeshMap1600,
+		m.KmeshMap192,
+		m.KmeshMap296,
+		m.KmeshMap64,
 		m.KmeshPerfInfo,
 		m.KmeshPerfMap,
 		m.KmeshService,
-		m.Map1600,
-		m.Map192,
-		m.Map296,
-		m.Map64,
 		m.MapOfAuth,
 		m.MapOfDstInfo,
 		m.MapOfKmeshSocket,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkloadcompat_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkloadcompat_bpfeb.go
@@ -104,7 +104,6 @@ type KmeshSockopsWorkloadCompatProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type KmeshSockopsWorkloadCompatMapSpecs struct {
-	InnerMap         *ebpf.MapSpec `ebpf:"inner_map"`
 	KmeshBackend     *ebpf.MapSpec `ebpf:"kmesh_backend"`
 	KmeshConfigMap   *ebpf.MapSpec `ebpf:"kmesh_config_map"`
 	KmeshEndpoint    *ebpf.MapSpec `ebpf:"kmesh_endpoint"`
@@ -114,6 +113,10 @@ type KmeshSockopsWorkloadCompatMapSpecs struct {
 	KmeshPerfInfo    *ebpf.MapSpec `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap     *ebpf.MapSpec `ebpf:"kmesh_perf_map"`
 	KmeshService     *ebpf.MapSpec `ebpf:"kmesh_service"`
+	Map1600          *ebpf.MapSpec `ebpf:"map1600"`
+	Map192           *ebpf.MapSpec `ebpf:"map192"`
+	Map296           *ebpf.MapSpec `ebpf:"map296"`
+	Map64            *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth        *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfDstInfo     *ebpf.MapSpec `ebpf:"map_of_dst_info"`
 	MapOfKmeshSocket *ebpf.MapSpec `ebpf:"map_of_kmesh_socket"`
@@ -121,7 +124,6 @@ type KmeshSockopsWorkloadCompatMapSpecs struct {
 	MapOfTcpInfo     *ebpf.MapSpec `ebpf:"map_of_tcp_info"`
 	MapOfTuple       *ebpf.MapSpec `ebpf:"map_of_tuple"`
 	MapOfWlPolicy    *ebpf.MapSpec `ebpf:"map_of_wl_policy"`
-	OuterMap         *ebpf.MapSpec `ebpf:"outer_map"`
 	TmpBuf           *ebpf.MapSpec `ebpf:"tmp_buf"`
 	TmpLogBuf        *ebpf.MapSpec `ebpf:"tmp_log_buf"`
 }
@@ -145,7 +147,6 @@ func (o *KmeshSockopsWorkloadCompatObjects) Close() error {
 //
 // It can be passed to LoadKmeshSockopsWorkloadCompatObjects or ebpf.CollectionSpec.LoadAndAssign.
 type KmeshSockopsWorkloadCompatMaps struct {
-	InnerMap         *ebpf.Map `ebpf:"inner_map"`
 	KmeshBackend     *ebpf.Map `ebpf:"kmesh_backend"`
 	KmeshConfigMap   *ebpf.Map `ebpf:"kmesh_config_map"`
 	KmeshEndpoint    *ebpf.Map `ebpf:"kmesh_endpoint"`
@@ -155,6 +156,10 @@ type KmeshSockopsWorkloadCompatMaps struct {
 	KmeshPerfInfo    *ebpf.Map `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap     *ebpf.Map `ebpf:"kmesh_perf_map"`
 	KmeshService     *ebpf.Map `ebpf:"kmesh_service"`
+	Map1600          *ebpf.Map `ebpf:"map1600"`
+	Map192           *ebpf.Map `ebpf:"map192"`
+	Map296           *ebpf.Map `ebpf:"map296"`
+	Map64            *ebpf.Map `ebpf:"map64"`
 	MapOfAuth        *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfDstInfo     *ebpf.Map `ebpf:"map_of_dst_info"`
 	MapOfKmeshSocket *ebpf.Map `ebpf:"map_of_kmesh_socket"`
@@ -162,14 +167,12 @@ type KmeshSockopsWorkloadCompatMaps struct {
 	MapOfTcpInfo     *ebpf.Map `ebpf:"map_of_tcp_info"`
 	MapOfTuple       *ebpf.Map `ebpf:"map_of_tuple"`
 	MapOfWlPolicy    *ebpf.Map `ebpf:"map_of_wl_policy"`
-	OuterMap         *ebpf.Map `ebpf:"outer_map"`
 	TmpBuf           *ebpf.Map `ebpf:"tmp_buf"`
 	TmpLogBuf        *ebpf.Map `ebpf:"tmp_log_buf"`
 }
 
 func (m *KmeshSockopsWorkloadCompatMaps) Close() error {
 	return _KmeshSockopsWorkloadCompatClose(
-		m.InnerMap,
 		m.KmeshBackend,
 		m.KmeshConfigMap,
 		m.KmeshEndpoint,
@@ -179,6 +182,10 @@ func (m *KmeshSockopsWorkloadCompatMaps) Close() error {
 		m.KmeshPerfInfo,
 		m.KmeshPerfMap,
 		m.KmeshService,
+		m.Map1600,
+		m.Map192,
+		m.Map296,
+		m.Map64,
 		m.MapOfAuth,
 		m.MapOfDstInfo,
 		m.MapOfKmeshSocket,
@@ -186,7 +193,6 @@ func (m *KmeshSockopsWorkloadCompatMaps) Close() error {
 		m.MapOfTcpInfo,
 		m.MapOfTuple,
 		m.MapOfWlPolicy,
-		m.OuterMap,
 		m.TmpBuf,
 		m.TmpLogBuf,
 	)

--- a/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkloadcompat_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkloadcompat_bpfeb.go
@@ -110,13 +110,13 @@ type KmeshSockopsWorkloadCompatMapSpecs struct {
 	KmeshEvents      *ebpf.MapSpec `ebpf:"kmesh_events"`
 	KmeshFrontend    *ebpf.MapSpec `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.MapSpec `ebpf:"kmesh_manage"`
+	KmeshMap1600     *ebpf.MapSpec `ebpf:"kmesh_map1600"`
+	KmeshMap192      *ebpf.MapSpec `ebpf:"kmesh_map192"`
+	KmeshMap296      *ebpf.MapSpec `ebpf:"kmesh_map296"`
+	KmeshMap64       *ebpf.MapSpec `ebpf:"kmesh_map64"`
 	KmeshPerfInfo    *ebpf.MapSpec `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap     *ebpf.MapSpec `ebpf:"kmesh_perf_map"`
 	KmeshService     *ebpf.MapSpec `ebpf:"kmesh_service"`
-	Map1600          *ebpf.MapSpec `ebpf:"map1600"`
-	Map192           *ebpf.MapSpec `ebpf:"map192"`
-	Map296           *ebpf.MapSpec `ebpf:"map296"`
-	Map64            *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth        *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfDstInfo     *ebpf.MapSpec `ebpf:"map_of_dst_info"`
 	MapOfKmeshSocket *ebpf.MapSpec `ebpf:"map_of_kmesh_socket"`
@@ -153,13 +153,13 @@ type KmeshSockopsWorkloadCompatMaps struct {
 	KmeshEvents      *ebpf.Map `ebpf:"kmesh_events"`
 	KmeshFrontend    *ebpf.Map `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.Map `ebpf:"kmesh_manage"`
+	KmeshMap1600     *ebpf.Map `ebpf:"kmesh_map1600"`
+	KmeshMap192      *ebpf.Map `ebpf:"kmesh_map192"`
+	KmeshMap296      *ebpf.Map `ebpf:"kmesh_map296"`
+	KmeshMap64       *ebpf.Map `ebpf:"kmesh_map64"`
 	KmeshPerfInfo    *ebpf.Map `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap     *ebpf.Map `ebpf:"kmesh_perf_map"`
 	KmeshService     *ebpf.Map `ebpf:"kmesh_service"`
-	Map1600          *ebpf.Map `ebpf:"map1600"`
-	Map192           *ebpf.Map `ebpf:"map192"`
-	Map296           *ebpf.Map `ebpf:"map296"`
-	Map64            *ebpf.Map `ebpf:"map64"`
 	MapOfAuth        *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfDstInfo     *ebpf.Map `ebpf:"map_of_dst_info"`
 	MapOfKmeshSocket *ebpf.Map `ebpf:"map_of_kmesh_socket"`
@@ -179,13 +179,13 @@ func (m *KmeshSockopsWorkloadCompatMaps) Close() error {
 		m.KmeshEvents,
 		m.KmeshFrontend,
 		m.KmeshManage,
+		m.KmeshMap1600,
+		m.KmeshMap192,
+		m.KmeshMap296,
+		m.KmeshMap64,
 		m.KmeshPerfInfo,
 		m.KmeshPerfMap,
 		m.KmeshService,
-		m.Map1600,
-		m.Map192,
-		m.Map296,
-		m.Map64,
 		m.MapOfAuth,
 		m.MapOfDstInfo,
 		m.MapOfKmeshSocket,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkloadcompat_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkloadcompat_bpfel.go
@@ -104,7 +104,6 @@ type KmeshSockopsWorkloadCompatProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type KmeshSockopsWorkloadCompatMapSpecs struct {
-	InnerMap         *ebpf.MapSpec `ebpf:"inner_map"`
 	KmeshBackend     *ebpf.MapSpec `ebpf:"kmesh_backend"`
 	KmeshConfigMap   *ebpf.MapSpec `ebpf:"kmesh_config_map"`
 	KmeshEndpoint    *ebpf.MapSpec `ebpf:"kmesh_endpoint"`
@@ -114,6 +113,10 @@ type KmeshSockopsWorkloadCompatMapSpecs struct {
 	KmeshPerfInfo    *ebpf.MapSpec `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap     *ebpf.MapSpec `ebpf:"kmesh_perf_map"`
 	KmeshService     *ebpf.MapSpec `ebpf:"kmesh_service"`
+	Map1600          *ebpf.MapSpec `ebpf:"map1600"`
+	Map192           *ebpf.MapSpec `ebpf:"map192"`
+	Map296           *ebpf.MapSpec `ebpf:"map296"`
+	Map64            *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth        *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfDstInfo     *ebpf.MapSpec `ebpf:"map_of_dst_info"`
 	MapOfKmeshSocket *ebpf.MapSpec `ebpf:"map_of_kmesh_socket"`
@@ -121,7 +124,6 @@ type KmeshSockopsWorkloadCompatMapSpecs struct {
 	MapOfTcpInfo     *ebpf.MapSpec `ebpf:"map_of_tcp_info"`
 	MapOfTuple       *ebpf.MapSpec `ebpf:"map_of_tuple"`
 	MapOfWlPolicy    *ebpf.MapSpec `ebpf:"map_of_wl_policy"`
-	OuterMap         *ebpf.MapSpec `ebpf:"outer_map"`
 	TmpBuf           *ebpf.MapSpec `ebpf:"tmp_buf"`
 	TmpLogBuf        *ebpf.MapSpec `ebpf:"tmp_log_buf"`
 }
@@ -145,7 +147,6 @@ func (o *KmeshSockopsWorkloadCompatObjects) Close() error {
 //
 // It can be passed to LoadKmeshSockopsWorkloadCompatObjects or ebpf.CollectionSpec.LoadAndAssign.
 type KmeshSockopsWorkloadCompatMaps struct {
-	InnerMap         *ebpf.Map `ebpf:"inner_map"`
 	KmeshBackend     *ebpf.Map `ebpf:"kmesh_backend"`
 	KmeshConfigMap   *ebpf.Map `ebpf:"kmesh_config_map"`
 	KmeshEndpoint    *ebpf.Map `ebpf:"kmesh_endpoint"`
@@ -155,6 +156,10 @@ type KmeshSockopsWorkloadCompatMaps struct {
 	KmeshPerfInfo    *ebpf.Map `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap     *ebpf.Map `ebpf:"kmesh_perf_map"`
 	KmeshService     *ebpf.Map `ebpf:"kmesh_service"`
+	Map1600          *ebpf.Map `ebpf:"map1600"`
+	Map192           *ebpf.Map `ebpf:"map192"`
+	Map296           *ebpf.Map `ebpf:"map296"`
+	Map64            *ebpf.Map `ebpf:"map64"`
 	MapOfAuth        *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfDstInfo     *ebpf.Map `ebpf:"map_of_dst_info"`
 	MapOfKmeshSocket *ebpf.Map `ebpf:"map_of_kmesh_socket"`
@@ -162,14 +167,12 @@ type KmeshSockopsWorkloadCompatMaps struct {
 	MapOfTcpInfo     *ebpf.Map `ebpf:"map_of_tcp_info"`
 	MapOfTuple       *ebpf.Map `ebpf:"map_of_tuple"`
 	MapOfWlPolicy    *ebpf.Map `ebpf:"map_of_wl_policy"`
-	OuterMap         *ebpf.Map `ebpf:"outer_map"`
 	TmpBuf           *ebpf.Map `ebpf:"tmp_buf"`
 	TmpLogBuf        *ebpf.Map `ebpf:"tmp_log_buf"`
 }
 
 func (m *KmeshSockopsWorkloadCompatMaps) Close() error {
 	return _KmeshSockopsWorkloadCompatClose(
-		m.InnerMap,
 		m.KmeshBackend,
 		m.KmeshConfigMap,
 		m.KmeshEndpoint,
@@ -179,6 +182,10 @@ func (m *KmeshSockopsWorkloadCompatMaps) Close() error {
 		m.KmeshPerfInfo,
 		m.KmeshPerfMap,
 		m.KmeshService,
+		m.Map1600,
+		m.Map192,
+		m.Map296,
+		m.Map64,
 		m.MapOfAuth,
 		m.MapOfDstInfo,
 		m.MapOfKmeshSocket,
@@ -186,7 +193,6 @@ func (m *KmeshSockopsWorkloadCompatMaps) Close() error {
 		m.MapOfTcpInfo,
 		m.MapOfTuple,
 		m.MapOfWlPolicy,
-		m.OuterMap,
 		m.TmpBuf,
 		m.TmpLogBuf,
 	)

--- a/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkloadcompat_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshsockopsworkloadcompat_bpfel.go
@@ -110,13 +110,13 @@ type KmeshSockopsWorkloadCompatMapSpecs struct {
 	KmeshEvents      *ebpf.MapSpec `ebpf:"kmesh_events"`
 	KmeshFrontend    *ebpf.MapSpec `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.MapSpec `ebpf:"kmesh_manage"`
+	KmeshMap1600     *ebpf.MapSpec `ebpf:"kmesh_map1600"`
+	KmeshMap192      *ebpf.MapSpec `ebpf:"kmesh_map192"`
+	KmeshMap296      *ebpf.MapSpec `ebpf:"kmesh_map296"`
+	KmeshMap64       *ebpf.MapSpec `ebpf:"kmesh_map64"`
 	KmeshPerfInfo    *ebpf.MapSpec `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap     *ebpf.MapSpec `ebpf:"kmesh_perf_map"`
 	KmeshService     *ebpf.MapSpec `ebpf:"kmesh_service"`
-	Map1600          *ebpf.MapSpec `ebpf:"map1600"`
-	Map192           *ebpf.MapSpec `ebpf:"map192"`
-	Map296           *ebpf.MapSpec `ebpf:"map296"`
-	Map64            *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth        *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfDstInfo     *ebpf.MapSpec `ebpf:"map_of_dst_info"`
 	MapOfKmeshSocket *ebpf.MapSpec `ebpf:"map_of_kmesh_socket"`
@@ -153,13 +153,13 @@ type KmeshSockopsWorkloadCompatMaps struct {
 	KmeshEvents      *ebpf.Map `ebpf:"kmesh_events"`
 	KmeshFrontend    *ebpf.Map `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.Map `ebpf:"kmesh_manage"`
+	KmeshMap1600     *ebpf.Map `ebpf:"kmesh_map1600"`
+	KmeshMap192      *ebpf.Map `ebpf:"kmesh_map192"`
+	KmeshMap296      *ebpf.Map `ebpf:"kmesh_map296"`
+	KmeshMap64       *ebpf.Map `ebpf:"kmesh_map64"`
 	KmeshPerfInfo    *ebpf.Map `ebpf:"kmesh_perf_info"`
 	KmeshPerfMap     *ebpf.Map `ebpf:"kmesh_perf_map"`
 	KmeshService     *ebpf.Map `ebpf:"kmesh_service"`
-	Map1600          *ebpf.Map `ebpf:"map1600"`
-	Map192           *ebpf.Map `ebpf:"map192"`
-	Map296           *ebpf.Map `ebpf:"map296"`
-	Map64            *ebpf.Map `ebpf:"map64"`
 	MapOfAuth        *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfDstInfo     *ebpf.Map `ebpf:"map_of_dst_info"`
 	MapOfKmeshSocket *ebpf.Map `ebpf:"map_of_kmesh_socket"`
@@ -179,13 +179,13 @@ func (m *KmeshSockopsWorkloadCompatMaps) Close() error {
 		m.KmeshEvents,
 		m.KmeshFrontend,
 		m.KmeshManage,
+		m.KmeshMap1600,
+		m.KmeshMap192,
+		m.KmeshMap296,
+		m.KmeshMap64,
 		m.KmeshPerfInfo,
 		m.KmeshPerfMap,
 		m.KmeshService,
-		m.Map1600,
-		m.Map192,
-		m.Map296,
-		m.Map64,
 		m.MapOfAuth,
 		m.MapOfDstInfo,
 		m.MapOfKmeshSocket,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshxdpauth_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshxdpauth_bpfeb.go
@@ -90,7 +90,6 @@ type KmeshXDPAuthProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type KmeshXDPAuthMapSpecs struct {
-	InnerMap         *ebpf.MapSpec `ebpf:"inner_map"`
 	KmeshBackend     *ebpf.MapSpec `ebpf:"kmesh_backend"`
 	KmeshConfigMap   *ebpf.MapSpec `ebpf:"kmesh_config_map"`
 	KmeshEndpoint    *ebpf.MapSpec `ebpf:"kmesh_endpoint"`
@@ -98,12 +97,15 @@ type KmeshXDPAuthMapSpecs struct {
 	KmeshFrontend    *ebpf.MapSpec `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.MapSpec `ebpf:"kmesh_manage"`
 	KmeshService     *ebpf.MapSpec `ebpf:"kmesh_service"`
+	Map1600          *ebpf.MapSpec `ebpf:"map1600"`
+	Map192           *ebpf.MapSpec `ebpf:"map192"`
+	Map296           *ebpf.MapSpec `ebpf:"map296"`
+	Map64            *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth        *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfAuthz       *ebpf.MapSpec `ebpf:"map_of_authz"`
 	MapOfSockStorage *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
 	MapOfTuple       *ebpf.MapSpec `ebpf:"map_of_tuple"`
 	MapOfWlPolicy    *ebpf.MapSpec `ebpf:"map_of_wl_policy"`
-	OuterMap         *ebpf.MapSpec `ebpf:"outer_map"`
 	TmpBuf           *ebpf.MapSpec `ebpf:"tmp_buf"`
 	TmpLogBuf        *ebpf.MapSpec `ebpf:"tmp_log_buf"`
 }
@@ -127,7 +129,6 @@ func (o *KmeshXDPAuthObjects) Close() error {
 //
 // It can be passed to LoadKmeshXDPAuthObjects or ebpf.CollectionSpec.LoadAndAssign.
 type KmeshXDPAuthMaps struct {
-	InnerMap         *ebpf.Map `ebpf:"inner_map"`
 	KmeshBackend     *ebpf.Map `ebpf:"kmesh_backend"`
 	KmeshConfigMap   *ebpf.Map `ebpf:"kmesh_config_map"`
 	KmeshEndpoint    *ebpf.Map `ebpf:"kmesh_endpoint"`
@@ -135,19 +136,21 @@ type KmeshXDPAuthMaps struct {
 	KmeshFrontend    *ebpf.Map `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.Map `ebpf:"kmesh_manage"`
 	KmeshService     *ebpf.Map `ebpf:"kmesh_service"`
+	Map1600          *ebpf.Map `ebpf:"map1600"`
+	Map192           *ebpf.Map `ebpf:"map192"`
+	Map296           *ebpf.Map `ebpf:"map296"`
+	Map64            *ebpf.Map `ebpf:"map64"`
 	MapOfAuth        *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfAuthz       *ebpf.Map `ebpf:"map_of_authz"`
 	MapOfSockStorage *ebpf.Map `ebpf:"map_of_sock_storage"`
 	MapOfTuple       *ebpf.Map `ebpf:"map_of_tuple"`
 	MapOfWlPolicy    *ebpf.Map `ebpf:"map_of_wl_policy"`
-	OuterMap         *ebpf.Map `ebpf:"outer_map"`
 	TmpBuf           *ebpf.Map `ebpf:"tmp_buf"`
 	TmpLogBuf        *ebpf.Map `ebpf:"tmp_log_buf"`
 }
 
 func (m *KmeshXDPAuthMaps) Close() error {
 	return _KmeshXDPAuthClose(
-		m.InnerMap,
 		m.KmeshBackend,
 		m.KmeshConfigMap,
 		m.KmeshEndpoint,
@@ -155,12 +158,15 @@ func (m *KmeshXDPAuthMaps) Close() error {
 		m.KmeshFrontend,
 		m.KmeshManage,
 		m.KmeshService,
+		m.Map1600,
+		m.Map192,
+		m.Map296,
+		m.Map64,
 		m.MapOfAuth,
 		m.MapOfAuthz,
 		m.MapOfSockStorage,
 		m.MapOfTuple,
 		m.MapOfWlPolicy,
-		m.OuterMap,
 		m.TmpBuf,
 		m.TmpLogBuf,
 	)

--- a/bpf/kmesh/bpf2go/dualengine/kmeshxdpauth_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshxdpauth_bpfeb.go
@@ -96,11 +96,11 @@ type KmeshXDPAuthMapSpecs struct {
 	KmeshEvents      *ebpf.MapSpec `ebpf:"kmesh_events"`
 	KmeshFrontend    *ebpf.MapSpec `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.MapSpec `ebpf:"kmesh_manage"`
+	KmeshMap1600     *ebpf.MapSpec `ebpf:"kmesh_map1600"`
+	KmeshMap192      *ebpf.MapSpec `ebpf:"kmesh_map192"`
+	KmeshMap296      *ebpf.MapSpec `ebpf:"kmesh_map296"`
+	KmeshMap64       *ebpf.MapSpec `ebpf:"kmesh_map64"`
 	KmeshService     *ebpf.MapSpec `ebpf:"kmesh_service"`
-	Map1600          *ebpf.MapSpec `ebpf:"map1600"`
-	Map192           *ebpf.MapSpec `ebpf:"map192"`
-	Map296           *ebpf.MapSpec `ebpf:"map296"`
-	Map64            *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth        *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfAuthz       *ebpf.MapSpec `ebpf:"map_of_authz"`
 	MapOfSockStorage *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
@@ -135,11 +135,11 @@ type KmeshXDPAuthMaps struct {
 	KmeshEvents      *ebpf.Map `ebpf:"kmesh_events"`
 	KmeshFrontend    *ebpf.Map `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.Map `ebpf:"kmesh_manage"`
+	KmeshMap1600     *ebpf.Map `ebpf:"kmesh_map1600"`
+	KmeshMap192      *ebpf.Map `ebpf:"kmesh_map192"`
+	KmeshMap296      *ebpf.Map `ebpf:"kmesh_map296"`
+	KmeshMap64       *ebpf.Map `ebpf:"kmesh_map64"`
 	KmeshService     *ebpf.Map `ebpf:"kmesh_service"`
-	Map1600          *ebpf.Map `ebpf:"map1600"`
-	Map192           *ebpf.Map `ebpf:"map192"`
-	Map296           *ebpf.Map `ebpf:"map296"`
-	Map64            *ebpf.Map `ebpf:"map64"`
 	MapOfAuth        *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfAuthz       *ebpf.Map `ebpf:"map_of_authz"`
 	MapOfSockStorage *ebpf.Map `ebpf:"map_of_sock_storage"`
@@ -157,11 +157,11 @@ func (m *KmeshXDPAuthMaps) Close() error {
 		m.KmeshEvents,
 		m.KmeshFrontend,
 		m.KmeshManage,
+		m.KmeshMap1600,
+		m.KmeshMap192,
+		m.KmeshMap296,
+		m.KmeshMap64,
 		m.KmeshService,
-		m.Map1600,
-		m.Map192,
-		m.Map296,
-		m.Map64,
 		m.MapOfAuth,
 		m.MapOfAuthz,
 		m.MapOfSockStorage,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshxdpauth_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshxdpauth_bpfel.go
@@ -90,7 +90,6 @@ type KmeshXDPAuthProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type KmeshXDPAuthMapSpecs struct {
-	InnerMap         *ebpf.MapSpec `ebpf:"inner_map"`
 	KmeshBackend     *ebpf.MapSpec `ebpf:"kmesh_backend"`
 	KmeshConfigMap   *ebpf.MapSpec `ebpf:"kmesh_config_map"`
 	KmeshEndpoint    *ebpf.MapSpec `ebpf:"kmesh_endpoint"`
@@ -98,12 +97,15 @@ type KmeshXDPAuthMapSpecs struct {
 	KmeshFrontend    *ebpf.MapSpec `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.MapSpec `ebpf:"kmesh_manage"`
 	KmeshService     *ebpf.MapSpec `ebpf:"kmesh_service"`
+	Map1600          *ebpf.MapSpec `ebpf:"map1600"`
+	Map192           *ebpf.MapSpec `ebpf:"map192"`
+	Map296           *ebpf.MapSpec `ebpf:"map296"`
+	Map64            *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth        *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfAuthz       *ebpf.MapSpec `ebpf:"map_of_authz"`
 	MapOfSockStorage *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
 	MapOfTuple       *ebpf.MapSpec `ebpf:"map_of_tuple"`
 	MapOfWlPolicy    *ebpf.MapSpec `ebpf:"map_of_wl_policy"`
-	OuterMap         *ebpf.MapSpec `ebpf:"outer_map"`
 	TmpBuf           *ebpf.MapSpec `ebpf:"tmp_buf"`
 	TmpLogBuf        *ebpf.MapSpec `ebpf:"tmp_log_buf"`
 }
@@ -127,7 +129,6 @@ func (o *KmeshXDPAuthObjects) Close() error {
 //
 // It can be passed to LoadKmeshXDPAuthObjects or ebpf.CollectionSpec.LoadAndAssign.
 type KmeshXDPAuthMaps struct {
-	InnerMap         *ebpf.Map `ebpf:"inner_map"`
 	KmeshBackend     *ebpf.Map `ebpf:"kmesh_backend"`
 	KmeshConfigMap   *ebpf.Map `ebpf:"kmesh_config_map"`
 	KmeshEndpoint    *ebpf.Map `ebpf:"kmesh_endpoint"`
@@ -135,19 +136,21 @@ type KmeshXDPAuthMaps struct {
 	KmeshFrontend    *ebpf.Map `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.Map `ebpf:"kmesh_manage"`
 	KmeshService     *ebpf.Map `ebpf:"kmesh_service"`
+	Map1600          *ebpf.Map `ebpf:"map1600"`
+	Map192           *ebpf.Map `ebpf:"map192"`
+	Map296           *ebpf.Map `ebpf:"map296"`
+	Map64            *ebpf.Map `ebpf:"map64"`
 	MapOfAuth        *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfAuthz       *ebpf.Map `ebpf:"map_of_authz"`
 	MapOfSockStorage *ebpf.Map `ebpf:"map_of_sock_storage"`
 	MapOfTuple       *ebpf.Map `ebpf:"map_of_tuple"`
 	MapOfWlPolicy    *ebpf.Map `ebpf:"map_of_wl_policy"`
-	OuterMap         *ebpf.Map `ebpf:"outer_map"`
 	TmpBuf           *ebpf.Map `ebpf:"tmp_buf"`
 	TmpLogBuf        *ebpf.Map `ebpf:"tmp_log_buf"`
 }
 
 func (m *KmeshXDPAuthMaps) Close() error {
 	return _KmeshXDPAuthClose(
-		m.InnerMap,
 		m.KmeshBackend,
 		m.KmeshConfigMap,
 		m.KmeshEndpoint,
@@ -155,12 +158,15 @@ func (m *KmeshXDPAuthMaps) Close() error {
 		m.KmeshFrontend,
 		m.KmeshManage,
 		m.KmeshService,
+		m.Map1600,
+		m.Map192,
+		m.Map296,
+		m.Map64,
 		m.MapOfAuth,
 		m.MapOfAuthz,
 		m.MapOfSockStorage,
 		m.MapOfTuple,
 		m.MapOfWlPolicy,
-		m.OuterMap,
 		m.TmpBuf,
 		m.TmpLogBuf,
 	)

--- a/bpf/kmesh/bpf2go/dualengine/kmeshxdpauth_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshxdpauth_bpfel.go
@@ -96,11 +96,11 @@ type KmeshXDPAuthMapSpecs struct {
 	KmeshEvents      *ebpf.MapSpec `ebpf:"kmesh_events"`
 	KmeshFrontend    *ebpf.MapSpec `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.MapSpec `ebpf:"kmesh_manage"`
+	KmeshMap1600     *ebpf.MapSpec `ebpf:"kmesh_map1600"`
+	KmeshMap192      *ebpf.MapSpec `ebpf:"kmesh_map192"`
+	KmeshMap296      *ebpf.MapSpec `ebpf:"kmesh_map296"`
+	KmeshMap64       *ebpf.MapSpec `ebpf:"kmesh_map64"`
 	KmeshService     *ebpf.MapSpec `ebpf:"kmesh_service"`
-	Map1600          *ebpf.MapSpec `ebpf:"map1600"`
-	Map192           *ebpf.MapSpec `ebpf:"map192"`
-	Map296           *ebpf.MapSpec `ebpf:"map296"`
-	Map64            *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth        *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfAuthz       *ebpf.MapSpec `ebpf:"map_of_authz"`
 	MapOfSockStorage *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
@@ -135,11 +135,11 @@ type KmeshXDPAuthMaps struct {
 	KmeshEvents      *ebpf.Map `ebpf:"kmesh_events"`
 	KmeshFrontend    *ebpf.Map `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.Map `ebpf:"kmesh_manage"`
+	KmeshMap1600     *ebpf.Map `ebpf:"kmesh_map1600"`
+	KmeshMap192      *ebpf.Map `ebpf:"kmesh_map192"`
+	KmeshMap296      *ebpf.Map `ebpf:"kmesh_map296"`
+	KmeshMap64       *ebpf.Map `ebpf:"kmesh_map64"`
 	KmeshService     *ebpf.Map `ebpf:"kmesh_service"`
-	Map1600          *ebpf.Map `ebpf:"map1600"`
-	Map192           *ebpf.Map `ebpf:"map192"`
-	Map296           *ebpf.Map `ebpf:"map296"`
-	Map64            *ebpf.Map `ebpf:"map64"`
 	MapOfAuth        *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfAuthz       *ebpf.Map `ebpf:"map_of_authz"`
 	MapOfSockStorage *ebpf.Map `ebpf:"map_of_sock_storage"`
@@ -157,11 +157,11 @@ func (m *KmeshXDPAuthMaps) Close() error {
 		m.KmeshEvents,
 		m.KmeshFrontend,
 		m.KmeshManage,
+		m.KmeshMap1600,
+		m.KmeshMap192,
+		m.KmeshMap296,
+		m.KmeshMap64,
 		m.KmeshService,
-		m.Map1600,
-		m.Map192,
-		m.Map296,
-		m.Map64,
 		m.MapOfAuth,
 		m.MapOfAuthz,
 		m.MapOfSockStorage,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshxdpauthcompat_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshxdpauthcompat_bpfeb.go
@@ -96,11 +96,11 @@ type KmeshXDPAuthCompatMapSpecs struct {
 	KmeshEvents      *ebpf.MapSpec `ebpf:"kmesh_events"`
 	KmeshFrontend    *ebpf.MapSpec `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.MapSpec `ebpf:"kmesh_manage"`
+	KmeshMap1600     *ebpf.MapSpec `ebpf:"kmesh_map1600"`
+	KmeshMap192      *ebpf.MapSpec `ebpf:"kmesh_map192"`
+	KmeshMap296      *ebpf.MapSpec `ebpf:"kmesh_map296"`
+	KmeshMap64       *ebpf.MapSpec `ebpf:"kmesh_map64"`
 	KmeshService     *ebpf.MapSpec `ebpf:"kmesh_service"`
-	Map1600          *ebpf.MapSpec `ebpf:"map1600"`
-	Map192           *ebpf.MapSpec `ebpf:"map192"`
-	Map296           *ebpf.MapSpec `ebpf:"map296"`
-	Map64            *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth        *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfAuthz       *ebpf.MapSpec `ebpf:"map_of_authz"`
 	MapOfSockStorage *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
@@ -135,11 +135,11 @@ type KmeshXDPAuthCompatMaps struct {
 	KmeshEvents      *ebpf.Map `ebpf:"kmesh_events"`
 	KmeshFrontend    *ebpf.Map `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.Map `ebpf:"kmesh_manage"`
+	KmeshMap1600     *ebpf.Map `ebpf:"kmesh_map1600"`
+	KmeshMap192      *ebpf.Map `ebpf:"kmesh_map192"`
+	KmeshMap296      *ebpf.Map `ebpf:"kmesh_map296"`
+	KmeshMap64       *ebpf.Map `ebpf:"kmesh_map64"`
 	KmeshService     *ebpf.Map `ebpf:"kmesh_service"`
-	Map1600          *ebpf.Map `ebpf:"map1600"`
-	Map192           *ebpf.Map `ebpf:"map192"`
-	Map296           *ebpf.Map `ebpf:"map296"`
-	Map64            *ebpf.Map `ebpf:"map64"`
 	MapOfAuth        *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfAuthz       *ebpf.Map `ebpf:"map_of_authz"`
 	MapOfSockStorage *ebpf.Map `ebpf:"map_of_sock_storage"`
@@ -157,11 +157,11 @@ func (m *KmeshXDPAuthCompatMaps) Close() error {
 		m.KmeshEvents,
 		m.KmeshFrontend,
 		m.KmeshManage,
+		m.KmeshMap1600,
+		m.KmeshMap192,
+		m.KmeshMap296,
+		m.KmeshMap64,
 		m.KmeshService,
-		m.Map1600,
-		m.Map192,
-		m.Map296,
-		m.Map64,
 		m.MapOfAuth,
 		m.MapOfAuthz,
 		m.MapOfSockStorage,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshxdpauthcompat_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshxdpauthcompat_bpfeb.go
@@ -90,7 +90,6 @@ type KmeshXDPAuthCompatProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type KmeshXDPAuthCompatMapSpecs struct {
-	InnerMap         *ebpf.MapSpec `ebpf:"inner_map"`
 	KmeshBackend     *ebpf.MapSpec `ebpf:"kmesh_backend"`
 	KmeshConfigMap   *ebpf.MapSpec `ebpf:"kmesh_config_map"`
 	KmeshEndpoint    *ebpf.MapSpec `ebpf:"kmesh_endpoint"`
@@ -98,12 +97,15 @@ type KmeshXDPAuthCompatMapSpecs struct {
 	KmeshFrontend    *ebpf.MapSpec `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.MapSpec `ebpf:"kmesh_manage"`
 	KmeshService     *ebpf.MapSpec `ebpf:"kmesh_service"`
+	Map1600          *ebpf.MapSpec `ebpf:"map1600"`
+	Map192           *ebpf.MapSpec `ebpf:"map192"`
+	Map296           *ebpf.MapSpec `ebpf:"map296"`
+	Map64            *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth        *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfAuthz       *ebpf.MapSpec `ebpf:"map_of_authz"`
 	MapOfSockStorage *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
 	MapOfTuple       *ebpf.MapSpec `ebpf:"map_of_tuple"`
 	MapOfWlPolicy    *ebpf.MapSpec `ebpf:"map_of_wl_policy"`
-	OuterMap         *ebpf.MapSpec `ebpf:"outer_map"`
 	TmpBuf           *ebpf.MapSpec `ebpf:"tmp_buf"`
 	TmpLogBuf        *ebpf.MapSpec `ebpf:"tmp_log_buf"`
 }
@@ -127,7 +129,6 @@ func (o *KmeshXDPAuthCompatObjects) Close() error {
 //
 // It can be passed to LoadKmeshXDPAuthCompatObjects or ebpf.CollectionSpec.LoadAndAssign.
 type KmeshXDPAuthCompatMaps struct {
-	InnerMap         *ebpf.Map `ebpf:"inner_map"`
 	KmeshBackend     *ebpf.Map `ebpf:"kmesh_backend"`
 	KmeshConfigMap   *ebpf.Map `ebpf:"kmesh_config_map"`
 	KmeshEndpoint    *ebpf.Map `ebpf:"kmesh_endpoint"`
@@ -135,19 +136,21 @@ type KmeshXDPAuthCompatMaps struct {
 	KmeshFrontend    *ebpf.Map `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.Map `ebpf:"kmesh_manage"`
 	KmeshService     *ebpf.Map `ebpf:"kmesh_service"`
+	Map1600          *ebpf.Map `ebpf:"map1600"`
+	Map192           *ebpf.Map `ebpf:"map192"`
+	Map296           *ebpf.Map `ebpf:"map296"`
+	Map64            *ebpf.Map `ebpf:"map64"`
 	MapOfAuth        *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfAuthz       *ebpf.Map `ebpf:"map_of_authz"`
 	MapOfSockStorage *ebpf.Map `ebpf:"map_of_sock_storage"`
 	MapOfTuple       *ebpf.Map `ebpf:"map_of_tuple"`
 	MapOfWlPolicy    *ebpf.Map `ebpf:"map_of_wl_policy"`
-	OuterMap         *ebpf.Map `ebpf:"outer_map"`
 	TmpBuf           *ebpf.Map `ebpf:"tmp_buf"`
 	TmpLogBuf        *ebpf.Map `ebpf:"tmp_log_buf"`
 }
 
 func (m *KmeshXDPAuthCompatMaps) Close() error {
 	return _KmeshXDPAuthCompatClose(
-		m.InnerMap,
 		m.KmeshBackend,
 		m.KmeshConfigMap,
 		m.KmeshEndpoint,
@@ -155,12 +158,15 @@ func (m *KmeshXDPAuthCompatMaps) Close() error {
 		m.KmeshFrontend,
 		m.KmeshManage,
 		m.KmeshService,
+		m.Map1600,
+		m.Map192,
+		m.Map296,
+		m.Map64,
 		m.MapOfAuth,
 		m.MapOfAuthz,
 		m.MapOfSockStorage,
 		m.MapOfTuple,
 		m.MapOfWlPolicy,
-		m.OuterMap,
 		m.TmpBuf,
 		m.TmpLogBuf,
 	)

--- a/bpf/kmesh/bpf2go/dualengine/kmeshxdpauthcompat_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshxdpauthcompat_bpfel.go
@@ -96,11 +96,11 @@ type KmeshXDPAuthCompatMapSpecs struct {
 	KmeshEvents      *ebpf.MapSpec `ebpf:"kmesh_events"`
 	KmeshFrontend    *ebpf.MapSpec `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.MapSpec `ebpf:"kmesh_manage"`
+	KmeshMap1600     *ebpf.MapSpec `ebpf:"kmesh_map1600"`
+	KmeshMap192      *ebpf.MapSpec `ebpf:"kmesh_map192"`
+	KmeshMap296      *ebpf.MapSpec `ebpf:"kmesh_map296"`
+	KmeshMap64       *ebpf.MapSpec `ebpf:"kmesh_map64"`
 	KmeshService     *ebpf.MapSpec `ebpf:"kmesh_service"`
-	Map1600          *ebpf.MapSpec `ebpf:"map1600"`
-	Map192           *ebpf.MapSpec `ebpf:"map192"`
-	Map296           *ebpf.MapSpec `ebpf:"map296"`
-	Map64            *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth        *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfAuthz       *ebpf.MapSpec `ebpf:"map_of_authz"`
 	MapOfSockStorage *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
@@ -135,11 +135,11 @@ type KmeshXDPAuthCompatMaps struct {
 	KmeshEvents      *ebpf.Map `ebpf:"kmesh_events"`
 	KmeshFrontend    *ebpf.Map `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.Map `ebpf:"kmesh_manage"`
+	KmeshMap1600     *ebpf.Map `ebpf:"kmesh_map1600"`
+	KmeshMap192      *ebpf.Map `ebpf:"kmesh_map192"`
+	KmeshMap296      *ebpf.Map `ebpf:"kmesh_map296"`
+	KmeshMap64       *ebpf.Map `ebpf:"kmesh_map64"`
 	KmeshService     *ebpf.Map `ebpf:"kmesh_service"`
-	Map1600          *ebpf.Map `ebpf:"map1600"`
-	Map192           *ebpf.Map `ebpf:"map192"`
-	Map296           *ebpf.Map `ebpf:"map296"`
-	Map64            *ebpf.Map `ebpf:"map64"`
 	MapOfAuth        *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfAuthz       *ebpf.Map `ebpf:"map_of_authz"`
 	MapOfSockStorage *ebpf.Map `ebpf:"map_of_sock_storage"`
@@ -157,11 +157,11 @@ func (m *KmeshXDPAuthCompatMaps) Close() error {
 		m.KmeshEvents,
 		m.KmeshFrontend,
 		m.KmeshManage,
+		m.KmeshMap1600,
+		m.KmeshMap192,
+		m.KmeshMap296,
+		m.KmeshMap64,
 		m.KmeshService,
-		m.Map1600,
-		m.Map192,
-		m.Map296,
-		m.Map64,
 		m.MapOfAuth,
 		m.MapOfAuthz,
 		m.MapOfSockStorage,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshxdpauthcompat_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshxdpauthcompat_bpfel.go
@@ -90,7 +90,6 @@ type KmeshXDPAuthCompatProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type KmeshXDPAuthCompatMapSpecs struct {
-	InnerMap         *ebpf.MapSpec `ebpf:"inner_map"`
 	KmeshBackend     *ebpf.MapSpec `ebpf:"kmesh_backend"`
 	KmeshConfigMap   *ebpf.MapSpec `ebpf:"kmesh_config_map"`
 	KmeshEndpoint    *ebpf.MapSpec `ebpf:"kmesh_endpoint"`
@@ -98,12 +97,15 @@ type KmeshXDPAuthCompatMapSpecs struct {
 	KmeshFrontend    *ebpf.MapSpec `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.MapSpec `ebpf:"kmesh_manage"`
 	KmeshService     *ebpf.MapSpec `ebpf:"kmesh_service"`
+	Map1600          *ebpf.MapSpec `ebpf:"map1600"`
+	Map192           *ebpf.MapSpec `ebpf:"map192"`
+	Map296           *ebpf.MapSpec `ebpf:"map296"`
+	Map64            *ebpf.MapSpec `ebpf:"map64"`
 	MapOfAuth        *ebpf.MapSpec `ebpf:"map_of_auth"`
 	MapOfAuthz       *ebpf.MapSpec `ebpf:"map_of_authz"`
 	MapOfSockStorage *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
 	MapOfTuple       *ebpf.MapSpec `ebpf:"map_of_tuple"`
 	MapOfWlPolicy    *ebpf.MapSpec `ebpf:"map_of_wl_policy"`
-	OuterMap         *ebpf.MapSpec `ebpf:"outer_map"`
 	TmpBuf           *ebpf.MapSpec `ebpf:"tmp_buf"`
 	TmpLogBuf        *ebpf.MapSpec `ebpf:"tmp_log_buf"`
 }
@@ -127,7 +129,6 @@ func (o *KmeshXDPAuthCompatObjects) Close() error {
 //
 // It can be passed to LoadKmeshXDPAuthCompatObjects or ebpf.CollectionSpec.LoadAndAssign.
 type KmeshXDPAuthCompatMaps struct {
-	InnerMap         *ebpf.Map `ebpf:"inner_map"`
 	KmeshBackend     *ebpf.Map `ebpf:"kmesh_backend"`
 	KmeshConfigMap   *ebpf.Map `ebpf:"kmesh_config_map"`
 	KmeshEndpoint    *ebpf.Map `ebpf:"kmesh_endpoint"`
@@ -135,19 +136,21 @@ type KmeshXDPAuthCompatMaps struct {
 	KmeshFrontend    *ebpf.Map `ebpf:"kmesh_frontend"`
 	KmeshManage      *ebpf.Map `ebpf:"kmesh_manage"`
 	KmeshService     *ebpf.Map `ebpf:"kmesh_service"`
+	Map1600          *ebpf.Map `ebpf:"map1600"`
+	Map192           *ebpf.Map `ebpf:"map192"`
+	Map296           *ebpf.Map `ebpf:"map296"`
+	Map64            *ebpf.Map `ebpf:"map64"`
 	MapOfAuth        *ebpf.Map `ebpf:"map_of_auth"`
 	MapOfAuthz       *ebpf.Map `ebpf:"map_of_authz"`
 	MapOfSockStorage *ebpf.Map `ebpf:"map_of_sock_storage"`
 	MapOfTuple       *ebpf.Map `ebpf:"map_of_tuple"`
 	MapOfWlPolicy    *ebpf.Map `ebpf:"map_of_wl_policy"`
-	OuterMap         *ebpf.Map `ebpf:"outer_map"`
 	TmpBuf           *ebpf.Map `ebpf:"tmp_buf"`
 	TmpLogBuf        *ebpf.Map `ebpf:"tmp_log_buf"`
 }
 
 func (m *KmeshXDPAuthCompatMaps) Close() error {
 	return _KmeshXDPAuthCompatClose(
-		m.InnerMap,
 		m.KmeshBackend,
 		m.KmeshConfigMap,
 		m.KmeshEndpoint,
@@ -155,12 +158,15 @@ func (m *KmeshXDPAuthCompatMaps) Close() error {
 		m.KmeshFrontend,
 		m.KmeshManage,
 		m.KmeshService,
+		m.Map1600,
+		m.Map192,
+		m.Map296,
+		m.Map64,
 		m.MapOfAuth,
 		m.MapOfAuthz,
 		m.MapOfSockStorage,
 		m.MapOfTuple,
 		m.MapOfWlPolicy,
-		m.OuterMap,
 		m.TmpBuf,
 		m.TmpLogBuf,
 	)

--- a/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsock_bpfeb.go
+++ b/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsock_bpfeb.go
@@ -102,7 +102,6 @@ type KmeshCgroupSockProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type KmeshCgroupSockMapSpecs struct {
-	InnerMap            *ebpf.MapSpec `ebpf:"inner_map"`
 	KmeshCluster        *ebpf.MapSpec `ebpf:"kmesh_cluster"`
 	KmeshClusterStats   *ebpf.MapSpec `ebpf:"kmesh_cluster_stats"`
 	KmeshConfigMap      *ebpf.MapSpec `ebpf:"kmesh_config_map"`
@@ -112,11 +111,14 @@ type KmeshCgroupSockMapSpecs struct {
 	KmeshRatelimit      *ebpf.MapSpec `ebpf:"kmesh_ratelimit"`
 	KmeshTailCallCtx    *ebpf.MapSpec `ebpf:"kmesh_tail_call_ctx"`
 	KmeshTailCallProg   *ebpf.MapSpec `ebpf:"kmesh_tail_call_prog"`
+	Map1600             *ebpf.MapSpec `ebpf:"map1600"`
+	Map192              *ebpf.MapSpec `ebpf:"map192"`
+	Map296              *ebpf.MapSpec `ebpf:"map296"`
+	Map64               *ebpf.MapSpec `ebpf:"map64"`
 	MapOfClusterEps     *ebpf.MapSpec `ebpf:"map_of_cluster_eps"`
 	MapOfClusterEpsData *ebpf.MapSpec `ebpf:"map_of_cluster_eps_data"`
 	MapOfClusterSock    *ebpf.MapSpec `ebpf:"map_of_cluster_sock"`
 	MapOfSockStorage    *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
-	OuterMap            *ebpf.MapSpec `ebpf:"outer_map"`
 	OuterOfMaglev       *ebpf.MapSpec `ebpf:"outer_of_maglev"`
 	TmpBuf              *ebpf.MapSpec `ebpf:"tmp_buf"`
 	TmpLogBuf           *ebpf.MapSpec `ebpf:"tmp_log_buf"`
@@ -141,7 +143,6 @@ func (o *KmeshCgroupSockObjects) Close() error {
 //
 // It can be passed to LoadKmeshCgroupSockObjects or ebpf.CollectionSpec.LoadAndAssign.
 type KmeshCgroupSockMaps struct {
-	InnerMap            *ebpf.Map `ebpf:"inner_map"`
 	KmeshCluster        *ebpf.Map `ebpf:"kmesh_cluster"`
 	KmeshClusterStats   *ebpf.Map `ebpf:"kmesh_cluster_stats"`
 	KmeshConfigMap      *ebpf.Map `ebpf:"kmesh_config_map"`
@@ -151,11 +152,14 @@ type KmeshCgroupSockMaps struct {
 	KmeshRatelimit      *ebpf.Map `ebpf:"kmesh_ratelimit"`
 	KmeshTailCallCtx    *ebpf.Map `ebpf:"kmesh_tail_call_ctx"`
 	KmeshTailCallProg   *ebpf.Map `ebpf:"kmesh_tail_call_prog"`
+	Map1600             *ebpf.Map `ebpf:"map1600"`
+	Map192              *ebpf.Map `ebpf:"map192"`
+	Map296              *ebpf.Map `ebpf:"map296"`
+	Map64               *ebpf.Map `ebpf:"map64"`
 	MapOfClusterEps     *ebpf.Map `ebpf:"map_of_cluster_eps"`
 	MapOfClusterEpsData *ebpf.Map `ebpf:"map_of_cluster_eps_data"`
 	MapOfClusterSock    *ebpf.Map `ebpf:"map_of_cluster_sock"`
 	MapOfSockStorage    *ebpf.Map `ebpf:"map_of_sock_storage"`
-	OuterMap            *ebpf.Map `ebpf:"outer_map"`
 	OuterOfMaglev       *ebpf.Map `ebpf:"outer_of_maglev"`
 	TmpBuf              *ebpf.Map `ebpf:"tmp_buf"`
 	TmpLogBuf           *ebpf.Map `ebpf:"tmp_log_buf"`
@@ -163,7 +167,6 @@ type KmeshCgroupSockMaps struct {
 
 func (m *KmeshCgroupSockMaps) Close() error {
 	return _KmeshCgroupSockClose(
-		m.InnerMap,
 		m.KmeshCluster,
 		m.KmeshClusterStats,
 		m.KmeshConfigMap,
@@ -173,11 +176,14 @@ func (m *KmeshCgroupSockMaps) Close() error {
 		m.KmeshRatelimit,
 		m.KmeshTailCallCtx,
 		m.KmeshTailCallProg,
+		m.Map1600,
+		m.Map192,
+		m.Map296,
+		m.Map64,
 		m.MapOfClusterEps,
 		m.MapOfClusterEpsData,
 		m.MapOfClusterSock,
 		m.MapOfSockStorage,
-		m.OuterMap,
 		m.OuterOfMaglev,
 		m.TmpBuf,
 		m.TmpLogBuf,

--- a/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsock_bpfeb.go
+++ b/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsock_bpfeb.go
@@ -108,13 +108,13 @@ type KmeshCgroupSockMapSpecs struct {
 	KmeshEvents         *ebpf.MapSpec `ebpf:"kmesh_events"`
 	KmeshListener       *ebpf.MapSpec `ebpf:"kmesh_listener"`
 	KmeshManage         *ebpf.MapSpec `ebpf:"kmesh_manage"`
+	KmeshMap1600        *ebpf.MapSpec `ebpf:"kmesh_map1600"`
+	KmeshMap192         *ebpf.MapSpec `ebpf:"kmesh_map192"`
+	KmeshMap296         *ebpf.MapSpec `ebpf:"kmesh_map296"`
+	KmeshMap64          *ebpf.MapSpec `ebpf:"kmesh_map64"`
 	KmeshRatelimit      *ebpf.MapSpec `ebpf:"kmesh_ratelimit"`
 	KmeshTailCallCtx    *ebpf.MapSpec `ebpf:"kmesh_tail_call_ctx"`
 	KmeshTailCallProg   *ebpf.MapSpec `ebpf:"kmesh_tail_call_prog"`
-	Map1600             *ebpf.MapSpec `ebpf:"map1600"`
-	Map192              *ebpf.MapSpec `ebpf:"map192"`
-	Map296              *ebpf.MapSpec `ebpf:"map296"`
-	Map64               *ebpf.MapSpec `ebpf:"map64"`
 	MapOfClusterEps     *ebpf.MapSpec `ebpf:"map_of_cluster_eps"`
 	MapOfClusterEpsData *ebpf.MapSpec `ebpf:"map_of_cluster_eps_data"`
 	MapOfClusterSock    *ebpf.MapSpec `ebpf:"map_of_cluster_sock"`
@@ -149,13 +149,13 @@ type KmeshCgroupSockMaps struct {
 	KmeshEvents         *ebpf.Map `ebpf:"kmesh_events"`
 	KmeshListener       *ebpf.Map `ebpf:"kmesh_listener"`
 	KmeshManage         *ebpf.Map `ebpf:"kmesh_manage"`
+	KmeshMap1600        *ebpf.Map `ebpf:"kmesh_map1600"`
+	KmeshMap192         *ebpf.Map `ebpf:"kmesh_map192"`
+	KmeshMap296         *ebpf.Map `ebpf:"kmesh_map296"`
+	KmeshMap64          *ebpf.Map `ebpf:"kmesh_map64"`
 	KmeshRatelimit      *ebpf.Map `ebpf:"kmesh_ratelimit"`
 	KmeshTailCallCtx    *ebpf.Map `ebpf:"kmesh_tail_call_ctx"`
 	KmeshTailCallProg   *ebpf.Map `ebpf:"kmesh_tail_call_prog"`
-	Map1600             *ebpf.Map `ebpf:"map1600"`
-	Map192              *ebpf.Map `ebpf:"map192"`
-	Map296              *ebpf.Map `ebpf:"map296"`
-	Map64               *ebpf.Map `ebpf:"map64"`
 	MapOfClusterEps     *ebpf.Map `ebpf:"map_of_cluster_eps"`
 	MapOfClusterEpsData *ebpf.Map `ebpf:"map_of_cluster_eps_data"`
 	MapOfClusterSock    *ebpf.Map `ebpf:"map_of_cluster_sock"`
@@ -173,13 +173,13 @@ func (m *KmeshCgroupSockMaps) Close() error {
 		m.KmeshEvents,
 		m.KmeshListener,
 		m.KmeshManage,
+		m.KmeshMap1600,
+		m.KmeshMap192,
+		m.KmeshMap296,
+		m.KmeshMap64,
 		m.KmeshRatelimit,
 		m.KmeshTailCallCtx,
 		m.KmeshTailCallProg,
-		m.Map1600,
-		m.Map192,
-		m.Map296,
-		m.Map64,
 		m.MapOfClusterEps,
 		m.MapOfClusterEpsData,
 		m.MapOfClusterSock,

--- a/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsock_bpfel.go
+++ b/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsock_bpfel.go
@@ -102,7 +102,6 @@ type KmeshCgroupSockProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type KmeshCgroupSockMapSpecs struct {
-	InnerMap            *ebpf.MapSpec `ebpf:"inner_map"`
 	KmeshCluster        *ebpf.MapSpec `ebpf:"kmesh_cluster"`
 	KmeshClusterStats   *ebpf.MapSpec `ebpf:"kmesh_cluster_stats"`
 	KmeshConfigMap      *ebpf.MapSpec `ebpf:"kmesh_config_map"`
@@ -112,11 +111,14 @@ type KmeshCgroupSockMapSpecs struct {
 	KmeshRatelimit      *ebpf.MapSpec `ebpf:"kmesh_ratelimit"`
 	KmeshTailCallCtx    *ebpf.MapSpec `ebpf:"kmesh_tail_call_ctx"`
 	KmeshTailCallProg   *ebpf.MapSpec `ebpf:"kmesh_tail_call_prog"`
+	Map1600             *ebpf.MapSpec `ebpf:"map1600"`
+	Map192              *ebpf.MapSpec `ebpf:"map192"`
+	Map296              *ebpf.MapSpec `ebpf:"map296"`
+	Map64               *ebpf.MapSpec `ebpf:"map64"`
 	MapOfClusterEps     *ebpf.MapSpec `ebpf:"map_of_cluster_eps"`
 	MapOfClusterEpsData *ebpf.MapSpec `ebpf:"map_of_cluster_eps_data"`
 	MapOfClusterSock    *ebpf.MapSpec `ebpf:"map_of_cluster_sock"`
 	MapOfSockStorage    *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
-	OuterMap            *ebpf.MapSpec `ebpf:"outer_map"`
 	OuterOfMaglev       *ebpf.MapSpec `ebpf:"outer_of_maglev"`
 	TmpBuf              *ebpf.MapSpec `ebpf:"tmp_buf"`
 	TmpLogBuf           *ebpf.MapSpec `ebpf:"tmp_log_buf"`
@@ -141,7 +143,6 @@ func (o *KmeshCgroupSockObjects) Close() error {
 //
 // It can be passed to LoadKmeshCgroupSockObjects or ebpf.CollectionSpec.LoadAndAssign.
 type KmeshCgroupSockMaps struct {
-	InnerMap            *ebpf.Map `ebpf:"inner_map"`
 	KmeshCluster        *ebpf.Map `ebpf:"kmesh_cluster"`
 	KmeshClusterStats   *ebpf.Map `ebpf:"kmesh_cluster_stats"`
 	KmeshConfigMap      *ebpf.Map `ebpf:"kmesh_config_map"`
@@ -151,11 +152,14 @@ type KmeshCgroupSockMaps struct {
 	KmeshRatelimit      *ebpf.Map `ebpf:"kmesh_ratelimit"`
 	KmeshTailCallCtx    *ebpf.Map `ebpf:"kmesh_tail_call_ctx"`
 	KmeshTailCallProg   *ebpf.Map `ebpf:"kmesh_tail_call_prog"`
+	Map1600             *ebpf.Map `ebpf:"map1600"`
+	Map192              *ebpf.Map `ebpf:"map192"`
+	Map296              *ebpf.Map `ebpf:"map296"`
+	Map64               *ebpf.Map `ebpf:"map64"`
 	MapOfClusterEps     *ebpf.Map `ebpf:"map_of_cluster_eps"`
 	MapOfClusterEpsData *ebpf.Map `ebpf:"map_of_cluster_eps_data"`
 	MapOfClusterSock    *ebpf.Map `ebpf:"map_of_cluster_sock"`
 	MapOfSockStorage    *ebpf.Map `ebpf:"map_of_sock_storage"`
-	OuterMap            *ebpf.Map `ebpf:"outer_map"`
 	OuterOfMaglev       *ebpf.Map `ebpf:"outer_of_maglev"`
 	TmpBuf              *ebpf.Map `ebpf:"tmp_buf"`
 	TmpLogBuf           *ebpf.Map `ebpf:"tmp_log_buf"`
@@ -163,7 +167,6 @@ type KmeshCgroupSockMaps struct {
 
 func (m *KmeshCgroupSockMaps) Close() error {
 	return _KmeshCgroupSockClose(
-		m.InnerMap,
 		m.KmeshCluster,
 		m.KmeshClusterStats,
 		m.KmeshConfigMap,
@@ -173,11 +176,14 @@ func (m *KmeshCgroupSockMaps) Close() error {
 		m.KmeshRatelimit,
 		m.KmeshTailCallCtx,
 		m.KmeshTailCallProg,
+		m.Map1600,
+		m.Map192,
+		m.Map296,
+		m.Map64,
 		m.MapOfClusterEps,
 		m.MapOfClusterEpsData,
 		m.MapOfClusterSock,
 		m.MapOfSockStorage,
-		m.OuterMap,
 		m.OuterOfMaglev,
 		m.TmpBuf,
 		m.TmpLogBuf,

--- a/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsock_bpfel.go
+++ b/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsock_bpfel.go
@@ -108,13 +108,13 @@ type KmeshCgroupSockMapSpecs struct {
 	KmeshEvents         *ebpf.MapSpec `ebpf:"kmesh_events"`
 	KmeshListener       *ebpf.MapSpec `ebpf:"kmesh_listener"`
 	KmeshManage         *ebpf.MapSpec `ebpf:"kmesh_manage"`
+	KmeshMap1600        *ebpf.MapSpec `ebpf:"kmesh_map1600"`
+	KmeshMap192         *ebpf.MapSpec `ebpf:"kmesh_map192"`
+	KmeshMap296         *ebpf.MapSpec `ebpf:"kmesh_map296"`
+	KmeshMap64          *ebpf.MapSpec `ebpf:"kmesh_map64"`
 	KmeshRatelimit      *ebpf.MapSpec `ebpf:"kmesh_ratelimit"`
 	KmeshTailCallCtx    *ebpf.MapSpec `ebpf:"kmesh_tail_call_ctx"`
 	KmeshTailCallProg   *ebpf.MapSpec `ebpf:"kmesh_tail_call_prog"`
-	Map1600             *ebpf.MapSpec `ebpf:"map1600"`
-	Map192              *ebpf.MapSpec `ebpf:"map192"`
-	Map296              *ebpf.MapSpec `ebpf:"map296"`
-	Map64               *ebpf.MapSpec `ebpf:"map64"`
 	MapOfClusterEps     *ebpf.MapSpec `ebpf:"map_of_cluster_eps"`
 	MapOfClusterEpsData *ebpf.MapSpec `ebpf:"map_of_cluster_eps_data"`
 	MapOfClusterSock    *ebpf.MapSpec `ebpf:"map_of_cluster_sock"`
@@ -149,13 +149,13 @@ type KmeshCgroupSockMaps struct {
 	KmeshEvents         *ebpf.Map `ebpf:"kmesh_events"`
 	KmeshListener       *ebpf.Map `ebpf:"kmesh_listener"`
 	KmeshManage         *ebpf.Map `ebpf:"kmesh_manage"`
+	KmeshMap1600        *ebpf.Map `ebpf:"kmesh_map1600"`
+	KmeshMap192         *ebpf.Map `ebpf:"kmesh_map192"`
+	KmeshMap296         *ebpf.Map `ebpf:"kmesh_map296"`
+	KmeshMap64          *ebpf.Map `ebpf:"kmesh_map64"`
 	KmeshRatelimit      *ebpf.Map `ebpf:"kmesh_ratelimit"`
 	KmeshTailCallCtx    *ebpf.Map `ebpf:"kmesh_tail_call_ctx"`
 	KmeshTailCallProg   *ebpf.Map `ebpf:"kmesh_tail_call_prog"`
-	Map1600             *ebpf.Map `ebpf:"map1600"`
-	Map192              *ebpf.Map `ebpf:"map192"`
-	Map296              *ebpf.Map `ebpf:"map296"`
-	Map64               *ebpf.Map `ebpf:"map64"`
 	MapOfClusterEps     *ebpf.Map `ebpf:"map_of_cluster_eps"`
 	MapOfClusterEpsData *ebpf.Map `ebpf:"map_of_cluster_eps_data"`
 	MapOfClusterSock    *ebpf.Map `ebpf:"map_of_cluster_sock"`
@@ -173,13 +173,13 @@ func (m *KmeshCgroupSockMaps) Close() error {
 		m.KmeshEvents,
 		m.KmeshListener,
 		m.KmeshManage,
+		m.KmeshMap1600,
+		m.KmeshMap192,
+		m.KmeshMap296,
+		m.KmeshMap64,
 		m.KmeshRatelimit,
 		m.KmeshTailCallCtx,
 		m.KmeshTailCallProg,
-		m.Map1600,
-		m.Map192,
-		m.Map296,
-		m.Map64,
 		m.MapOfClusterEps,
 		m.MapOfClusterEpsData,
 		m.MapOfClusterSock,

--- a/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsockcompat_bpfeb.go
+++ b/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsockcompat_bpfeb.go
@@ -108,13 +108,13 @@ type KmeshCgroupSockCompatMapSpecs struct {
 	KmeshEvents         *ebpf.MapSpec `ebpf:"kmesh_events"`
 	KmeshListener       *ebpf.MapSpec `ebpf:"kmesh_listener"`
 	KmeshManage         *ebpf.MapSpec `ebpf:"kmesh_manage"`
+	KmeshMap1600        *ebpf.MapSpec `ebpf:"kmesh_map1600"`
+	KmeshMap192         *ebpf.MapSpec `ebpf:"kmesh_map192"`
+	KmeshMap296         *ebpf.MapSpec `ebpf:"kmesh_map296"`
+	KmeshMap64          *ebpf.MapSpec `ebpf:"kmesh_map64"`
 	KmeshRatelimit      *ebpf.MapSpec `ebpf:"kmesh_ratelimit"`
 	KmeshTailCallCtx    *ebpf.MapSpec `ebpf:"kmesh_tail_call_ctx"`
 	KmeshTailCallProg   *ebpf.MapSpec `ebpf:"kmesh_tail_call_prog"`
-	Map1600             *ebpf.MapSpec `ebpf:"map1600"`
-	Map192              *ebpf.MapSpec `ebpf:"map192"`
-	Map296              *ebpf.MapSpec `ebpf:"map296"`
-	Map64               *ebpf.MapSpec `ebpf:"map64"`
 	MapOfClusterEps     *ebpf.MapSpec `ebpf:"map_of_cluster_eps"`
 	MapOfClusterEpsData *ebpf.MapSpec `ebpf:"map_of_cluster_eps_data"`
 	MapOfClusterSock    *ebpf.MapSpec `ebpf:"map_of_cluster_sock"`
@@ -149,13 +149,13 @@ type KmeshCgroupSockCompatMaps struct {
 	KmeshEvents         *ebpf.Map `ebpf:"kmesh_events"`
 	KmeshListener       *ebpf.Map `ebpf:"kmesh_listener"`
 	KmeshManage         *ebpf.Map `ebpf:"kmesh_manage"`
+	KmeshMap1600        *ebpf.Map `ebpf:"kmesh_map1600"`
+	KmeshMap192         *ebpf.Map `ebpf:"kmesh_map192"`
+	KmeshMap296         *ebpf.Map `ebpf:"kmesh_map296"`
+	KmeshMap64          *ebpf.Map `ebpf:"kmesh_map64"`
 	KmeshRatelimit      *ebpf.Map `ebpf:"kmesh_ratelimit"`
 	KmeshTailCallCtx    *ebpf.Map `ebpf:"kmesh_tail_call_ctx"`
 	KmeshTailCallProg   *ebpf.Map `ebpf:"kmesh_tail_call_prog"`
-	Map1600             *ebpf.Map `ebpf:"map1600"`
-	Map192              *ebpf.Map `ebpf:"map192"`
-	Map296              *ebpf.Map `ebpf:"map296"`
-	Map64               *ebpf.Map `ebpf:"map64"`
 	MapOfClusterEps     *ebpf.Map `ebpf:"map_of_cluster_eps"`
 	MapOfClusterEpsData *ebpf.Map `ebpf:"map_of_cluster_eps_data"`
 	MapOfClusterSock    *ebpf.Map `ebpf:"map_of_cluster_sock"`
@@ -173,13 +173,13 @@ func (m *KmeshCgroupSockCompatMaps) Close() error {
 		m.KmeshEvents,
 		m.KmeshListener,
 		m.KmeshManage,
+		m.KmeshMap1600,
+		m.KmeshMap192,
+		m.KmeshMap296,
+		m.KmeshMap64,
 		m.KmeshRatelimit,
 		m.KmeshTailCallCtx,
 		m.KmeshTailCallProg,
-		m.Map1600,
-		m.Map192,
-		m.Map296,
-		m.Map64,
 		m.MapOfClusterEps,
 		m.MapOfClusterEpsData,
 		m.MapOfClusterSock,

--- a/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsockcompat_bpfeb.go
+++ b/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsockcompat_bpfeb.go
@@ -102,7 +102,6 @@ type KmeshCgroupSockCompatProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type KmeshCgroupSockCompatMapSpecs struct {
-	InnerMap            *ebpf.MapSpec `ebpf:"inner_map"`
 	KmeshCluster        *ebpf.MapSpec `ebpf:"kmesh_cluster"`
 	KmeshClusterStats   *ebpf.MapSpec `ebpf:"kmesh_cluster_stats"`
 	KmeshConfigMap      *ebpf.MapSpec `ebpf:"kmesh_config_map"`
@@ -112,11 +111,14 @@ type KmeshCgroupSockCompatMapSpecs struct {
 	KmeshRatelimit      *ebpf.MapSpec `ebpf:"kmesh_ratelimit"`
 	KmeshTailCallCtx    *ebpf.MapSpec `ebpf:"kmesh_tail_call_ctx"`
 	KmeshTailCallProg   *ebpf.MapSpec `ebpf:"kmesh_tail_call_prog"`
+	Map1600             *ebpf.MapSpec `ebpf:"map1600"`
+	Map192              *ebpf.MapSpec `ebpf:"map192"`
+	Map296              *ebpf.MapSpec `ebpf:"map296"`
+	Map64               *ebpf.MapSpec `ebpf:"map64"`
 	MapOfClusterEps     *ebpf.MapSpec `ebpf:"map_of_cluster_eps"`
 	MapOfClusterEpsData *ebpf.MapSpec `ebpf:"map_of_cluster_eps_data"`
 	MapOfClusterSock    *ebpf.MapSpec `ebpf:"map_of_cluster_sock"`
 	MapOfSockStorage    *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
-	OuterMap            *ebpf.MapSpec `ebpf:"outer_map"`
 	OuterOfMaglev       *ebpf.MapSpec `ebpf:"outer_of_maglev"`
 	TmpBuf              *ebpf.MapSpec `ebpf:"tmp_buf"`
 	TmpLogBuf           *ebpf.MapSpec `ebpf:"tmp_log_buf"`
@@ -141,7 +143,6 @@ func (o *KmeshCgroupSockCompatObjects) Close() error {
 //
 // It can be passed to LoadKmeshCgroupSockCompatObjects or ebpf.CollectionSpec.LoadAndAssign.
 type KmeshCgroupSockCompatMaps struct {
-	InnerMap            *ebpf.Map `ebpf:"inner_map"`
 	KmeshCluster        *ebpf.Map `ebpf:"kmesh_cluster"`
 	KmeshClusterStats   *ebpf.Map `ebpf:"kmesh_cluster_stats"`
 	KmeshConfigMap      *ebpf.Map `ebpf:"kmesh_config_map"`
@@ -151,11 +152,14 @@ type KmeshCgroupSockCompatMaps struct {
 	KmeshRatelimit      *ebpf.Map `ebpf:"kmesh_ratelimit"`
 	KmeshTailCallCtx    *ebpf.Map `ebpf:"kmesh_tail_call_ctx"`
 	KmeshTailCallProg   *ebpf.Map `ebpf:"kmesh_tail_call_prog"`
+	Map1600             *ebpf.Map `ebpf:"map1600"`
+	Map192              *ebpf.Map `ebpf:"map192"`
+	Map296              *ebpf.Map `ebpf:"map296"`
+	Map64               *ebpf.Map `ebpf:"map64"`
 	MapOfClusterEps     *ebpf.Map `ebpf:"map_of_cluster_eps"`
 	MapOfClusterEpsData *ebpf.Map `ebpf:"map_of_cluster_eps_data"`
 	MapOfClusterSock    *ebpf.Map `ebpf:"map_of_cluster_sock"`
 	MapOfSockStorage    *ebpf.Map `ebpf:"map_of_sock_storage"`
-	OuterMap            *ebpf.Map `ebpf:"outer_map"`
 	OuterOfMaglev       *ebpf.Map `ebpf:"outer_of_maglev"`
 	TmpBuf              *ebpf.Map `ebpf:"tmp_buf"`
 	TmpLogBuf           *ebpf.Map `ebpf:"tmp_log_buf"`
@@ -163,7 +167,6 @@ type KmeshCgroupSockCompatMaps struct {
 
 func (m *KmeshCgroupSockCompatMaps) Close() error {
 	return _KmeshCgroupSockCompatClose(
-		m.InnerMap,
 		m.KmeshCluster,
 		m.KmeshClusterStats,
 		m.KmeshConfigMap,
@@ -173,11 +176,14 @@ func (m *KmeshCgroupSockCompatMaps) Close() error {
 		m.KmeshRatelimit,
 		m.KmeshTailCallCtx,
 		m.KmeshTailCallProg,
+		m.Map1600,
+		m.Map192,
+		m.Map296,
+		m.Map64,
 		m.MapOfClusterEps,
 		m.MapOfClusterEpsData,
 		m.MapOfClusterSock,
 		m.MapOfSockStorage,
-		m.OuterMap,
 		m.OuterOfMaglev,
 		m.TmpBuf,
 		m.TmpLogBuf,

--- a/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsockcompat_bpfel.go
+++ b/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsockcompat_bpfel.go
@@ -108,13 +108,13 @@ type KmeshCgroupSockCompatMapSpecs struct {
 	KmeshEvents         *ebpf.MapSpec `ebpf:"kmesh_events"`
 	KmeshListener       *ebpf.MapSpec `ebpf:"kmesh_listener"`
 	KmeshManage         *ebpf.MapSpec `ebpf:"kmesh_manage"`
+	KmeshMap1600        *ebpf.MapSpec `ebpf:"kmesh_map1600"`
+	KmeshMap192         *ebpf.MapSpec `ebpf:"kmesh_map192"`
+	KmeshMap296         *ebpf.MapSpec `ebpf:"kmesh_map296"`
+	KmeshMap64          *ebpf.MapSpec `ebpf:"kmesh_map64"`
 	KmeshRatelimit      *ebpf.MapSpec `ebpf:"kmesh_ratelimit"`
 	KmeshTailCallCtx    *ebpf.MapSpec `ebpf:"kmesh_tail_call_ctx"`
 	KmeshTailCallProg   *ebpf.MapSpec `ebpf:"kmesh_tail_call_prog"`
-	Map1600             *ebpf.MapSpec `ebpf:"map1600"`
-	Map192              *ebpf.MapSpec `ebpf:"map192"`
-	Map296              *ebpf.MapSpec `ebpf:"map296"`
-	Map64               *ebpf.MapSpec `ebpf:"map64"`
 	MapOfClusterEps     *ebpf.MapSpec `ebpf:"map_of_cluster_eps"`
 	MapOfClusterEpsData *ebpf.MapSpec `ebpf:"map_of_cluster_eps_data"`
 	MapOfClusterSock    *ebpf.MapSpec `ebpf:"map_of_cluster_sock"`
@@ -149,13 +149,13 @@ type KmeshCgroupSockCompatMaps struct {
 	KmeshEvents         *ebpf.Map `ebpf:"kmesh_events"`
 	KmeshListener       *ebpf.Map `ebpf:"kmesh_listener"`
 	KmeshManage         *ebpf.Map `ebpf:"kmesh_manage"`
+	KmeshMap1600        *ebpf.Map `ebpf:"kmesh_map1600"`
+	KmeshMap192         *ebpf.Map `ebpf:"kmesh_map192"`
+	KmeshMap296         *ebpf.Map `ebpf:"kmesh_map296"`
+	KmeshMap64          *ebpf.Map `ebpf:"kmesh_map64"`
 	KmeshRatelimit      *ebpf.Map `ebpf:"kmesh_ratelimit"`
 	KmeshTailCallCtx    *ebpf.Map `ebpf:"kmesh_tail_call_ctx"`
 	KmeshTailCallProg   *ebpf.Map `ebpf:"kmesh_tail_call_prog"`
-	Map1600             *ebpf.Map `ebpf:"map1600"`
-	Map192              *ebpf.Map `ebpf:"map192"`
-	Map296              *ebpf.Map `ebpf:"map296"`
-	Map64               *ebpf.Map `ebpf:"map64"`
 	MapOfClusterEps     *ebpf.Map `ebpf:"map_of_cluster_eps"`
 	MapOfClusterEpsData *ebpf.Map `ebpf:"map_of_cluster_eps_data"`
 	MapOfClusterSock    *ebpf.Map `ebpf:"map_of_cluster_sock"`
@@ -173,13 +173,13 @@ func (m *KmeshCgroupSockCompatMaps) Close() error {
 		m.KmeshEvents,
 		m.KmeshListener,
 		m.KmeshManage,
+		m.KmeshMap1600,
+		m.KmeshMap192,
+		m.KmeshMap296,
+		m.KmeshMap64,
 		m.KmeshRatelimit,
 		m.KmeshTailCallCtx,
 		m.KmeshTailCallProg,
-		m.Map1600,
-		m.Map192,
-		m.Map296,
-		m.Map64,
 		m.MapOfClusterEps,
 		m.MapOfClusterEpsData,
 		m.MapOfClusterSock,

--- a/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsockcompat_bpfel.go
+++ b/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsockcompat_bpfel.go
@@ -102,7 +102,6 @@ type KmeshCgroupSockCompatProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type KmeshCgroupSockCompatMapSpecs struct {
-	InnerMap            *ebpf.MapSpec `ebpf:"inner_map"`
 	KmeshCluster        *ebpf.MapSpec `ebpf:"kmesh_cluster"`
 	KmeshClusterStats   *ebpf.MapSpec `ebpf:"kmesh_cluster_stats"`
 	KmeshConfigMap      *ebpf.MapSpec `ebpf:"kmesh_config_map"`
@@ -112,11 +111,14 @@ type KmeshCgroupSockCompatMapSpecs struct {
 	KmeshRatelimit      *ebpf.MapSpec `ebpf:"kmesh_ratelimit"`
 	KmeshTailCallCtx    *ebpf.MapSpec `ebpf:"kmesh_tail_call_ctx"`
 	KmeshTailCallProg   *ebpf.MapSpec `ebpf:"kmesh_tail_call_prog"`
+	Map1600             *ebpf.MapSpec `ebpf:"map1600"`
+	Map192              *ebpf.MapSpec `ebpf:"map192"`
+	Map296              *ebpf.MapSpec `ebpf:"map296"`
+	Map64               *ebpf.MapSpec `ebpf:"map64"`
 	MapOfClusterEps     *ebpf.MapSpec `ebpf:"map_of_cluster_eps"`
 	MapOfClusterEpsData *ebpf.MapSpec `ebpf:"map_of_cluster_eps_data"`
 	MapOfClusterSock    *ebpf.MapSpec `ebpf:"map_of_cluster_sock"`
 	MapOfSockStorage    *ebpf.MapSpec `ebpf:"map_of_sock_storage"`
-	OuterMap            *ebpf.MapSpec `ebpf:"outer_map"`
 	OuterOfMaglev       *ebpf.MapSpec `ebpf:"outer_of_maglev"`
 	TmpBuf              *ebpf.MapSpec `ebpf:"tmp_buf"`
 	TmpLogBuf           *ebpf.MapSpec `ebpf:"tmp_log_buf"`
@@ -141,7 +143,6 @@ func (o *KmeshCgroupSockCompatObjects) Close() error {
 //
 // It can be passed to LoadKmeshCgroupSockCompatObjects or ebpf.CollectionSpec.LoadAndAssign.
 type KmeshCgroupSockCompatMaps struct {
-	InnerMap            *ebpf.Map `ebpf:"inner_map"`
 	KmeshCluster        *ebpf.Map `ebpf:"kmesh_cluster"`
 	KmeshClusterStats   *ebpf.Map `ebpf:"kmesh_cluster_stats"`
 	KmeshConfigMap      *ebpf.Map `ebpf:"kmesh_config_map"`
@@ -151,11 +152,14 @@ type KmeshCgroupSockCompatMaps struct {
 	KmeshRatelimit      *ebpf.Map `ebpf:"kmesh_ratelimit"`
 	KmeshTailCallCtx    *ebpf.Map `ebpf:"kmesh_tail_call_ctx"`
 	KmeshTailCallProg   *ebpf.Map `ebpf:"kmesh_tail_call_prog"`
+	Map1600             *ebpf.Map `ebpf:"map1600"`
+	Map192              *ebpf.Map `ebpf:"map192"`
+	Map296              *ebpf.Map `ebpf:"map296"`
+	Map64               *ebpf.Map `ebpf:"map64"`
 	MapOfClusterEps     *ebpf.Map `ebpf:"map_of_cluster_eps"`
 	MapOfClusterEpsData *ebpf.Map `ebpf:"map_of_cluster_eps_data"`
 	MapOfClusterSock    *ebpf.Map `ebpf:"map_of_cluster_sock"`
 	MapOfSockStorage    *ebpf.Map `ebpf:"map_of_sock_storage"`
-	OuterMap            *ebpf.Map `ebpf:"outer_map"`
 	OuterOfMaglev       *ebpf.Map `ebpf:"outer_of_maglev"`
 	TmpBuf              *ebpf.Map `ebpf:"tmp_buf"`
 	TmpLogBuf           *ebpf.Map `ebpf:"tmp_log_buf"`
@@ -163,7 +167,6 @@ type KmeshCgroupSockCompatMaps struct {
 
 func (m *KmeshCgroupSockCompatMaps) Close() error {
 	return _KmeshCgroupSockCompatClose(
-		m.InnerMap,
 		m.KmeshCluster,
 		m.KmeshClusterStats,
 		m.KmeshConfigMap,
@@ -173,11 +176,14 @@ func (m *KmeshCgroupSockCompatMaps) Close() error {
 		m.KmeshRatelimit,
 		m.KmeshTailCallCtx,
 		m.KmeshTailCallProg,
+		m.Map1600,
+		m.Map192,
+		m.Map296,
+		m.Map64,
 		m.MapOfClusterEps,
 		m.MapOfClusterEpsData,
 		m.MapOfClusterSock,
 		m.MapOfSockStorage,
-		m.OuterMap,
 		m.OuterOfMaglev,
 		m.TmpBuf,
 		m.TmpLogBuf,

--- a/pkg/bpf/ads/loader.go
+++ b/pkg/bpf/ads/loader.go
@@ -106,19 +106,19 @@ func (sc *BpfAds) ApiEnvCfg() error {
 		return err
 	}
 
-	if err = utils.SetEnvByBpfMapId(sc.SockConn.Map64, "Map64"); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockConn.KmeshMap64, "KmeshMap64"); err != nil {
 		return err
 	}
 
-	if err = utils.SetEnvByBpfMapId(sc.SockConn.Map192, "Map192"); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockConn.KmeshMap192, "KmeshMap192"); err != nil {
 		return err
 	}
 
-	if err = utils.SetEnvByBpfMapId(sc.SockConn.Map296, "Map296"); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockConn.KmeshMap296, "KmeshMap296"); err != nil {
 		return err
 	}
 
-	if err = utils.SetEnvByBpfMapId(sc.SockConn.Map1600, "Map1600"); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockConn.KmeshMap1600, "KmeshMap1600"); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/bpf/ads/loader.go
+++ b/pkg/bpf/ads/loader.go
@@ -25,13 +25,11 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/cilium/ebpf"
 
 	"kmesh.net/kmesh/daemon/options"
-	"kmesh.net/kmesh/pkg/bpf/restart"
+	"kmesh.net/kmesh/pkg/bpf/utils"
 	"kmesh.net/kmesh/pkg/consistenthash/maglev"
 	"kmesh.net/kmesh/pkg/logger"
 )
@@ -68,7 +66,7 @@ func (sc *BpfAds) Start() error {
 		return fmt.Errorf("api env config failed, %s", err)
 	}
 
-	ret := C.deserial_init(restart.GetStartType() == restart.Restart)
+	ret := C.deserial_init()
 	if ret != 0 {
 		return fmt.Errorf("deserial_init failed:%v", ret)
 	}
@@ -85,7 +83,7 @@ func (sc *BpfAds) GetKmeshConfigMap() *ebpf.Map {
 }
 
 func (sc *BpfAds) Stop() error {
-	C.deserial_uninit(false)
+	C.deserial_uninit()
 	return sc.Detach()
 }
 
@@ -98,35 +96,29 @@ func (sc *BpfAds) Load() error {
 }
 
 func (sc *BpfAds) ApiEnvCfg() error {
-	info, err := sc.SockConn.KmeshCgroupSockMaps.KmeshListener.Info()
-	if err != nil {
+	var err error
+
+	if err = utils.SetEnvByBpfMapId(sc.SockConn.KmeshCgroupSockMaps.KmeshListener, "Listener"); err != nil {
 		return err
 	}
 
-	id, _ := info.ID()
-	stringId := strconv.Itoa(int(id))
-	if err = os.Setenv("Listener", stringId); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockConn.KmeshCluster, "Cluster"); err != nil {
 		return err
 	}
 
-	info, _ = sc.SockConn.KmeshCgroupSockMaps.OuterMap.Info()
-	id, _ = info.ID()
-	stringId = strconv.Itoa(int(id))
-	if err = os.Setenv("OUTTER_MAP_ID", stringId); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockConn.Map64, "Map64"); err != nil {
 		return err
 	}
 
-	info, _ = sc.SockConn.KmeshCgroupSockMaps.InnerMap.Info()
-	id, _ = info.ID()
-	stringId = strconv.Itoa(int(id))
-	if err = os.Setenv("INNER_MAP_ID", stringId); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockConn.Map192, "Map192"); err != nil {
 		return err
 	}
 
-	info, _ = sc.SockConn.KmeshCluster.Info()
-	id, _ = info.ID()
-	stringId = strconv.Itoa(int(id))
-	if err = os.Setenv("Cluster", stringId); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockConn.Map296, "Map296"); err != nil {
+		return err
+	}
+
+	if err = utils.SetEnvByBpfMapId(sc.SockConn.Map1600, "Map1600"); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/bpf/ads/loader_enhanced.go
+++ b/pkg/bpf/ads/loader_enhanced.go
@@ -25,13 +25,11 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/cilium/ebpf"
 
 	"kmesh.net/kmesh/daemon/options"
-	"kmesh.net/kmesh/pkg/bpf/restart"
+	"kmesh.net/kmesh/pkg/bpf/utils"
 	"kmesh.net/kmesh/pkg/logger"
 )
 
@@ -75,7 +73,7 @@ func (sc *BpfAds) Start() error {
 		return fmt.Errorf("failed to set api env")
 	}
 
-	ret := C.deserial_init(restart.GetStartType() == restart.Restart)
+	ret := C.deserial_init()
 	if ret != 0 {
 		return fmt.Errorf("deserial_init failed:%v", ret)
 	}
@@ -83,7 +81,7 @@ func (sc *BpfAds) Start() error {
 }
 
 func (sc *BpfAds) Stop() error {
-	C.deserial_uninit(false)
+	C.deserial_uninit()
 	if err := sc.Detach(); err != nil {
 		log.Errorf("failed detach when stop kmesh, err: %v", err)
 		return err
@@ -112,46 +110,35 @@ func (sc *BpfAds) Load() error {
 }
 
 func (sc *BpfAds) ApiEnvCfg() error {
-	var id ebpf.MapID
-	info, err := sc.SockOps.KmeshSockopsMaps.KmeshListener.Info()
-	if err != nil {
+	var err error
+
+	if err = utils.SetEnvByBpfMapId(sc.SockOps.KmeshSockopsMaps.KmeshListener, "Listener"); err != nil {
 		return err
 	}
 
-	id, _ = info.ID()
-	stringId := strconv.Itoa(int(id))
-	if err := os.Setenv("Listener", stringId); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockOps.MapOfRouterConfig, "RouteConfiguration"); err != nil {
 		return err
 	}
 
-	info, _ = sc.SockOps.KmeshSockopsMaps.OuterMap.Info()
-	id, _ = info.ID()
-	stringId = strconv.Itoa(int(id))
-	if err := os.Setenv("OUTTER_MAP_ID", stringId); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockOps.KmeshCluster, "Cluster"); err != nil {
 		return err
 	}
 
-	info, _ = sc.SockOps.KmeshSockopsMaps.InnerMap.Info()
-	id, _ = info.ID()
-	stringId = strconv.Itoa(int(id))
-	if err := os.Setenv("INNER_MAP_ID", stringId); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockOps.Map64, "Map64"); err != nil {
 		return err
 	}
 
-	info, _ = sc.SockOps.MapOfRouterConfig.Info()
-	id, _ = info.ID()
-	stringId = strconv.Itoa(int(id))
-	if err := os.Setenv("RouteConfiguration", stringId); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockOps.Map192, "Map192"); err != nil {
 		return err
 	}
 
-	info, _ = sc.SockOps.KmeshCluster.Info()
-	id, _ = info.ID()
-	stringId = strconv.Itoa(int(id))
-	if err := os.Setenv("Cluster", stringId); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockOps.Map296, "Map296"); err != nil {
 		return err
 	}
 
+	if err = utils.SetEnvByBpfMapId(sc.SockOps.Map1600, "Map1600"); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/bpf/ads/loader_enhanced.go
+++ b/pkg/bpf/ads/loader_enhanced.go
@@ -124,19 +124,19 @@ func (sc *BpfAds) ApiEnvCfg() error {
 		return err
 	}
 
-	if err = utils.SetEnvByBpfMapId(sc.SockOps.Map64, "Map64"); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockOps.KmeshMap64, "KmeshMap64"); err != nil {
 		return err
 	}
 
-	if err = utils.SetEnvByBpfMapId(sc.SockOps.Map192, "Map192"); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockOps.KmeshMap192, "KmeshMap192"); err != nil {
 		return err
 	}
 
-	if err = utils.SetEnvByBpfMapId(sc.SockOps.Map296, "Map296"); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockOps.KmeshMap296, "KmeshMap296"); err != nil {
 		return err
 	}
 
-	if err = utils.SetEnvByBpfMapId(sc.SockOps.Map1600, "Map1600"); err != nil {
+	if err = utils.SetEnvByBpfMapId(sc.SockOps.KmeshMap1600, "KmeshMap1600"); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/bpf/ads/sock_connection.go
+++ b/pkg/bpf/ads/sock_connection.go
@@ -40,7 +40,6 @@ var KMESH_TAIL_CALL_FILTER = uint32(C.KMESH_TAIL_CALL_FILTER)
 var KMESH_TAIL_CALL_ROUTER = uint32(C.KMESH_TAIL_CALL_ROUTER)
 var KMESH_TAIL_CALL_CLUSTER = uint32(C.KMESH_TAIL_CALL_CLUSTER)
 var KMESH_TAIL_CALL_ROUTER_CONFIG = uint32(C.KMESH_TAIL_CALL_ROUTER_CONFIG)
-var BPF_INNER_MAP_DATA_LEN = uint32(C.BPF_INNER_MAP_DATA_LEN)
 
 type BpfInfo struct {
 	MapPath     string
@@ -94,7 +93,6 @@ func (sc *BpfSockConn) loadKmeshSockConnObjects() (*ebpf.CollectionSpec, error) 
 		return nil, err
 	}
 
-	utils.SetInnerMap(spec)
 	utils.SetMapPinType(spec, ebpf.PinByName)
 	if err = spec.LoadAndAssign(&sc.KmeshCgroupSockObjects, &opts); err != nil {
 		return nil, err

--- a/pkg/bpf/ads/sock_ops.go
+++ b/pkg/bpf/ads/sock_ops.go
@@ -76,7 +76,6 @@ func (sc *BpfSockOps) loadKmeshSockopsObjects() (*ebpf.CollectionSpec, error) {
 		return nil, err
 	}
 
-	utils.SetInnerMap(spec)
 	utils.SetMapPinType(spec, ebpf.PinByName)
 	if err = spec.LoadAndAssign(&sc.KmeshSockopsObjects, &opts); err != nil {
 		return nil, err

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -140,7 +140,7 @@ func StopMda() error {
 func (l *BpfLoader) Stop() {
 	var err error
 	if restart.GetExitType() == restart.Restart && l.config.DualEngineEnabled() {
-		C.deserial_uninit(true)
+		C.deserial_uninit()
 		log.Infof("kmesh restart, not clean bpf map and prog")
 		return
 	}

--- a/pkg/bpf/utils/bpf_helper.go
+++ b/pkg/bpf/utils/bpf_helper.go
@@ -16,22 +16,16 @@
 
 package utils
 
-import "github.com/cilium/ebpf"
+import (
+	"os"
+	"strconv"
 
-func SetInnerMap(spec *ebpf.CollectionSpec) {
-	var (
-		InnerMapKeySize    uint32 = 4
-		InnerMapDataLength uint32 = 1300 // C.BPF_INNER_MAP_DATA_LEN
-		InnerMapMaxEntries uint32 = 1
-	)
-	for _, v := range spec.Maps {
-		if v.Name == "outer_map" {
-			v.InnerMap = &ebpf.MapSpec{
-				Type:       ebpf.Array,
-				KeySize:    InnerMapKeySize,
-				ValueSize:  InnerMapDataLength,
-				MaxEntries: InnerMapMaxEntries,
-			}
-		}
-	}
+	"github.com/cilium/ebpf"
+)
+
+func SetEnvByBpfMapId(m *ebpf.Map, key string) error {
+	info, _ := m.Info()
+	id, _ := info.ID()
+	stringId := strconv.Itoa(int(id))
+	return os.Setenv(key, stringId)
 }

--- a/pkg/bpf/workload/loader.go
+++ b/pkg/bpf/workload/loader.go
@@ -167,19 +167,19 @@ func (w *BpfWorkload) ApiEnvCfg() error {
 		return err
 	}
 
-	if err = utils.SetEnvByBpfMapId(w.XdpAuth.Map64, "Map64"); err != nil {
+	if err = utils.SetEnvByBpfMapId(w.XdpAuth.KmeshMap64, "KmeshMap64"); err != nil {
 		return err
 	}
 
-	if err = utils.SetEnvByBpfMapId(w.XdpAuth.Map192, "Map192"); err != nil {
+	if err = utils.SetEnvByBpfMapId(w.XdpAuth.KmeshMap192, "KmeshMap192"); err != nil {
 		return err
 	}
 
-	if err = utils.SetEnvByBpfMapId(w.XdpAuth.Map296, "Map296"); err != nil {
+	if err = utils.SetEnvByBpfMapId(w.XdpAuth.KmeshMap296, "KmeshMap296"); err != nil {
 		return err
 	}
 
-	if err = utils.SetEnvByBpfMapId(w.XdpAuth.Map1600, "Map1600"); err != nil {
+	if err = utils.SetEnvByBpfMapId(w.XdpAuth.KmeshMap1600, "KmeshMap1600"); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/bpf/workload/loader.go
+++ b/pkg/bpf/workload/loader.go
@@ -22,13 +22,11 @@ import "C"
 import (
 	"errors"
 	"fmt"
-	"os"
-	"strconv"
 
 	"github.com/cilium/ebpf"
 
 	"kmesh.net/kmesh/daemon/options"
-	"kmesh.net/kmesh/pkg/bpf/restart"
+	"kmesh.net/kmesh/pkg/bpf/utils"
 	"kmesh.net/kmesh/pkg/logger"
 )
 
@@ -91,7 +89,7 @@ func (w *BpfWorkload) Start() error {
 		return fmt.Errorf("failed to set api env")
 	}
 
-	ret := C.deserial_init(restart.GetStartType() == restart.Restart)
+	ret := C.deserial_init()
 	if ret != 0 {
 		return fmt.Errorf("deserial_init failed:%v", ret)
 	}
@@ -99,7 +97,7 @@ func (w *BpfWorkload) Start() error {
 }
 
 func (w *BpfWorkload) Stop() error {
-	C.deserial_uninit(false)
+	C.deserial_uninit()
 	return w.Detach()
 }
 
@@ -163,28 +161,25 @@ func (w *BpfWorkload) Detach() error {
 }
 
 func (w *BpfWorkload) ApiEnvCfg() error {
-	info, err := w.XdpAuth.KmeshXDPAuthMaps.MapOfAuthz.Info()
-	if err != nil {
+	var err error
+
+	if err = utils.SetEnvByBpfMapId(w.XdpAuth.KmeshXDPAuthMaps.MapOfAuthz, "Authorization"); err != nil {
 		return err
 	}
 
-	id, _ := info.ID()
-	stringId := strconv.Itoa(int(id))
-	if err = os.Setenv("Authorization", stringId); err != nil {
+	if err = utils.SetEnvByBpfMapId(w.XdpAuth.Map64, "Map64"); err != nil {
 		return err
 	}
 
-	info, _ = w.XdpAuth.KmeshXDPAuthMaps.OuterMap.Info()
-	id, _ = info.ID()
-	stringId = strconv.Itoa(int(id))
-	if err = os.Setenv("OUTTER_MAP_ID", stringId); err != nil {
+	if err = utils.SetEnvByBpfMapId(w.XdpAuth.Map192, "Map192"); err != nil {
 		return err
 	}
 
-	info, _ = w.XdpAuth.KmeshXDPAuthMaps.InnerMap.Info()
-	id, _ = info.ID()
-	stringId = strconv.Itoa(int(id))
-	if err := os.Setenv("INNER_MAP_ID", stringId); err != nil {
+	if err = utils.SetEnvByBpfMapId(w.XdpAuth.Map296, "Map296"); err != nil {
+		return err
+	}
+
+	if err = utils.SetEnvByBpfMapId(w.XdpAuth.Map1600, "Map1600"); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/bpf/workload/sock_connection.go
+++ b/pkg/bpf/workload/sock_connection.go
@@ -78,7 +78,6 @@ func (sc *SockConnWorkload) loadKmeshSockConnObjects() (*ebpf.CollectionSpec, er
 		return nil, err
 	}
 
-	utils.SetInnerMap(spec)
 	utils.SetMapPinType(spec, ebpf.PinByName)
 	if err = spec.LoadAndAssign(&sc.KmeshCgroupSockWorkloadObjects, &opts); err != nil {
 		return nil, err

--- a/pkg/bpf/workload/sock_ops.go
+++ b/pkg/bpf/workload/sock_ops.go
@@ -80,7 +80,6 @@ func (so *BpfSockOpsWorkload) loadKmeshSockopsObjects() (*ebpf.CollectionSpec, e
 		return nil, fmt.Errorf("error: loadKmeshSockopsObjects() spec is nil")
 	}
 
-	utils.SetInnerMap(spec)
 	utils.SetMapPinType(spec, ebpf.PinByName)
 	if err = spec.LoadAndAssign(&so.KmeshSockopsWorkloadObjects, &opts); err != nil {
 		return nil, err

--- a/pkg/bpf/workload/xdp.go
+++ b/pkg/bpf/workload/xdp.go
@@ -78,7 +78,6 @@ func (xa *BpfXdpAuthWorkload) loadKmeshXdpAuthObjects() (*ebpf.CollectionSpec, e
 		return nil, fmt.Errorf("error: loadKmeshXdpAuthObjects() spec is nil")
 	}
 
-	utils.SetInnerMap(spec)
 	utils.SetMapPinType(spec, ebpf.PinByName)
 	if err = spec.LoadAndAssign(&xa.KmeshXDPAuthObjects, &opts); err != nil {
 		return nil, err


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
As discussed at the community meeting, the current xDS bpf map has the following problems:
1. Map-in-map update is slow. To support a large number of map records, a batch of map records need to be prepared in advance, causing memory waste and complex implementation logic.
2. The value length of inner-map is 1300, which is a waste in most scenarios.

Solution:
1. The map-in-map is no longer used to manage xDS data storage.
2. Define a group of bpf hash map (64/192/296/1600), select a proper bpf map for storing the xDS data based on the length, set the map flag to NO_PREMALLOC, and apply for the memory as required.
3. For data of the string type, the size cannot exceed MAP_VAL_STR_SIZE(192). For data of the repeat type, the size cannot exceed MAP_VAL_REPEAT_SIZE(1600). That is, for the repeat member of the xDS, the number of instances cannot exceed 200.

After the modification, the content of the xDS pointer is as follows:
ptr(outer_key):
Reserved(4 bytes) + map_type(1 byte) + inner_idx(3 bytes)

Known issues:
1. In extreme scenarios, the repeat member has a large number of instances (more than 200), and a bpf map cannot store all the instances. Therefore, multiple records need to be designed for storage.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
