### PR TITLE
update hostname and record unknown services of service metrics

### DIFF
--- a/pkg/controller/ads/cache.go
+++ b/pkg/controller/ads/cache.go
@@ -315,7 +315,7 @@ func (load *AdsCache) CreateApiRouteByRds(status core_v2.ApiStatus, routeConfig 
 	load.RouteCache.SetApiRouteConfig(apiRouteConfig.GetName(), apiRouteConfig)
 }
 
-func (load *AdsCache) UpateApiRouteStatus(key string, status core_v2.ApiStatus) {
+func (load *AdsCache) UpdateApiRouteStatus(key string, status core_v2.ApiStatus) {
 	load.RouteCache.UpdateApiRouteStatus(key, status)
 }
 

--- a/pkg/controller/telemetry/accesslog.go
+++ b/pkg/controller/telemetry/accesslog.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"syscall"
 	"time"
+
+	"kmesh.net/kmesh/api/v2/workloadapi"
 )
 
 type logInfo struct {
@@ -32,6 +34,46 @@ type logInfo struct {
 	destinationService   string
 	destinationWorkload  string
 	destinationNamespace string
+}
+
+func NewLogInfo() *logInfo {
+	return &logInfo{
+		direction:            DEFAULT_UNKNOWN,
+		sourceAddress:        DEFAULT_UNKNOWN,
+		sourceWorkload:       DEFAULT_UNKNOWN,
+		sourceNamespace:      DEFAULT_UNKNOWN,
+		destinationAddress:   DEFAULT_UNKNOWN,
+		destinationService:   DEFAULT_UNKNOWN,
+		destinationWorkload:  DEFAULT_UNKNOWN,
+		destinationNamespace: DEFAULT_UNKNOWN,
+	}
+}
+
+func (l *logInfo) withSource(workload *workloadapi.Workload) *logInfo {
+	if workload.GetNamespace() != "" {
+		l.sourceNamespace = workload.GetNamespace()
+	}
+	if workload.GetName() != "" {
+		l.sourceWorkload = workload.GetName()
+	}
+	return l
+}
+
+func (l *logInfo) withDestination(workload *workloadapi.Workload) *logInfo {
+	if workload.GetName() != "" {
+		l.destinationWorkload = workload.GetName()
+	}
+	return l
+}
+
+func (l *logInfo) withDestinationService(service *workloadapi.Service) *logInfo {
+	if service.GetNamespace() != "" {
+		l.destinationNamespace = service.GetNamespace()
+	}
+	if service.GetHostname() != "" {
+		l.destinationService = service.GetHostname()
+	}
+	return l
 }
 
 func OutputAccesslog(data requestMetric, accesslog logInfo) {

--- a/pkg/controller/telemetry/metric_test.go
+++ b/pkg/controller/telemetry/metric_test.go
@@ -569,9 +569,10 @@ func TestBuildServiceMetric(t *testing.T) {
 				requestProtocol:              "tcp",
 				responseFlags:                "",
 				connectionSecurityPolicy:     "mutual_tls",
+				reporter:                     "source",
 			},
 			wantLogInfo: logInfo{
-				direction:            "-",
+				direction:            "OUTBOUND",
 				sourceAddress:        "10.19.25.31:8000",
 				sourceWorkload:       "kmesh",
 				sourceNamespace:      "kmesh-system",
@@ -617,9 +618,10 @@ func TestBuildServiceMetric(t *testing.T) {
 				requestProtocol:              "tcp",
 				responseFlags:                "",
 				connectionSecurityPolicy:     "mutual_tls",
+				reporter:                     "source",
 			},
 			wantLogInfo: logInfo{
-				direction:            "-",
+				direction:            "OUTBOUND",
 				sourceAddress:        "10.19.25.31:8000",
 				sourceWorkload:       "kmesh",
 				sourceNamespace:      "kmesh-system",

--- a/pkg/controller/workload/cache/waypoint_cache.go
+++ b/pkg/controller/workload/cache/waypoint_cache.go
@@ -29,7 +29,7 @@ type WaypointCache interface {
 	DeleteService(resourceName string)
 	// AddOrUpdateWorkload add or update workload in this cache, return true if the
 	// workload's waypoint doesn't need to be resolved or resolved successfully.
-	AddOrUpateWorkload(workload *workloadapi.Workload) bool
+	AddOrUpdateWorkload(workload *workloadapi.Workload) bool
 	DeleteWorkload(uid string)
 
 	// Refresh is used to process waypoint service.
@@ -148,12 +148,12 @@ func (w *waypointCache) DeleteService(resourceName string) {
 	delete(w.waypointAssociatedObjects, resourceName)
 }
 
-func (w *waypointCache) AddOrUpateWorkload(workload *workloadapi.Workload) bool {
+func (w *waypointCache) AddOrUpdateWorkload(workload *workloadapi.Workload) bool {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
 	uid := workload.GetUid()
-	// If this is a workload withwaypoint or  with an IP address type waypoint, no processing is required and
+	// If this is a workload with waypoint or with an IP address type waypoint, no processing is required and
 	// return directly.
 	if workload.GetWaypoint() == nil || workload.GetWaypoint().GetAddress() != nil {
 		// Workload may become unassociated with waypoint.

--- a/pkg/controller/workload/cache/waypoint_cache_test.go
+++ b/pkg/controller/workload/cache/waypoint_cache_test.go
@@ -50,7 +50,7 @@ func TestBasic(t *testing.T) {
 	}
 
 	for _, wl := range []*workloadapi.Workload{wl1, wl2, wl3} {
-		cache.AddOrUpateWorkload(wl)
+		cache.AddOrUpdateWorkload(wl)
 	}
 
 	// Waypoint service has not been processed.
@@ -91,7 +91,7 @@ func TestBasic(t *testing.T) {
 	svc4 := createFakeService("svc4", "10.240.10.4", waypointHostname)
 	wl4 := createFakeWorkload("1.2.3.8", waypointHostname)
 	cache.AddOrUpdateService(svc4)
-	cache.AddOrUpateWorkload(wl4)
+	cache.AddOrUpdateWorkload(wl4)
 
 	// svc4 and wl4 have been added to the waypoint cache and hostname of waypoint has been resolved.
 	assert.Equal(t, isHostnameTypeWaypoint(associated.services[svc4.ResourceName()].Waypoint), false)

--- a/pkg/controller/workload/workload_controller.go
+++ b/pkg/controller/workload/workload_controller.go
@@ -57,7 +57,7 @@ func NewController(bpfWorkload *bpfwl.BpfWorkload, enableMonitoring, enablePerfM
 		c.Processor.bpf.RestoreEndpointKeys()
 	}
 	c.Rbac = auth.NewRbac(c.Processor.WorkloadCache)
-	c.MetricController = telemetry.NewMetric(c.Processor.WorkloadCache, enableMonitoring)
+	c.MetricController = telemetry.NewMetric(c.Processor.WorkloadCache, c.Processor.ServiceCache, enableMonitoring)
 	if enablePerfMonitor {
 		c.OperationMetricController = telemetry.NewBpfProgMetric()
 		c.MapMetricController = telemetry.NewMapMetric()

--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -437,7 +437,7 @@ func (p *Processor) updateWorkloadInFrontendMap(workload *workloadapi.Workload) 
 func (p *Processor) handleWorkload(workload *workloadapi.Workload) error {
 	log.Debugf("handle workload: %s", workload.ResourceName())
 
-	if resolved := p.WaypointCache.AddOrUpateWorkload(workload); !resolved {
+	if resolved := p.WaypointCache.AddOrUpdateWorkload(workload); !resolved {
 		// If the hostname type waypoint of workload has not been resolved, it will not be processed
 		// for the time being. The corresponding waypoint service should be processed immediately, and then
 		// it will be handled after the batch resolution is completed in `WaypointCache.Refresh`.

--- a/test/e2e/baseline_test.go
+++ b/test/e2e/baseline_test.go
@@ -833,7 +833,7 @@ func buildL4Query(src, dst echo.Instance) prometheus.Query {
 		"destination_canonical_service":  dst.ServiceName(),
 		"destination_canonical_revision": dst.Config().Version,
 		"destination_service":            fmt.Sprintf("%s.%s.svc.cluster.local", dst.Config().Service, destns),
-		"destination_service_name":       fmt.Sprintf("%s.%s.svc.cluster.local", dst.Config().Service, destns),
+		"destination_service_name":       dst.Config().Service,
 		"destination_service_namespace":  destns,
 		"destination_principal":          "-",
 		"destination_version":            dst.Config().Version,


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1089. Update `destination_service_name` to service name instead of host.

Here are some issues tha remain to be disccused:
- When a service is not found when building service metrics, I record the `dstIp` in `destination_service`, I'm not sure if it is appropriate.
- When recording waypoint metrics, services can not found since the `dstIp` is 15019, but only 15021 and 15008 are defined in waypoint services, so the following logic fails every time. Ztunnel uses actual service as destination service instead of the waypoint service, but seems like kmesh can not achieve that. I'm not sure how to handle this situation.
```go
namespacedhost := ""
if dstWorkload != nil {
	for k, portList := range dstWorkload.Services {
		for _, port := range portList.Ports {
			if port.TargetPort == uint32(data.dstPort) {
				namespacedhost = k
				break
			}
		}
		if namespacedhost != "" {
			break
		}
	}
}
```
```shell
# kmesh waypoint metric
kmesh_tcp_connections_closed_total{connection_security_policy="mutual_tls",destination_app="reviews-svc-waypoint",destination_canonical_revision="latest",destination_canonical_service="reviews-svc-waypoint",destination_cluster="Kubernetes",destination_principal="-",destination_service="10.244.1.11",destination_service_name="-",destination_service_namespace="-",destination_version="latest",destination_workload="reviews-svc-waypoint",destination_workload_namespace="default",reporter="source",request_protocol="tcp",response_flags="-",source_app="productpage",source_canonical_revision="v1",source_canonical_service="productpage",source_cluster="Kubernetes",source_principal="-",source_version="v1",source_workload="productpage-v1",source_workload_namespace="default"} 14

# ztunnel waypoint metric
istio_tcp_received_bytes_total{app="ztunnel", app_kubernetes_io_instance="istio", app_kubernetes_io_managed_by="Helm", app_kubernetes_io_name="ztunnel", app_kubernetes_io_part_of="istio", app_kubernetes_io_version="1.24.1", connection_security_policy="mutual_tls", controller_revision_hash="5d8567b5cd", destination_app="reviews-svc-waypoint", destination_canonical_revision="latest", destination_canonical_service="reviews-svc-waypoint", destination_cluster="Kubernetes", destination_principal="spiffe://cluster.local/ns/default/sa/reviews-svc-waypoint", destination_service="reviews.default.svc.cluster.local", destination_service_name="reviews", destination_service_namespace="default", destination_version="latest", destination_workload="reviews-svc-waypoint", destination_workload_namespace="default", helm_sh_chart="ztunnel-1.24.1", instance="10.17.40.69:15020", istio_io_dataplane_mode="none", job="kubernetes-pods", namespace="istio-system", node="ap-northeast-1.10.17.40.52", pod="ztunnel-28bpw", pod_template_generation="1", reporter="source", request_protocol="tcp", response_flags="-", sidecar_istio_io_inject="false", source_app="productpage", source_canonical_revision="v1", source_canonical_service="productpage", source_cluster="Kubernetes", source_principal="spiffe://cluster.local/ns/default/sa/bookinfo-productpage", source_version="v1", source_workload="productpage-v1", source_workload_namespace="default"}
```
- And a small question that why the metric are separated into service metric and workload metric?

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
