### PR TITLE
Added changes to generated api file under same package

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -21,7 +21,7 @@ include ../mk/bpf.print.mk
 include ../mk/bpf.vars.mk
 
 C_OUTPUT_DIR := v2-c
-GO_OUTPUT_DIR := v2
+GO_OUTPUT_DIR := kmesh/api/workloadapi
 GO_BUILD_DIR := kmesh.net/kmesh/api
 
 PROTO_PATH := ../


### PR DESCRIPTION
**What type of PR is this?**
### Added changes to `Makefile` to make protobuf generated api file under same package with .proto
/kind bug

**What this PR does / why we need it**:
This add nessacry change to `Makefile` to generate the file inside the same directory using `protoc --proto_path=. --go_out=. --go_opt=paths=source_relative workloadapi/workload.proto`
**Which issue(s) this PR fixes**:
Fixes #1024 

**Special notes for your reviewer**:
**checking to CI because of arm64**

