### PR TITLE
Add kmesh-daemon version subcommand and fix `kmeshctl version`

### DIFF
--- a/ctl/version/version.go
+++ b/ctl/version/version.go
@@ -45,21 +45,19 @@ kmeshctl version
 # Show version info of a specific kmesh daemon
 kmeshctl version <kmesh-daemon-pod>`,
 		Run: func(cmd *cobra.Command, args []string) {
-			_ = RunVersion(cmd, args)
+			runVersion(cmd, args)
 		},
 	}
 	return cmd
 }
 
-// RunVersion provides the version info of kmeshctl or specific Kmesh daemon.
-func RunVersion(cmd *cobra.Command, args []string) error {
+// runVersion output the version info of kmeshctl or kmesh-daemon.
+func runVersion(cmd *cobra.Command, args []string) {
 	cli, err := utils.CreateKubeClient()
 	if err != nil {
 		log.Errorf("failed to create kube client: %v", err)
 		os.Exit(1)
 	}
-
-	cli.Kube()
 
 	if len(args) == 0 {
 		v := version.Get()
@@ -83,21 +81,19 @@ func RunVersion(cmd *cobra.Command, args []string) error {
 			counts = append(counts, fmt.Sprintf("%s (%d daemons)", k, v))
 		}
 		cmd.Printf("%s\n", strings.Join(counts, ", "))
-		return nil
+		return
 	}
 
 	podName := args[0]
-
 	v := getVersion(cli, podName)
 	if v.GitVersion != "" {
 		data, err := json.MarshalIndent(&v, "", "  ")
 		if err != nil {
-			cmd.PrintErrf("Failed to marshal version info: %v", err)
-			return nil
+			log.Errorf("Failed to marshal version info: %v", err)
+			os.Exit(1)
 		}
 		cmd.Printf("%s\n", string(data))
 	}
-	return nil
 }
 
 func getVersion(client kube.CLIClient, podName string) (version version.Info) {

--- a/ctl/version/version.go
+++ b/ctl/version/version.go
@@ -90,7 +90,12 @@ func RunVersion(cmd *cobra.Command, args []string) error {
 
 	v := getVersion(cli, podName)
 	if v.GitVersion != "" {
-		cmd.Printf("%#v\n", v)
+		data, err := json.MarshalIndent(&v, "", "  ")
+		if err != nil {
+			cmd.PrintErrf("Failed to marshal version info: %v", err)
+			return nil
+		}
+		cmd.Printf("%s\n", string(data))
 	}
 	return nil
 }

--- a/ctl/version/version.go
+++ b/ctl/version/version.go
@@ -63,7 +63,7 @@ func RunVersion(cmd *cobra.Command, args []string) error {
 
 	if len(args) == 0 {
 		v := version.Get()
-		cmd.Printf("client version: %s\n", v.GitVersion)
+		cmd.Printf("client version: %s-%s\n", v.GitVersion, v.GitCommit)
 		podList, err := cli.PodsForSelector(context.TODO(), utils.KmeshNamespace, utils.KmeshLabel)
 		if err != nil {
 			log.Errorf("failed to get kmesh daemon pods: %v", err)
@@ -74,7 +74,7 @@ func RunVersion(cmd *cobra.Command, args []string) error {
 		for _, pod := range podList.Items {
 			v := getVersion(cli, pod.Name)
 			if v.GitVersion != "" {
-				daemonVersions[v.GitVersion] = daemonVersions[v.GitVersion] + 1
+				daemonVersions[v.GitVersion+"-"+v.GitCommit] = daemonVersions[v.GitVersion+"-"+v.GitCommit] + 1
 			}
 		}
 		counts := []string{}

--- a/daemon/manager/manager.go
+++ b/daemon/manager/manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"kmesh.net/kmesh/daemon/manager/uninstall"
+	"kmesh.net/kmesh/daemon/manager/version"
 	"kmesh.net/kmesh/daemon/options"
 	"kmesh.net/kmesh/pkg/bpf"
 	"kmesh.net/kmesh/pkg/bpf/restart"
@@ -68,6 +69,7 @@ func NewCommand() *cobra.Command {
 
 	// add sub commands
 	cmd.AddCommand(uninstall.NewCmd())
+	cmd.AddCommand(version.NewCmd())
 
 	return cmd
 }

--- a/daemon/manager/version/version.go
+++ b/daemon/manager/version/version.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package version
+
+import (
+	"github.com/spf13/cobra"
+
+	"kmesh.net/kmesh/pkg/version"
+)
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Prints out build version info",
+		Example: `# Show version of kmesh-daemon
+kmesh-daemon version`,
+		Run: func(cmd *cobra.Command, args []string) {
+			printVersion(cmd)
+		},
+	}
+	return cmd
+}
+
+// printVersion pritn out the version info of the kmesh daemon.
+func printVersion(cmd *cobra.Command) {
+	v := version.Get()
+	cmd.Printf("%s\n", v)
+}

--- a/docs/ctl/kmeshctl_version.md
+++ b/docs/ctl/kmeshctl_version.md
@@ -9,10 +9,10 @@ kmeshctl version [flags]
 ### Examples
 
 ```
-# Show version of kmeshctl
+# Show version of all kmesh components
 kmeshctl version
 
-# Show version info of a specific Kmesh daemon
+# Show version info of a specific kmesh daemon
 kmeshctl version <kmesh-daemon-pod>
 ```
 

--- a/pkg/kube/portforwarder.go
+++ b/pkg/kube/portforwarder.go
@@ -19,6 +19,7 @@ package kube
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"strconv"
@@ -75,7 +76,7 @@ func (p *portForwarder) Start() error {
 	}
 
 	ports := fmt.Sprintf("%d:%d", p.localPort, p.podPort)
-	ioStreams := genericiooptions.IOStreams{In: os.Stdin, Out: os.Stdout, ErrOut: os.Stderr}
+	ioStreams := genericiooptions.IOStreams{In: os.Stdin, Out: io.Discard, ErrOut: os.Stderr}
 	pfOptions := portforward.NewDefaultPortForwardOptions(ioStreams)
 	pfOptions.Address = address
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/kmesh-net/kmesh/issues/1112
Fix https://github.com/kmesh-net/kmesh/issues/1110

**Special notes for your reviewer**:

The output now 

```
$ kmeshctl version
client version: 1.0-dev-ce162fb7634b6122966da01fd45147e319b7625e
kmesh-daemon version: 1.0-dev-ab83d8ccffaca860a5a657d7873afddd5327a122 (2 daemons)
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
