### PR TITLE
Add kmesh ut test on 5.15

### DIFF
--- a/.github/workflows/main-5.15.yml
+++ b/.github/workflows/main-5.15.yml
@@ -1,0 +1,38 @@
+name: BPF Compatability Test on Kernel 5.15
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**.md'
+      - '**.svg'
+      - '**.png'
+  merge_group: # enable merge queue
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: true
+
+jobs:
+
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        go-version: [ '1.23' ]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v4.0.0
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Prepare kernel header # because the kernel header is up to date with 5.15
+        shell: bash
+        run: |
+          sudo cp /usr/src/linux-headers-$(uname -r)/include/uapi/linux/bpf.h /usr/include/linux/bpf.h
+
+      - name: Go Test
+        run: |
+          sudo make test RUN_IN_CONTAINER=1

--- a/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.c
+++ b/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.c
@@ -14,7 +14,6 @@
 
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
-#include <bpf/btf.h>
 #include <linux/bpf.h>
 
 #include <protobuf-c/protobuf-c.h>

--- a/hack/run-ut.sh
+++ b/hack/run-ut.sh
@@ -21,6 +21,11 @@ go_test_command=$(get_go_test_command)
 function docker_run_go_ut() {
     local container_id=$1
     docker exec $container_id $go_test_command
+    exit_code=$?
+    echo "exit code: $exit_code"
+    if [ $exit_code -ne 0 ]; then
+        exit $exit_code
+    fi
 }
 
 function run_go_ut_local() {

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -2,7 +2,7 @@
 
 function run_docker_container() {
     local container_id
-    container_id=$(docker run -itd --privileged=true \
+    container_id=$(docker run --rm -itd --privileged=true \
         -v /usr/src:/usr/src \
         -v /usr/include/linux/bpf.h:/kmesh/config/linux-bpf.h \
         -v /etc/cni/net.d:/etc/cni/net.d \


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

This to make sure bpf prog can be loaded successfully in kernel 5.15,  since github action has a limited node image. So uubuntu 2004 is the smallest version that we can use.

We have encountered many cases that previous CI can run successfully, but in our local dev machine(kernel 5.15) it failed.

See https://github.com/kmesh-net/kmesh/issues/1053

**Which issue(s) this PR fixes**:
Fixes #




**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
