### PR TITLE
fix Flake of TestAddRemovePodWaypoint

### DIFF
--- a/test/e2e/baseline_test.go
+++ b/test/e2e/baseline_test.go
@@ -508,7 +508,7 @@ func TestAddRemovePodWaypoint(t *testing.T) {
 				}
 				for _, dstWl := range dst.WorkloadsOrFail(t) {
 					t.NewSubTestf("from %v", src.Config().Service).Run(func(t framework.TestContext) {
-						c := IsL4()
+						c := IsL7()
 						opt := echo.CallOptions{
 							Address: dstWl.Address(),
 							Port:    echo.Port{ServicePort: ports.All().MustForName("http").WorkloadPort},


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This test case, after the waypoint is deployed, incorrectly checks whether it's L4 traffic instead of L7. When test runs fast enough, before the waypoint is deployed, the test has been completed, the test will pass. However, if the waypoint is deployed successfully during the test, it will fail, which is why this case is often flakey.

**Which issue(s) this PR fixes**:
Fixes #967

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
