### PR TITLE
Add kiali addon sample and  adjust prometheus_recording_istio sample

### DIFF
--- a/samples/addons/kiali.yaml
+++ b/samples/addons/kiali.yaml
@@ -1,0 +1,426 @@
+---
+# Source: kiali-server/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kiali
+  namespace: "kmesh-system"
+  labels:
+    helm.sh/chart: kiali-server-2.1.0
+    app: kiali
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/instance: kiali
+    version: "v2.1.0"
+    app.kubernetes.io/version: "v2.1.0"
+    app.kubernetes.io/part-of: "kiali"
+...
+---
+# Source: kiali-server/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kiali
+  namespace: "kmesh-system"
+  labels:
+    helm.sh/chart: kiali-server-2.1.0
+    app: kiali
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/instance: kiali
+    version: "v2.1.0"
+    app.kubernetes.io/version: "v2.1.0"
+    app.kubernetes.io/part-of: "kiali"
+data:
+  config.yaml: |
+    additional_display_details:
+    - annotation: kiali.io/api-spec
+      icon_annotation: kiali.io/api-type
+      title: API Documentation
+    auth:
+      openid: {}
+      openshift:
+        client_id_prefix: kiali
+      strategy: anonymous
+    clustering:
+      autodetect_secrets:
+        enabled: true
+        label: kiali.io/multiCluster=true
+      clusters: []
+    deployment:
+      additional_service_yaml: {}
+      affinity:
+        node: {}
+        pod: {}
+        pod_anti: {}
+      cluster_wide_access: true
+      configmap_annotations: {}
+      custom_envs: []
+      custom_secrets: []
+      dns:
+        config: {}
+        policy: ""
+      host_aliases: []
+      hpa:
+        api_version: autoscaling/v2
+        spec: {}
+      image_digest: ""
+      image_name: quay.io/kiali/kiali
+      image_pull_policy: IfNotPresent
+      image_pull_secrets: []
+      image_version: v2.1
+      ingress:
+        additional_labels: {}
+        class_name: nginx
+        override_yaml:
+          metadata: {}
+      ingress_enabled: false
+      instance_name: kiali
+      logger:
+        log_format: text
+        log_level: info
+        sampler_rate: "1"
+        time_field_format: 2006-01-02T15:04:05Z07:00
+      namespace: istio-system
+      node_selector: {}
+      pod_annotations: {}
+      pod_labels:
+        sidecar.istio.io/inject: "false"
+      priority_class_name: ""
+      remote_cluster_resources_only: false
+      replicas: 1
+      resources:
+        limits:
+          memory: 1Gi
+        requests:
+          cpu: 10m
+          memory: 64Mi
+      secret_name: kiali
+      security_context: {}
+      service_annotations: {}
+      service_type: ""
+      tolerations: []
+      version_label: v2.1.0
+      view_only_mode: false
+    external_services:
+      prometheus:
+        url: http://prometheus.kmesh-system:9090
+      grafana:
+        internal_url: http://grafana.kmesh-system:3000
+      custom_dashboards:
+        enabled: true
+      istio:
+        root_namespace: istio-system
+        gateway_api_classes:
+        - class_name: istio-waypoint
+          name: waypoint
+      tracing:
+        enabled: false
+    identity:
+      cert_file: ""
+      private_key_file: ""
+    istio_namespace: istio-system
+    kiali_feature_flags:
+      disabled_features: []
+      validations:
+        ignore:
+        - KIA1301
+    login_token:
+      signing_key: CHANGEME00000000
+    server:
+      observability:
+        metrics:
+          enabled: true
+          port: 9090
+      port: 20001
+      web_root: /kiali
+...
+---
+# Source: kiali-server/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kiali
+  labels:
+    helm.sh/chart: kiali-server-2.1.0
+    app: kiali
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/instance: kiali
+    version: "v2.1.0"
+    app.kubernetes.io/version: "v2.1.0"
+    app.kubernetes.io/part-of: "kiali"
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - endpoints
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups: [""]
+  resources:
+  - namespaces
+  - pods
+  - replicationcontrollers
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups: [""]
+  resources:
+  - pods/portforward
+  verbs:
+  - create
+  - post
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - networking.istio.io
+  - security.istio.io
+  - extensions.istio.io
+  - telemetry.istio.io
+  - gateway.networking.k8s.io
+  resources: ["*"]
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - patch
+- apiGroups: ["apps.openshift.io"]
+  resources:
+  - deploymentconfigs
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups: ["project.openshift.io"]
+  resources:
+  - projects
+  verbs:
+  - get
+- apiGroups: ["route.openshift.io"]
+  resources:
+  - routes
+  verbs:
+  - get
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups: ["oauth.openshift.io"]
+  resources:
+  - oauthclients
+  resourceNames:
+  - kiali-istio-system
+  verbs:
+  - get
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+...
+---
+# Source: kiali-server/templates/rolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kiali
+  labels:
+    helm.sh/chart: kiali-server-2.1.0
+    app: kiali
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/instance: kiali
+    version: "v2.1.0"
+    app.kubernetes.io/version: "v2.1.0"
+    app.kubernetes.io/part-of: "kiali"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kiali
+subjects:
+- kind: ServiceAccount
+  name: kiali
+  namespace: "kmesh-system"
+...
+---
+# Source: kiali-server/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: kiali
+  namespace: "kmesh-system"
+  labels:
+    helm.sh/chart: kiali-server-2.1.0
+    app: kiali
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/instance: kiali
+    version: "v2.1.0"
+    app.kubernetes.io/version: "v2.1.0"
+    app.kubernetes.io/part-of: "kiali"
+  annotations:
+spec:
+  ports:
+  - name: http
+    appProtocol: http
+    protocol: TCP
+    port: 20001
+  - name: http-metrics
+    appProtocol: http
+    protocol: TCP
+    port: 9090
+  selector:
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/instance: kiali
+...
+---
+# Source: kiali-server/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kiali
+  namespace: "kmesh-system"
+  labels:
+    helm.sh/chart: kiali-server-2.1.0
+    app: kiali
+    app.kubernetes.io/name: kiali
+    app.kubernetes.io/instance: kiali
+    version: "v2.1.0"
+    app.kubernetes.io/version: "v2.1.0"
+    app.kubernetes.io/part-of: "kiali"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kiali
+      app.kubernetes.io/instance: kiali
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      name: kiali
+      labels:
+        helm.sh/chart: kiali-server-2.1.0
+        app: kiali
+        app.kubernetes.io/name: kiali
+        app.kubernetes.io/instance: kiali
+        version: "v2.1.0"
+        app.kubernetes.io/version: "v2.1.0"
+        app.kubernetes.io/part-of: "kiali"
+        sidecar.istio.io/inject: "false"
+      annotations:
+        checksum/config: b6f715c420df4b1ad451aff16d99961cff61f0016b250b5a4fa1d897252be282
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        kiali.io/dashboards: go,kiali
+    spec:
+      serviceAccountName: kiali
+      containers:
+      - image: "quay.io/kiali/kiali:v2.1"
+        imagePullPolicy: IfNotPresent
+        name: kiali
+        command:
+        - "/opt/kiali/kiali"
+        - "-config"
+        - "/kiali-configuration/config.yaml"
+        securityContext:
+          allowPrivilegeEscalation: false
+          privileged: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+        ports:
+        - name: api-port
+          containerPort: 20001
+        - name: http-metrics
+          containerPort: 9090
+        readinessProbe:
+          httpGet:
+            path: /kiali/healthz
+            port: api-port
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 30
+        livenessProbe:
+          httpGet:
+            path: /kiali/healthz
+            port: api-port
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 30
+        env:
+        - name: ACTIVE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LOG_LEVEL
+          value: "info"
+        - name: LOG_FORMAT
+          value: "text"
+        - name: LOG_TIME_FIELD_FORMAT
+          value: "2006-01-02T15:04:05Z07:00"
+        - name: LOG_SAMPLER_RATE
+          value: "1"
+        volumeMounts:
+        - name: kiali-configuration
+          mountPath: "/kiali-configuration"
+        - name: kiali-cert
+          mountPath: "/kiali-cert"
+        - name: kiali-secret
+          mountPath: "/kiali-secret"
+        - name: kiali-cabundle
+          mountPath: "/kiali-cabundle"
+        resources:
+          limits:
+            memory: 1Gi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+      volumes:
+      - name: kiali-configuration
+        configMap:
+          name: kiali
+      - name: kiali-cert
+        secret:
+          secretName: istio.kiali-service-account
+          optional: true
+      - name: kiali-secret
+        secret:
+          secretName: kiali
+          optional: true
+      - name: kiali-cabundle
+        configMap:
+          name: kiali-cabundle
+          optional: true
+...

--- a/samples/addons/kiali.yaml
+++ b/samples/addons/kiali.yaml
@@ -36,42 +36,16 @@ data:
       icon_annotation: kiali.io/api-type
       title: API Documentation
     auth:
-      openid: {}
-      openshift:
-        client_id_prefix: kiali
       strategy: anonymous
     clustering:
       autodetect_secrets:
         enabled: true
         label: kiali.io/multiCluster=true
-      clusters: []
     deployment:
-      additional_service_yaml: {}
-      affinity:
-        node: {}
-        pod: {}
-        pod_anti: {}
       cluster_wide_access: true
-      configmap_annotations: {}
-      custom_envs: []
-      custom_secrets: []
-      dns:
-        config: {}
-        policy: ""
-      host_aliases: []
-      hpa:
-        api_version: autoscaling/v2
-        spec: {}
-      image_digest: ""
       image_name: quay.io/kiali/kiali
       image_pull_policy: IfNotPresent
-      image_pull_secrets: []
       image_version: v2.1
-      ingress:
-        additional_labels: {}
-        class_name: nginx
-        override_yaml:
-          metadata: {}
       ingress_enabled: false
       instance_name: kiali
       logger:
@@ -79,12 +53,9 @@ data:
         log_level: info
         sampler_rate: "1"
         time_field_format: 2006-01-02T15:04:05Z07:00
-      namespace: istio-system
-      node_selector: {}
-      pod_annotations: {}
+      namespace: kmesh-system
       pod_labels:
         sidecar.istio.io/inject: "false"
-      priority_class_name: ""
       remote_cluster_resources_only: false
       replicas: 1
       resources:
@@ -94,10 +65,6 @@ data:
           cpu: 10m
           memory: 64Mi
       secret_name: kiali
-      security_context: {}
-      service_annotations: {}
-      service_type: ""
-      tolerations: []
       version_label: v2.1.0
       view_only_mode: false
     external_services:
@@ -114,17 +81,11 @@ data:
           name: waypoint
       tracing:
         enabled: false
-    identity:
-      cert_file: ""
-      private_key_file: ""
     istio_namespace: istio-system
     kiali_feature_flags:
-      disabled_features: []
       validations:
         ignore:
         - KIA1301
-    login_token:
-      signing_key: CHANGEME00000000
     server:
       observability:
         metrics:

--- a/samples/addons/prometheus_recording_istio.yaml
+++ b/samples/addons/prometheus_recording_istio.yaml
@@ -47,19 +47,6 @@ data:
     - /etc/config/rules
     - /etc/config/alerts
     scrape_configs:
-    - job_name: prometheus
-      metrics_path: /status/metric
-      kubernetes_sd_configs:
-      - role: pod
-      relabel_configs:
-      - action: keep
-        regex: kmesh
-        source_labels: [__meta_kubernetes_pod_label_app]
-      - action: replace
-        source_labels: [__meta_kubernetes_pod_ip]
-        target_label: __address__
-        replacement: $1:15020  
-
     - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
       job_name: kubernetes-apiservers
       kubernetes_sd_configs:
@@ -299,7 +286,6 @@ data:
         source_labels:
         - __meta_kubernetes_pod_node_name
         target_label: node
-      - action: replace
       metric_relabel_configs:
       - source_labels: [app]
         regex: 'kmesh'


### PR DESCRIPTION

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->
/kind enhancement
**What this PR does / why we need it**:
Add kiali addon sample and  adjust prometheus_recording_istio sample for a better view of kiali
**Which issue(s) this PR fixes**:
Fixes #1100

**Special notes for your reviewer**:
This PR mainly fixes of the already existed `./samples/addon/prometheus_recoding_istio.yaml` and further provide a `kiali.yaml` for a sample Kiali deploy.
We can get a pretty decent sample traffic graph in Kiali with this and #1094 both resolved. The final look of the traffic graph will be like this
<img width="1573" alt="image" src="https://github.com/user-attachments/assets/03a51e68-35f6-4f40-8b6f-fa605135f21a">

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->

