### PR TITLE
Fix #134: Workflow to sync code from GitHub to Gitee upon a new release

### DIFF
--- a/.github/workflows/sync-to-gitee.yml
+++ b/.github/workflows/sync-to-gitee.yml
@@ -1,0 +1,17 @@
+name: Sync to Gitee on Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  sync-to-gitee:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Mirror to Gitee
+        uses: wearerequired/git-mirror-action@v1
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.GITEE_SSH_PRIVATE_KEY }}
+        with:
+          source-repo: 'git@github.com:kmesh-net/kmesh.git'
+          destination-repo: 'git@gitee.com:target.repo.git'


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:  Github Action Workflow to sync code from GitHub to Gitee upon a new release using the wearerequired/git-mirror-action.

**Which issue(s) this PR fixes**:
Fixes #134

**Special notes for your reviewer**:

- I was not able to get link to ```destination-repo: 'git@gitee.com:target.repo.git' ``` it would be great if you can provide it.
- Add a private key to GitHub secret named `GITEE_SSH_PRIVATE_KEY`

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
NONE
```release-note

```
