### PR TITLE
Optimised handling when no podCIDR is available

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -340,6 +340,10 @@ func getNodeIPAddress(node *corev1.Node) [16]byte {
 
 func getNodePodSubGateway(node *corev1.Node) [16]byte {
 	podCIDR := node.Spec.PodCIDR
+	if podCIDR == "" {
+		return [16]byte{0}
+	}
+
 	_, subNet, err := net.ParseCIDR(podCIDR)
 	if err != nil {
 		log.Errorf("failed to resolve ip from podCIDR: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
Not all clustered environments have `podCIDR`.
Therefore optimised for handling in this case
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
