### PR TITLE
fix Update mode failed

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -188,11 +188,14 @@ func (l *BpfLoader) Stop() {
 
 func NewVersionMap(config *options.BpfConfig) *ebpf.Map {
 	var versionPath string
+	var kmBpfPath string
 	var versionMap *ebpf.Map
 	if config.KernelNativeEnabled() {
 		versionPath = filepath.Join(config.BpfFsPath, constants.VersionPath)
+		kmBpfPath = filepath.Join(config.BpfFsPath, constants.KmKernelNativeBpfPath)
 	} else if config.DualEngineEnabled() {
 		versionPath = filepath.Join(config.BpfFsPath, constants.WorkloadVersionPath)
+		kmBpfPath = filepath.Join(config.BpfFsPath, constants.KmDualEngineBpfPath)
 	}
 
 	versionMapPinPath := filepath.Join(versionPath, "kmesh_version")
@@ -214,7 +217,7 @@ func NewVersionMap(config *options.BpfConfig) *ebpf.Map {
 	}
 
 	// Make sure the directory about to use is clean
-	err = os.RemoveAll(versionPath)
+	err = os.RemoveAll(kmBpfPath)
 	if err != nil {
 		log.Errorf("Clean bpf maps and progs failed, err is:%v", err)
 		return nil

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -73,6 +73,9 @@ const (
 	VersionPath         = "/bpf_kmesh/map/"
 	WorkloadVersionPath = "/bpf_kmesh_workload/map/"
 
+	KmKernelNativeBpfPath = "/bpf_kmesh"
+	KmDualEngineBpfPath   = "/bpf_kmesh_workload"
+
 	TailCallMap = "tail_call_map"
 	Prog_link   = "prog_link"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
kmesh currently does not support Update mode. When starting from Update mode, it should start in Normal mode. However, all residual data is not properly cleared, resulting in a startup error.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
