### PR TITLE
refine destination service metrics generation

### DIFF
--- a/bpf/include/errno.h
+++ b/bpf/include/errno.h
@@ -20,6 +20,10 @@
 #define EBUSY 16 /* Device or resource busy */
 #endif
 
+#ifndef EEXIST
+#define EEXIST 17 /* Device or resource busy */
+#endif
+
 #ifndef EINVAL
 #define EINVAL 22 /* Invalid argument */
 #endif

--- a/bpf/kmesh/probes/tcp_probe.h
+++ b/bpf/kmesh/probes/tcp_probe.h
@@ -39,9 +39,9 @@ struct tcp_probe_info {
     __u32 received_bytes;
     __u32 conn_success;
     __u32 direction;
+    __u32 state;    /* tcp state */
     __u64 duration; // ns
     __u64 close_ns;
-    __u32 state; /* tcp state */
     __u32 protocol;
     __u32 srtt_us; /* smoothed round trip time << 3 in usecs */
     __u32 rtt_min;

--- a/bpf/kmesh/probes/tcp_probe.h
+++ b/bpf/kmesh/probes/tcp_probe.h
@@ -116,13 +116,13 @@ static inline void get_tcp_probe_info(struct bpf_tcp_sock *tcp_sock, struct tcp_
     return;
 }
 
-// construct_orig_dst_info try to read the dst_info from map_of_dst_info first
+// construct_orig_dst_info try to read the dst_info from map_of_orig_dst first
 // if not found, use the tuple info for orig_dst
 static inline void construct_orig_dst_info(struct bpf_sock *sk, struct tcp_probe_info *info)
 {
     __u64 *current_sk = (__u64 *)sk;
     struct bpf_sock_tuple *dst;
-    dst = bpf_map_lookup_elem(&map_of_dst_info, &current_sk);
+    dst = bpf_map_lookup_elem(&map_of_orig_dst, &current_sk);
     if (dst) {
         if (sk->family == AF_INET) {
             info->orig_dst.ipv4.addr = dst->ipv4.daddr;

--- a/bpf/kmesh/probes/tcp_probe.h
+++ b/bpf/kmesh/probes/tcp_probe.h
@@ -20,15 +20,15 @@ enum family_type {
 
 struct orig_dst_info {
     union {
-		struct {
-			__be32 addr;
+        struct {
+            __be32 addr;
             __be16 port;
-		} ipv4;
-		struct {
-			__be32 addr[4];
+        } ipv4;
+        struct {
+            __be32 addr[4];
             __be16 port;
-		} ipv6;
-	};
+        } ipv6;
+    };
 };
 
 struct tcp_probe_info {
@@ -120,7 +120,7 @@ static inline void get_tcp_probe_info(struct bpf_tcp_sock *tcp_sock, struct tcp_
 // if not found, use the tuple info for orig_dst
 static inline void construct_orig_dst_info(struct bpf_sock *sk, struct tcp_probe_info *info)
 {
-     __u64 *current_sk = (__u64 *)sk;
+    __u64 *current_sk = (__u64 *)sk;
     struct bpf_sock_tuple *dst;
     dst = bpf_map_lookup_elem(&map_of_dst_info, &current_sk);
     if (dst) {

--- a/bpf/kmesh/workload/cgroup_sock.c
+++ b/bpf/kmesh/workload/cgroup_sock.c
@@ -110,7 +110,7 @@ int cgroup_connect4_prog(struct bpf_sock_addr *ctx)
     }
     ret = set_original_dst_info(&kmesh_ctx);
     if (ret) {
-        BPF_LOG(ERR, KMESH, "failed to set original destination info, ret is %d\n", ret);
+        BPF_LOG(ERR, KMESH, "[IPv4]failed to set original destination info, ret is %d\n", ret);
         return CGROUP_SOCK_OK;
     }
 
@@ -149,7 +149,7 @@ int cgroup_connect6_prog(struct bpf_sock_addr *ctx)
 
     ret = set_original_dst_info(&kmesh_ctx);
     if (ret) {
-        BPF_LOG(ERR, KMESH, "failed to set original destination info, ret is %d\n", ret);
+        BPF_LOG(ERR, KMESH, "[IPv6]failed to set original destination info, ret is %d\n", ret);
         return CGROUP_SOCK_OK;
     }
 

--- a/bpf/kmesh/workload/cgroup_sock.c
+++ b/bpf/kmesh/workload/cgroup_sock.c
@@ -80,7 +80,7 @@ static inline int set_original_dst_info(struct kmesh_context *kmesh_ctx)
         sk_tuple.ipv6.dport = ctx->user_port;
     }
 
-    ret = bpf_map_update_elem(&map_of_dst_info, &(sk), &sk_tuple, BPF_NOEXIST);
+    ret = bpf_map_update_elem(&map_of_orig_dst, &(sk), &sk_tuple, BPF_NOEXIST);
     if (ret) {
         // only record the first dst info for each socket
         if (ret == -EEXIST)

--- a/bpf/kmesh/workload/cgroup_sock.c
+++ b/bpf/kmesh/workload/cgroup_sock.c
@@ -65,9 +65,9 @@ static inline int set_original_dst_info(struct kmesh_context *kmesh_ctx)
     struct bpf_sock_tuple sk_tuple = {0};
     ctx_buff_t *ctx = (ctx_buff_t *)kmesh_ctx->ctx;
     __u64 *sk = (__u64 *)ctx->sk;
-    
+
     if (kmesh_ctx->via_waypoint) {
-        // since this field is never used, we use it 
+        // since this field is never used, we use it
         // to indicate whether the request will be handled by waypoint
         sk_tuple.ipv4.saddr = 1;
     }

--- a/bpf/kmesh/workload/include/backend.h
+++ b/bpf/kmesh/workload/include/backend.h
@@ -15,10 +15,7 @@ static inline backend_value *map_lookup_backend(const backend_key *key)
 
 static inline int waypoint_manager(struct kmesh_context *kmesh_ctx, struct ip_addr *wp_addr, __u32 port)
 {
-    int ret;
-    address_t target_addr;
     ctx_buff_t *ctx = (ctx_buff_t *)kmesh_ctx->ctx;
-    __u64 *sk = (__u64 *)ctx->sk;
 
     if (ctx->user_family == AF_INET)
         kmesh_ctx->dnat_ip.ip4 = wp_addr->ip4;

--- a/bpf/kmesh/workload/include/backend.h
+++ b/bpf/kmesh/workload/include/backend.h
@@ -19,21 +19,6 @@ static inline int waypoint_manager(struct kmesh_context *kmesh_ctx, struct ip_ad
     address_t target_addr;
     ctx_buff_t *ctx = (ctx_buff_t *)kmesh_ctx->ctx;
     __u64 *sk = (__u64 *)ctx->sk;
-    struct bpf_sock_tuple sk_tuple = {0};
-
-    if (ctx->family == AF_INET) {
-        sk_tuple.ipv4.daddr = kmesh_ctx->orig_dst_addr.ip4;
-        sk_tuple.ipv4.dport = ctx->user_port;
-    } else if (ctx->family == AF_INET6) {
-        bpf_memcpy(sk_tuple.ipv6.daddr, kmesh_ctx->orig_dst_addr.ip6, IPV6_ADDR_LEN);
-        sk_tuple.ipv6.dport = ctx->user_port;
-    }
-
-    ret = bpf_map_update_elem(&map_of_orig_dst, &(sk), &sk_tuple, BPF_NOEXIST);
-    if (ret) {
-        BPF_LOG(ERR, BACKEND, "record original dst address failed: %d\n", ret);
-        return ret;
-    }
 
     if (ctx->user_family == AF_INET)
         kmesh_ctx->dnat_ip.ip4 = wp_addr->ip4;

--- a/bpf/kmesh/workload/include/frontend.h
+++ b/bpf/kmesh/workload/include/frontend.h
@@ -35,7 +35,7 @@ static inline int frontend_manager(struct kmesh_context *kmesh_ctx, frontend_val
     }
 
     if (direct_backend) {
-        // For pod direct access, if a pod has watpoint captured, we will redirect to waypoint, otherwise we do nothing.
+        // For pod direct access, if a pod has waypoint captured, we will redirect to waypoint, otherwise we do nothing.
         if (backend_v->waypoint_port != 0) {
             BPF_LOG(
                 DEBUG,

--- a/bpf/kmesh/workload/sendmsg.c
+++ b/bpf/kmesh/workload/sendmsg.c
@@ -84,8 +84,9 @@ static inline int get_origin_dst(struct sk_msg_md *msg, struct ip_addr *dst_ip, 
     __u64 *current_sk = (__u64 *)msg->sk;
     struct bpf_sock_tuple *dst;
 
-    dst = bpf_map_lookup_elem(&map_of_orig_dst, &current_sk);
-    if (!dst)
+    dst = bpf_map_lookup_elem(&map_of_dst_info, &current_sk);
+    // !dst->ipv4.saddr indicates this is not from waypoint, we just return
+    if (!dst || !dst->ipv4.saddr)
         return -ENOENT;
 
     if (msg->family == AF_INET) {
@@ -96,7 +97,6 @@ static inline int get_origin_dst(struct sk_msg_md *msg, struct ip_addr *dst_ip, 
         *dst_port = dst->ipv6.dport;
     }
 
-    bpf_map_delete_elem(&map_of_orig_dst, &current_sk);
     return 0;
 }
 

--- a/bpf/kmesh/workload/sendmsg.c
+++ b/bpf/kmesh/workload/sendmsg.c
@@ -85,7 +85,7 @@ static inline int get_origin_dst(struct sk_msg_md *msg, struct ip_addr *dst_ip, 
     struct bpf_sock_tuple *dst;
 
     dst = bpf_map_lookup_elem(&map_of_orig_dst, &current_sk);
-    
+
     // !dst->ipv4.saddr indicates this is not from waypoint
     // dst->ipv4.sport indicates this connection is already encoded
     // for circumstances above, we just return
@@ -103,7 +103,7 @@ static inline int get_origin_dst(struct sk_msg_md *msg, struct ip_addr *dst_ip, 
     // since this field is never used, we use it to indicate whether the connection is already encoded
     dst->ipv4.sport = 1;
     int ret = bpf_map_update_elem(&map_of_orig_dst, &current_sk, dst, BPF_EXIST);
-    if (ret) 
+    if (ret)
         BPF_LOG(ERR, SENDMSG, "update dst info failed, ret: %d\n", ret);
 
     return 0;

--- a/bpf/kmesh/workload/sendmsg.c
+++ b/bpf/kmesh/workload/sendmsg.c
@@ -84,7 +84,7 @@ static inline int get_origin_dst(struct sk_msg_md *msg, struct ip_addr *dst_ip, 
     __u64 *current_sk = (__u64 *)msg->sk;
     struct bpf_sock_tuple *dst;
 
-    dst = bpf_map_lookup_elem(&map_of_dst_info, &current_sk);
+    dst = bpf_map_lookup_elem(&map_of_orig_dst, &current_sk);
     
     // !dst->ipv4.saddr indicates this is not from waypoint
     // dst->ipv4.sport indicates this connection is already encoded
@@ -102,7 +102,7 @@ static inline int get_origin_dst(struct sk_msg_md *msg, struct ip_addr *dst_ip, 
 
     // since this field is never used, we use it to indicate whether the connection is already encoded
     dst->ipv4.sport = 1;
-    int ret = bpf_map_update_elem(&map_of_dst_info, &current_sk, dst, BPF_EXIST);
+    int ret = bpf_map_update_elem(&map_of_orig_dst, &current_sk, dst, BPF_EXIST);
     if (ret) 
         BPF_LOG(ERR, SENDMSG, "update dst info failed, ret: %d\n", ret);
 

--- a/bpf/kmesh/workload/sendmsg.c
+++ b/bpf/kmesh/workload/sendmsg.c
@@ -85,8 +85,11 @@ static inline int get_origin_dst(struct sk_msg_md *msg, struct ip_addr *dst_ip, 
     struct bpf_sock_tuple *dst;
 
     dst = bpf_map_lookup_elem(&map_of_dst_info, &current_sk);
-    // !dst->ipv4.saddr indicates this is not from waypoint, we just return
-    if (!dst || !dst->ipv4.saddr)
+    
+    // !dst->ipv4.saddr indicates this is not from waypoint
+    // dst->ipv4.sport indicates this connection is already encoded
+    // for circumstances above, we just return
+    if (!dst || !dst->ipv4.saddr || dst->ipv4.sport)
         return -ENOENT;
 
     if (msg->family == AF_INET) {
@@ -96,6 +99,12 @@ static inline int get_origin_dst(struct sk_msg_md *msg, struct ip_addr *dst_ip, 
         bpf_memcpy(dst_ip->ip6, dst->ipv6.daddr, IPV6_ADDR_LEN);
         *dst_port = dst->ipv6.dport;
     }
+
+    // since this field is never used, we use it to indicate whether the connection is already encoded
+    dst->ipv4.sport = 1;
+    int ret = bpf_map_update_elem(&map_of_dst_info, &current_sk, dst, BPF_EXIST);
+    if (ret) 
+        BPF_LOG(ERR, SENDMSG, "update dst info failed, ret: %d\n", ret);
 
     return 0;
 }

--- a/pkg/controller/telemetry/metric.go
+++ b/pkg/controller/telemetry/metric.go
@@ -87,12 +87,13 @@ type connectionDataV4 struct {
 	_              [6]uint32
 	OriginalAddr   uint32
 	OriginalPort   uint16
-	_              uint16
 	_              [3]uint32
+	_              uint16
 	SentBytes      uint32
 	ReceivedBytes  uint32
 	ConnectSuccess uint32
 	Direction      uint32
+	_              uint32
 	Duration       uint64
 	CloseTime      uint64
 	State          uint32
@@ -111,6 +112,7 @@ type connectionDataV6 struct {
 	ReceivedBytes  uint32
 	ConnectSuccess uint32
 	Direction      uint32
+	_              uint32
 	Duration       uint64
 	CloseTime      uint64
 	State          uint32

--- a/pkg/controller/telemetry/metric_test.go
+++ b/pkg/controller/telemetry/metric_test.go
@@ -28,6 +28,7 @@ import (
 
 	"kmesh.net/kmesh/api/v2/workloadapi"
 	"kmesh.net/kmesh/pkg/controller/workload/cache"
+	"kmesh.net/kmesh/pkg/nets"
 )
 
 func TestCommonTrafficLabels2map(t *testing.T) {
@@ -487,7 +488,34 @@ func TestBuildServiceMetric(t *testing.T) {
 			},
 		},
 	})
+	serviceCache.AddOrUpdateService(&workloadapi.Service{
+		Hostname:  "httpbin.default.svc.cluster.local",
+		Namespace: "default",
+		Name:      "httpbin",
+		Addresses: []*workloadapi.NetworkAddress{
+			{
+				Address: net.ParseIP("192.168.1.23").To4(),
+			},
+		},
+	})
+
 	workloadCache := cache.NewWorkloadCache()
+
+	workloadCache.AddOrUpdateWorkload(&workloadapi.Workload{
+		Namespace:         "default",
+		Name:              "sleep",
+		WorkloadName:      "sleep",
+		CanonicalName:     "sleepCanonical",
+		CanonicalRevision: "sleepVersion",
+		ClusterId:         "Kubernetes",
+		TrustDomain:       "cluster.local",
+		ServiceAccount:    "default",
+		Addresses: [][]byte{
+			{10, 19, 25, 33},
+		},
+	})
+
+	// kmesh workload with service attached
 	workloadCache.AddOrUpdateWorkload(&workloadapi.Workload{
 		Namespace:         "kmesh-system",
 		Name:              "kmesh",
@@ -508,45 +536,25 @@ func TestBuildServiceMetric(t *testing.T) {
 			},
 		},
 		Addresses: [][]byte{
-			{192, 168, 224, 22},
-		},
-	})
-	workloadCache.AddOrUpdateWorkload(&workloadapi.Workload{
-		Namespace:         "kmesh-system",
-		Name:              "kmesh",
-		WorkloadName:      "kmesh-daemon",
-		CanonicalName:     "srcCanonical",
-		CanonicalRevision: "srcVersion",
-		ClusterId:         "Kubernetes",
-		TrustDomain:       "cluster.local",
-		ServiceAccount:    "default",
-		Addresses: [][]byte{
 			{10, 19, 25, 31},
 		},
 	})
+
+	// a solely workload without service attached
 	workloadCache.AddOrUpdateWorkload(&workloadapi.Workload{
 		Namespace:         "default",
-		Name:              "sleep",
-		WorkloadName:      "sleep",
-		CanonicalName:     "sleepCanonical",
-		CanonicalRevision: "sleepVersion",
+		Name:              "solelyWorkload",
+		WorkloadName:      "solelyWorkload",
+		CanonicalName:     "solelyCanonical",
+		CanonicalRevision: "solelyVersion",
 		ClusterId:         "Kubernetes",
 		TrustDomain:       "cluster.local",
 		ServiceAccount:    "default",
 		Addresses: [][]byte{
-			{10, 19, 25, 33},
+			{10, 19, 25, 34},
 		},
 	})
-	serviceCache.AddOrUpdateService(&workloadapi.Service{
-		Hostname:  "httpbin.default.svc.cluster.local",
-		Namespace: "default",
-		Name:      "httpbin",
-		Addresses: []*workloadapi.NetworkAddress{
-			{
-				Address: net.ParseIP("192.168.1.23").To4(),
-			},
-		},
-	})
+
 	workloadCache.AddOrUpdateWorkload(&workloadapi.Workload{
 		Namespace:         "default",
 		Name:              "waypoint",
@@ -560,6 +568,7 @@ func TestBuildServiceMetric(t *testing.T) {
 			{10, 19, 25, 32},
 		},
 	})
+
 	m := MetricController{
 		workloadCache: workloadCache,
 		serviceCache:  serviceCache,
@@ -571,14 +580,17 @@ func TestBuildServiceMetric(t *testing.T) {
 		wantLogInfo logInfo
 	}{
 		{
-			name: "normal capability test",
+			name: "destination exists with service attached, workload-type request",
 			args: args{
 				data: &requestMetric{
-					src:           [4]uint32{521736970, 0, 0, 0},
-					dst:           [4]uint32{383822016, 0, 0, 0},
-					dstPort:       uint16(8000),
-					srcPort:       uint16(8000),
-					origDstAddr:   [4]uint32{383822016, 0, 0, 0},
+					// sleep
+					src: [4]uint32{nets.ConvertIpToUint32("10.19.25.33"), 0, 0, 0},
+					// kmesh-daemon
+					dst:     [4]uint32{nets.ConvertIpToUint32("10.19.25.31"), 0, 0, 0},
+					dstPort: uint16(8000),
+					srcPort: uint16(8000),
+					// kmesh-daemon
+					origDstAddr:   [4]uint32{nets.ConvertIpToUint32("10.19.25.31"), 0, 0, 0},
 					origDstPort:   uint16(8000),
 					direction:     uint32(2),
 					sentBytes:     uint32(156),
@@ -586,13 +598,13 @@ func TestBuildServiceMetric(t *testing.T) {
 				},
 			},
 			want: serviceMetricLabels{
-				sourceWorkload:               "kmesh-daemon",
-				sourceCanonicalService:       "srcCanonical",
-				sourceCanonicalRevision:      "srcVersion",
-				sourceWorkloadNamespace:      "kmesh-system",
-				sourcePrincipal:              "spiffe://cluster.local/ns/kmesh-system/sa/default",
-				sourceApp:                    "srcCanonical",
-				sourceVersion:                "srcVersion",
+				sourceWorkload:               "sleep",
+				sourceCanonicalService:       "sleepCanonical",
+				sourceCanonicalRevision:      "sleepVersion",
+				sourceWorkloadNamespace:      "default",
+				sourcePrincipal:              "spiffe://cluster.local/ns/default/sa/default",
+				sourceApp:                    "sleepCanonical",
+				sourceVersion:                "sleepVersion",
 				sourceCluster:                "Kubernetes",
 				destinationService:           "kmesh.kmesh-system.svc.cluster.local",
 				destinationServiceNamespace:  "kmesh-system",
@@ -612,10 +624,64 @@ func TestBuildServiceMetric(t *testing.T) {
 			},
 			wantLogInfo: logInfo{
 				direction:            "OUTBOUND",
-				sourceAddress:        "10.19.25.31:8000",
-				sourceWorkload:       "kmesh",
-				sourceNamespace:      "kmesh-system",
-				destinationAddress:   "192.168.224.22:8000",
+				sourceAddress:        "10.19.25.33:8000",
+				sourceWorkload:       "sleep",
+				sourceNamespace:      "default",
+				destinationAddress:   "10.19.25.31:8000",
+				destinationService:   "kmesh.kmesh-system.svc.cluster.local",
+				destinationWorkload:  "kmesh",
+				destinationNamespace: "kmesh-system",
+			},
+		},
+		{
+			name: "destination exists with service attached, service-type request",
+			args: args{
+				data: &requestMetric{
+					// sleep
+					src: [4]uint32{nets.ConvertIpToUint32("10.19.25.33"), 0, 0, 0},
+					// kmesh-daemon
+					dst:     [4]uint32{nets.ConvertIpToUint32("10.19.25.31"), 0, 0, 0},
+					dstPort: uint16(8000),
+					srcPort: uint16(8000),
+					// kmesh-daemon
+					origDstAddr:   [4]uint32{nets.ConvertIpToUint32("192.168.1.22"), 0, 0, 0},
+					origDstPort:   uint16(8000),
+					direction:     uint32(2),
+					sentBytes:     uint32(156),
+					receivedBytes: uint32(1024),
+				},
+			},
+			want: serviceMetricLabels{
+				sourceWorkload:               "sleep",
+				sourceCanonicalService:       "sleepCanonical",
+				sourceCanonicalRevision:      "sleepVersion",
+				sourceWorkloadNamespace:      "default",
+				sourcePrincipal:              "spiffe://cluster.local/ns/default/sa/default",
+				sourceApp:                    "sleepCanonical",
+				sourceVersion:                "sleepVersion",
+				sourceCluster:                "Kubernetes",
+				destinationService:           "kmesh.kmesh-system.svc.cluster.local",
+				destinationServiceNamespace:  "kmesh-system",
+				destinationServiceName:       "kmesh",
+				destinationWorkload:          "kmesh-daemon",
+				destinationCanonicalService:  "dstCanonical",
+				destinationCanonicalRevision: "dstVersion",
+				destinationWorkloadNamespace: "kmesh-system",
+				destinationPrincipal:         "spiffe://cluster.local/ns/kmesh-system/sa/default",
+				destinationApp:               "dstCanonical",
+				destinationVersion:           "dstVersion",
+				destinationCluster:           "Kubernetes",
+				requestProtocol:              "tcp",
+				responseFlags:                "",
+				connectionSecurityPolicy:     "mutual_tls",
+				reporter:                     "source",
+			},
+			wantLogInfo: logInfo{
+				direction:            "OUTBOUND",
+				sourceAddress:        "10.19.25.33:8000",
+				sourceWorkload:       "sleep",
+				sourceNamespace:      "default",
+				destinationAddress:   "10.19.25.31:8000",
 				destinationService:   "kmesh.kmesh-system.svc.cluster.local",
 				destinationWorkload:  "kmesh",
 				destinationNamespace: "kmesh-system",
@@ -625,11 +691,14 @@ func TestBuildServiceMetric(t *testing.T) {
 			name: "nil destination workload",
 			args: args{
 				data: &requestMetric{
-					src:           [4]uint32{521736970, 0, 0, 0},
-					dst:           [4]uint32{383822015, 0, 0, 0},
-					dstPort:       uint16(80),
-					srcPort:       uint16(8000),
-					origDstAddr:   [4]uint32{383822015, 0, 0, 0},
+					// sleep
+					src: [4]uint32{nets.ConvertIpToUint32("10.19.25.33"), 0, 0, 0},
+					// unknown address
+					dst:     [4]uint32{nets.ConvertIpToUint32("191.168.224.22"), 0, 0, 0},
+					dstPort: uint16(80),
+					srcPort: uint16(8000),
+					// unknown address
+					origDstAddr:   [4]uint32{nets.ConvertIpToUint32("191.168.224.22"), 0, 0, 0},
 					origDstPort:   uint16(80),
 					direction:     uint32(2),
 					sentBytes:     uint32(156),
@@ -637,13 +706,13 @@ func TestBuildServiceMetric(t *testing.T) {
 				},
 			},
 			want: serviceMetricLabels{
-				sourceWorkload:               "kmesh-daemon",
-				sourceCanonicalService:       "srcCanonical",
-				sourceCanonicalRevision:      "srcVersion",
-				sourceWorkloadNamespace:      "kmesh-system",
-				sourcePrincipal:              "spiffe://cluster.local/ns/kmesh-system/sa/default",
-				sourceApp:                    "srcCanonical",
-				sourceVersion:                "srcVersion",
+				sourceWorkload:               "sleep",
+				sourceCanonicalService:       "sleepCanonical",
+				sourceCanonicalRevision:      "sleepVersion",
+				sourceWorkloadNamespace:      "default",
+				sourcePrincipal:              "spiffe://cluster.local/ns/default/sa/default",
+				sourceApp:                    "sleepCanonical",
+				sourceVersion:                "sleepVersion",
 				sourceCluster:                "Kubernetes",
 				destinationService:           "191.168.224.22",
 				destinationServiceNamespace:  "",
@@ -663,9 +732,9 @@ func TestBuildServiceMetric(t *testing.T) {
 			},
 			wantLogInfo: logInfo{
 				direction:            "OUTBOUND",
-				sourceAddress:        "10.19.25.31:8000",
-				sourceWorkload:       "kmesh",
-				sourceNamespace:      "kmesh-system",
+				sourceAddress:        "10.19.25.33:8000",
+				sourceWorkload:       "sleep",
+				sourceNamespace:      "default",
 				destinationAddress:   "191.168.224.22:80",
 				destinationService:   "191.168.224.22",
 				destinationWorkload:  "-",
@@ -673,17 +742,17 @@ func TestBuildServiceMetric(t *testing.T) {
 			},
 		},
 		{
-			name: "redirected to waypoint",
+			name: "service-type request, redirected to waypoint",
 			args: args{
 				data: &requestMetric{
-					// address 10.19.25.33, sleep
-					src:     [4]uint32{555291402, 0, 0, 0},
+					// sleep
+					src:     [4]uint32{nets.ConvertIpToUint32("10.19.25.33"), 0, 0, 0},
 					srcPort: uint16(49875),
-					// address 10.19.25.32, waypoint
-					dst:     [4]uint32{538514186, 0, 0, 0},
+					// waypoint
+					dst:     [4]uint32{nets.ConvertIpToUint32("10.19.25.32"), 0, 0, 0},
 					dstPort: uint16(80),
-					// address 192.168.1.23, httpbin service
-					origDstAddr:   [4]uint32{385984704, 0, 0, 0},
+					// httpbin service
+					origDstAddr:   [4]uint32{nets.ConvertIpToUint32("192.168.1.23"), 0, 0, 0},
 					origDstPort:   uint16(80),
 					direction:     uint32(2),
 					sentBytes:     uint32(156),
@@ -723,6 +792,114 @@ func TestBuildServiceMetric(t *testing.T) {
 				destinationAddress:   "10.19.25.32:80",
 				destinationService:   "httpbin.default.svc.cluster.local",
 				destinationWorkload:  "waypoint",
+				destinationNamespace: "default",
+			},
+		},
+		{
+			name: "workload-type request, redirected to waypoint",
+			args: args{
+				data: &requestMetric{
+					// sleep
+					src:     [4]uint32{nets.ConvertIpToUint32("10.19.25.33"), 0, 0, 0},
+					srcPort: uint16(49875),
+					// waypoint
+					dst:     [4]uint32{nets.ConvertIpToUint32("10.19.25.32"), 0, 0, 0},
+					dstPort: uint16(80),
+					// solelyWorkload
+					origDstAddr:   [4]uint32{nets.ConvertIpToUint32("10.19.25.34"), 0, 0, 0},
+					origDstPort:   uint16(80),
+					direction:     uint32(2),
+					sentBytes:     uint32(156),
+					receivedBytes: uint32(1024),
+				},
+			},
+			want: serviceMetricLabels{
+				sourceWorkload:               "sleep",
+				sourceCanonicalService:       "sleepCanonical",
+				sourceCanonicalRevision:      "sleepVersion",
+				sourceWorkloadNamespace:      "default",
+				sourcePrincipal:              "spiffe://cluster.local/ns/default/sa/default",
+				sourceApp:                    "sleepCanonical",
+				sourceVersion:                "sleepVersion",
+				sourceCluster:                "Kubernetes",
+				destinationService:           "10.19.25.34",
+				destinationServiceNamespace:  "default",
+				destinationServiceName:       "",
+				destinationWorkload:          "waypoint",
+				destinationCanonicalService:  "waypointCanonical",
+				destinationCanonicalRevision: "waypointVersion",
+				destinationWorkloadNamespace: "default",
+				destinationPrincipal:         "spiffe://cluster.local/ns/default/sa/default",
+				destinationApp:               "waypointCanonical",
+				destinationVersion:           "waypointVersion",
+				destinationCluster:           "Kubernetes",
+				requestProtocol:              "tcp",
+				responseFlags:                "",
+				connectionSecurityPolicy:     "mutual_tls",
+				reporter:                     "source",
+			},
+			wantLogInfo: logInfo{
+				direction:            "OUTBOUND",
+				sourceAddress:        "10.19.25.33:49875",
+				sourceWorkload:       "sleep",
+				sourceNamespace:      "default",
+				destinationAddress:   "10.19.25.32:80",
+				destinationService:   "10.19.25.34",
+				destinationWorkload:  "waypoint",
+				destinationNamespace: "default",
+			},
+		},
+		{
+			name: "destination workload exists without service attached",
+			args: args{
+				data: &requestMetric{
+					// sleep
+					src:     [4]uint32{nets.ConvertIpToUint32("10.19.25.33"), 0, 0, 0},
+					srcPort: uint16(49875),
+					// solely workload
+					dst:     [4]uint32{nets.ConvertIpToUint32("10.19.25.34"), 0, 0, 0},
+					dstPort: uint16(80),
+					// httpbin service
+					origDstAddr:   [4]uint32{nets.ConvertIpToUint32("10.19.25.34"), 0, 0, 0},
+					origDstPort:   uint16(80),
+					direction:     uint32(2),
+					sentBytes:     uint32(156),
+					receivedBytes: uint32(1024),
+				},
+			},
+			want: serviceMetricLabels{
+				sourceWorkload:               "sleep",
+				sourceCanonicalService:       "sleepCanonical",
+				sourceCanonicalRevision:      "sleepVersion",
+				sourceWorkloadNamespace:      "default",
+				sourcePrincipal:              "spiffe://cluster.local/ns/default/sa/default",
+				sourceApp:                    "sleepCanonical",
+				sourceVersion:                "sleepVersion",
+				sourceCluster:                "Kubernetes",
+				destinationService:           "10.19.25.34",
+				destinationServiceNamespace:  "default",
+				destinationServiceName:       "",
+				destinationWorkload:          "solelyWorkload",
+				destinationCanonicalService:  "solelyCanonical",
+				destinationCanonicalRevision: "solelyVersion",
+				destinationWorkloadNamespace: "default",
+				destinationPrincipal:         "spiffe://cluster.local/ns/default/sa/default",
+				destinationApp:               "solelyCanonical",
+				destinationVersion:           "solelyVersion",
+				destinationCluster:           "Kubernetes",
+				requestProtocol:              "tcp",
+				responseFlags:                "",
+				connectionSecurityPolicy:     "mutual_tls",
+				reporter:                     "source",
+			},
+			wantLogInfo: logInfo{
+				direction:            "OUTBOUND",
+				sourceAddress:        "10.19.25.33:49875",
+				sourceWorkload:       "sleep",
+				sourceNamespace:      "default",
+				destinationAddress:   "10.19.25.34:80",
+				destinationService:   "10.19.25.34",
+				destinationWorkload:  "solelyWorkload",
 				destinationNamespace: "default",
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind enhancement

-->

**What this PR does / why we need it**:
Currently kmesh get destination service info by looking up from the services of a workload, which may not properly handle circumstances below:
1. multiple services with same workload backend, for example, `example-a.com` and `example-b.com` share the same workload backend, and the ports of them are exactly the same, currently kmesh can only guess the destination service since currently only workload info is passed to the metric controller.
2. for requests redirected to the waypoint, the metrics will be like:
```shell
kmesh_tcp_connections_closed_total{destination_app="reviews-svc-waypoint",destination_service_name="reviews-svc-waypoint"...} 14
```
both `destination_app` and `destination_service` will be the waypoint, and we can not know where the intended destination of the request is, which may be a little bit confusing.

To solve the issues mentioned before, I passed the original destination info to the metric controller so that we can know where the intended destination of the request is instead of the actual destination of the connection.

By doing this, we do not need to guess the destination service when we send request to a service, and the waypoint metric will be like:
```shell
# destination_service_name is `reviews` instead of `reviews-svc-waypoint`
kmesh_tcp_connections_closed_total{destination_app="reviews-svc-waypoint",destination_service_name="reviews"...} 14
```
from where we can know what the intended service is.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
