### PR TITLE
Correct Workload handle order

### DIFF
--- a/pkg/controller/workload/bpfcache/endpoint.go
+++ b/pkg/controller/workload/bpfcache/endpoint.go
@@ -18,6 +18,7 @@ package bpfcache
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/cilium/ebpf"
 	"istio.io/istio/pkg/util/sets"
@@ -71,6 +72,9 @@ func (c *Cache) EndpointDelete(key *EndpointKey) error {
 
 // EndpointSwap update the last endpoint index and remove the current endpoint
 func (c *Cache) EndpointSwap(currentIndex, lastIndex uint32, serviceId uint32, prio uint32) error {
+	if currentIndex > lastIndex {
+		return fmt.Errorf("currentIndex %d > lastIndex %d", currentIndex, lastIndex)
+	}
 	if currentIndex == lastIndex {
 		return c.EndpointDelete(&EndpointKey{
 			ServiceId:    serviceId,

--- a/pkg/controller/workload/bpfcache/endpoint_test.go
+++ b/pkg/controller/workload/bpfcache/endpoint_test.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bpfcache
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEndpointSwap(t *testing.T) {
+	workloadMap := NewFakeWorkloadMap(t)
+	defer CleanupFakeWorkloadMap(workloadMap)
+
+	c := NewCache(workloadMap)
+	endpointsMap := map[*EndpointKey]*EndpointValue{
+		{ServiceId: 1, Prio: 1, BackendIndex: 1}: {BackendUid: 1},
+		{ServiceId: 1, Prio: 1, BackendIndex: 2}: {BackendUid: 2},
+		{ServiceId: 1, Prio: 1, BackendIndex: 3}: {BackendUid: 3},
+		{ServiceId: 1, Prio: 1, BackendIndex: 4}: {BackendUid: 4},
+		{ServiceId: 1, Prio: 1, BackendIndex: 5}: {BackendUid: 5},
+	}
+	for k, v := range endpointsMap {
+		c.EndpointUpdate(k, v)
+	}
+
+	// invalid currentIndex
+	err := c.EndpointSwap(6, 5, 1, 1)
+	assert.ErrorContains(t, err, "> lastIndex")
+
+	// delete mid element 3 -> 1 2 5 4
+	err = c.EndpointSwap(3, 5, 1, 1)
+	assert.Nil(t, err)
+
+	// delete the last element 4 -> 1 2 5
+	err = c.EndpointSwap(4, 4, 1, 1)
+	assert.Nil(t, err)
+
+	// delete the first element 1 -> 5 2
+	err = c.EndpointSwap(1, 3, 1, 1)
+	assert.Nil(t, err)
+
+	eps := c.GetAllEndpointsForService(1)
+	assert.Equal(t, len(eps), 2)
+
+	assert.Equal(t, 2, len(c.endpointKeys))
+	epKs := c.GetEndpointKeys(2)
+	assert.Equal(t, 1, epKs.Len())
+	epKs = c.GetEndpointKeys(5)
+	assert.Equal(t, 1, epKs.Len())
+}

--- a/pkg/controller/workload/bpfcache/endpoint_test.go
+++ b/pkg/controller/workload/bpfcache/endpoint_test.go
@@ -39,20 +39,41 @@ func TestEndpointSwap(t *testing.T) {
 	}
 
 	// invalid currentIndex
-	err := c.EndpointSwap(6, 5, 1, 1)
+	err := c.EndpointSwap(6, 5, 5, 1, 1)
 	assert.ErrorContains(t, err, "> lastIndex")
 
-	// delete mid element 3 -> 1 2 5 4
-	err = c.EndpointSwap(3, 5, 1, 1)
+	// update mid element 3 with 5 -> 1 2 5 4 5
+	err = c.EndpointSwap(3, 3, 5, 1, 1)
 	assert.Nil(t, err)
 
-	// delete the last element 4 -> 1 2 5
-	err = c.EndpointSwap(4, 4, 1, 1)
+	lastKey := &EndpointKey{
+		ServiceId:    1,
+		Prio:         1,
+		BackendIndex: 5,
+	}
+	// 1 2 5 4 5 -> 1 2 5 4
+	if err := c.EndpointDelete(lastKey); err != nil {
+		t.Errorf("EndpointDelete [%#v] failed: %v", lastKey, err)
+	}
+
+	// delete the last element 4 -> 1 2 5 5
+	err = c.EndpointSwap(4, 4, 4, 1, 1)
 	assert.Nil(t, err)
 
-	// delete the first element 1 -> 5 2
-	err = c.EndpointSwap(1, 3, 1, 1)
+	lastKey.BackendIndex = 4
+	// 1 2 5 5 -> 1 2 5
+	if err := c.EndpointDelete(lastKey); err != nil {
+		t.Errorf("EndpointDelete [%#v] failed: %v", lastKey, err)
+	}
+
+	// delete the first element  1 2 5 -> 5 2 5
+	err = c.EndpointSwap(1, 1, 3, 1, 1)
 	assert.Nil(t, err)
+	lastKey.BackendIndex = 3
+	// 5 2 5 -> 5 2
+	if err := c.EndpointDelete(lastKey); err != nil {
+		t.Errorf("EndpointDelete [%#v] failed: %v", lastKey, err)
+	}
 
 	eps := c.GetAllEndpointsForService(1)
 	assert.Equal(t, len(eps), 2)

--- a/pkg/controller/workload/cache/endpoint_cache.go
+++ b/pkg/controller/workload/cache/endpoint_cache.go
@@ -30,7 +30,11 @@ type Endpoint struct {
 type EndpointCache interface {
 	List(uint32) map[uint32]Endpoint // Endpoint slice by ServiceId
 	AddEndpointToService(ep Endpoint, serviceID uint32)
+	// DeleteEndpoint delete a endpoint regardless of the priority
 	DeleteEndpoint(workloadID, serviceID uint32)
+	// DeleteEndpointWithPriority delete a endpoint with given priority
+	DeleteEndpointWithPriority(serviceID, workloadID, prio uint32)
+	// DeleteEndpointByServiceId delete all endpoints belong to a given service
 	DeleteEndpointByServiceId(uint32)
 }
 
@@ -60,6 +64,16 @@ func (s *endpointCache) DeleteEndpoint(serviceID, workloadID uint32) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	delete(s.endpointsByServiceId[serviceID], workloadID)
+}
+
+func (s *endpointCache) DeleteEndpointWithPriority(serviceID, workloadID, prio uint32) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.endpointsByServiceId[serviceID] != nil {
+		if ep, ok := s.endpointsByServiceId[serviceID][workloadID]; ok && ep.Prio == prio {
+			delete(s.endpointsByServiceId[serviceID], workloadID)
+		}
+	}
 }
 
 func (s *endpointCache) DeleteEndpointByServiceId(serviceId uint32) {

--- a/pkg/controller/workload/workload_processor_test.go
+++ b/pkg/controller/workload/workload_processor_test.go
@@ -782,17 +782,19 @@ func TestLBPolicyUpdate(t *testing.T) {
 	checkServiceMap(t, p, p.hashName.Hash(randomSvc.ResourceName()), randomSvc, 3, 0)
 	assert.Equal(t, 1, p.bpf.ServiceCount())
 	// check endpoint map
-	t.Log("1. check endpoint map")
+	t.Log("2. check endpoint map")
 
 	checkEndpointMap(t, p, randomSvc, backendUid)
 	assert.Equal(t, 4, p.bpf.EndpointCount())
 	// check backend map
+	t.Log("3. check backend map")
 	for _, wl := range []*workloadapi.Workload{wl1, wl2, wl3, wl4} {
 		checkBackendMap(t, p, p.hashName.Hash(wl.ResourceName()), wl)
 	}
 	assert.Equal(t, 4, p.bpf.BackendCount())
 
 	// 2. Locality Loadbalance Update from random to locality LB
+	t.Log("lb policy update to locality lb")
 	addr = serviceToAddress(llbSvc)
 	res2.Resources = append(res2.Resources, &service_discovery_v3.Resource{
 		Resource: protoconv.MessageToAny(addr),
@@ -803,14 +805,14 @@ func TestLBPolicyUpdate(t *testing.T) {
 
 	assert.Equal(t, 5, p.bpf.FrontendCount())
 	// check service map
-	t.Log("2. check service map")
+	t.Log("4. check service map")
 	checkServiceMap(t, p, p.hashName.Hash(llbSvc.ResourceName()), llbSvc, 0, 1)
 	checkServiceMap(t, p, p.hashName.Hash(llbSvc.ResourceName()), llbSvc, 1, 1)
 	checkServiceMap(t, p, p.hashName.Hash(llbSvc.ResourceName()), llbSvc, 2, 1)
 	checkServiceMap(t, p, p.hashName.Hash(llbSvc.ResourceName()), llbSvc, 3, 1)
 	assert.Equal(t, 1, p.bpf.ServiceCount())
 	// check endpoint map
-	t.Log("2. check endpoint map")
+	t.Log("5. check endpoint map")
 	checkEndpointMap(t, p, llbSvc, backendUid)
 	assert.Equal(t, 4, p.bpf.EndpointCount())
 
@@ -825,14 +827,14 @@ func TestLBPolicyUpdate(t *testing.T) {
 
 	assert.Equal(t, 5, p.bpf.FrontendCount())
 	// check service map
-	t.Log("3. check service map")
+	t.Log("6. check service map")
 	checkServiceMap(t, p, p.hashName.Hash(randomSvc.ResourceName()), randomSvc, 0, 4) // 4 1
 	checkServiceMap(t, p, p.hashName.Hash(randomSvc.ResourceName()), randomSvc, 1, 0) // 0 1
 	checkServiceMap(t, p, p.hashName.Hash(randomSvc.ResourceName()), randomSvc, 2, 0) // 0 1
 	checkServiceMap(t, p, p.hashName.Hash(randomSvc.ResourceName()), randomSvc, 3, 0) // 0 1
 	assert.Equal(t, 1, p.bpf.ServiceCount())
 	// check endpoint map
-	t.Log("3. check endpoint map")
+	t.Log("7. check endpoint map")
 	checkEndpointMap(t, p, randomSvc, backendUid)
 	assert.Equal(t, 4, p.bpf.EndpointCount())
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

No matter workload/service update, we should make sure bpf map is updated in the following orders:

backendmap-> endpoint map -> service map -> frontend map

In case workload/service delete, the order should be as below:

frontend map-> service map -> endpoint map -> backend map



**Which issue(s) this PR fixes**:
Fixes #1042

And made many cleanups

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
