### PR TITLE
Improve Authz UX: Immediate Feedback & Status Subcommand

### DIFF
--- a/ctl/authz/authz.go
+++ b/ctl/authz/authz.go
@@ -57,7 +57,7 @@ func NewEnableCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "enable [podNames...]",
 		Short:   "Enable xdp authz eBPF program for Kmesh's authz offloading",
-		Example: "kmeshctl authz enable\nkmeshctl authz pod1 pod2 enable",
+		Example: "kmeshctl authz enable\nkmeshctl authz enable pod1 pod2",
 		Args:    cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			// If no pod names are given, apply to all kmesh daemon pods.
@@ -73,7 +73,7 @@ func NewDisableCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "disable [podNames...]",
 		Short:   "Disable xdp authz eBPF program for Kmesh's authz offloading",
-		Example: "kmeshctl authz disable\nkmeshctl authz pod1 pod2 disable",
+		Example: "kmeshctl authz disable\nkmeshctl authz disable pod1 pod2",
 		Args:    cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			SetAuthzForPods(args, "false")
@@ -112,12 +112,14 @@ func NewStatusCmd() *cobra.Command {
 				podNames = args
 			}
 
-			// Collect the status for each pod.
+			// Prepare a slice of podStatuses. We can pre-allocate since we know how many pods we'll check.
 			type podStatus struct {
 				Pod    string
 				Status string
 			}
-			var statuses []podStatus
+			statuses := make([]podStatus, 0, len(podNames))
+
+			// Collect the status for each pod.
 			for _, podName := range podNames {
 				status, err := fetchAuthzStatus(cli, podName)
 				if err != nil {

--- a/ctl/authz/authz.go
+++ b/ctl/authz/authz.go
@@ -19,6 +19,7 @@ package authz
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 
@@ -35,43 +36,95 @@ const (
 
 var log = logger.NewLoggerScope("kmeshctl/authz")
 
+// NewCmd returns the root authz command with its subcommands.
 func NewCmd() *cobra.Command {
-	cmd := &cobra.Command{
+	authzCmd := &cobra.Command{
 		Use:   "authz",
-		Short: "Enable or disable xdp authz eBPF Prog for Kmesh's authz offloading",
-		Example: `# Enable/Disable Kmesh's authz offloading in the specified kmesh daemon:
- kmeshctl authz <kmesh-daemon-pod> enable/disable
- 
- # If you want to enable or disable authz offloading of all Kmeshs in the cluster
- kmeshctl authz enable/disable`,
-		Args: cobra.MinimumNArgs(1),
+		Short: "Manage xdp authz eBPF program for Kmesh's authz offloading",
+	}
+
+	authzCmd.AddCommand(NewEnableCmd())
+	authzCmd.AddCommand(NewDisableCmd())
+	authzCmd.AddCommand(NewStatusCmd())
+
+	return authzCmd
+}
+
+// NewEnableCmd creates a command to enable authz.
+func NewEnableCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "enable [podNames...]",
+		Short:   "Enable xdp authz eBPF program for Kmesh's authz offloading",
+		Example: "kmeshctl authz enable\nkmeshctl authz pod1 pod2 enable",
+		Args:    cobra.ArbitraryArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			SetAuthz(cmd, args)
+			// If no pod names are given, apply to all kmesh daemon pods.
+			SetAuthzForPods(args, "true")
+			fmt.Println("Authorization has been enabled.")
 		},
 	}
 	return cmd
 }
 
-func SetAuthz(cmd *cobra.Command, args []string) {
-	var info string
-	authzFlag := args[len(args)-1]
-	if authzFlag == "enable" {
-		info = "true"
-	} else if authzFlag == "disable" {
-		info = "false"
-	} else {
-		log.Errorf("Error: Argument must be 'enable' or 'disable'")
-		os.Exit(1)
+// NewDisableCmd creates a command to disable authz.
+func NewDisableCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "disable [podNames...]",
+		Short:   "Disable xdp authz eBPF program for Kmesh's authz offloading",
+		Example: "kmeshctl authz disable\nkmeshctl authz pod1 pod2 disable",
+		Args:    cobra.ArbitraryArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			SetAuthzForPods(args, "false")
+			fmt.Println("Authorization has been disabled.")
+		},
 	}
+	return cmd
+}
 
+// NewStatusCmd creates a command to display the current authz status.
+func NewStatusCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "status [podNames...]",
+		Short:   "Display the current authorization status",
+		Example: "kmeshctl authz status\nkmeshctl authz pod1 pod2 status",
+		Args:    cobra.ArbitraryArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			cli, err := utils.CreateKubeClient()
+			if err != nil {
+				log.Errorf("failed to create cli client: %v", err)
+				os.Exit(1)
+			}
+			// If no pod names are provided, check all kmesh daemon pods.
+			if len(args) == 0 {
+				podList, err := cli.PodsForSelector(context.TODO(), utils.KmeshNamespace, utils.KmeshLabel)
+				if err != nil {
+					log.Errorf("failed to get kmesh podList: %v", err)
+					os.Exit(1)
+				}
+				for _, pod := range podList.Items {
+					GetAuthzStatusPerKmeshDaemon(cli, pod.GetName())
+				}
+			} else {
+				for _, podName := range args {
+					GetAuthzStatusPerKmeshDaemon(cli, podName)
+				}
+			}
+		},
+	}
+	return cmd
+}
+
+// SetAuthzForPods applies the authz setting (enable/disable) for the given pod(s).
+// If no pod names are specified, it applies the setting to all kmesh daemon pods.
+func SetAuthzForPods(podNames []string, info string) {
 	cli, err := utils.CreateKubeClient()
 	if err != nil {
 		log.Errorf("failed to create cli client: %v", err)
 		os.Exit(1)
 	}
 
-	if len(args) == 1 {
-		// Perform operations on all kmesh daemons.
+	if len(podNames) == 0 {
+		// Apply to all kmesh daemon pods.
 		podList, err := cli.PodsForSelector(context.TODO(), utils.KmeshNamespace, utils.KmeshLabel)
 		if err != nil {
 			log.Errorf("failed to get kmesh podList: %v", err)
@@ -81,13 +134,15 @@ func SetAuthz(cmd *cobra.Command, args []string) {
 			SetAuthzPerKmeshDaemon(cli, pod.GetName(), info)
 		}
 	} else {
-		// Processes authz triggers for specified kmesh daemon.
-		for _, podname := range args[:len(args)-1] {
-			SetAuthzPerKmeshDaemon(cli, podname, info)
+		// Process for specified pods.
+		for _, podName := range podNames {
+			SetAuthzPerKmeshDaemon(cli, podName, info)
 		}
 	}
 }
 
+// SetAuthzPerKmeshDaemon sends a POST request to a specific kmesh daemon pod
+// to set the authz flag based on the info parameter ("true" or "false").
 func SetAuthzPerKmeshDaemon(cli kube.CLIClient, podName, info string) {
 	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
 	if err != nil {
@@ -121,4 +176,50 @@ func SetAuthzPerKmeshDaemon(cli kube.CLIClient, podName, info string) {
 		log.Errorf("Error: received status code %d", resp.StatusCode)
 		return
 	}
+}
+
+// GetAuthzStatusPerKmeshDaemon sends a GET request to a specific kmesh daemon pod
+// to retrieve the current authz status and prints it.
+func GetAuthzStatusPerKmeshDaemon(cli kube.CLIClient, podName string) {
+	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
+	if err != nil {
+		log.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
+		os.Exit(1)
+	}
+	if err := fw.Start(); err != nil {
+		log.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
+		os.Exit(1)
+	}
+	defer fw.Close()
+
+	url := fmt.Sprintf("http://%s%s", fw.Address(), patternAuthz)
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		log.Errorf("Error creating request: %v", err)
+		return
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Errorf("failed to make HTTP request: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		log.Errorf("Error: received status code %d", resp.StatusCode)
+		return
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		log.Errorf("failed to read response body: %v", err)
+		return
+	}
+
+	status := string(bodyBytes)
+	fmt.Printf("Pod %s: Authorization status: %s\n", podName, status)
 }


### PR DESCRIPTION
- Added confirmation messages in the 'enable' and 'disable' commands to inform users
  when authorization offloading is successfully enabled or disabled.
- Introduced a new 'status' subcommand that queries and displays the current authorization
  status from the Kmesh daemon pod(s).
- Refactored authz command handling to support both single and multiple pod scenarios.
- These improvements enhance the overall user experience and provide better debugging
  and verification of authz state.

Fixes #1181 
