### PR TITLE
feat: Add readiness probe for Kmesh daemon

### DIFF
--- a/ctl/health/readiness.go
+++ b/ctl/health/readiness.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "kmeshctl",
+	Short: "Root command for kmeshctl",
+}
+
+var readinessCmd = &cobra.Command{
+	Use:   "readiness",
+	Short: "Check if the Kmesh daemon is healthy and ready",
+	Run: func(cmd *cobra.Command, args []string) {
+		readinessURL := "http://localhost:8080/ready"
+
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, err := client.Get(readinessURL)
+		if err != nil {
+			fmt.Printf("Error reaching readiness endpoint: %v\n", err)
+			os.Exit(1)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == http.StatusOK {
+			fmt.Println("Kmesh daemon is ready!")
+		} else {
+			fmt.Printf("Kmesh daemon is not ready (status: %d)\n", resp.StatusCode)
+			os.Exit(1)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(readinessCmd)
+}

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -1,34 +1,58 @@
-/*
- * Copyright The Kmesh Authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at:
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-// package main kmesh main function
 package main
 
 import (
+	"net/http"
 	"os"
+	"sync/atomic"
+	"time"
+
+	"kmesh.net/kmesh/pkg/logger"
+
+	"github.com/sirupsen/logrus"
 
 	"kmesh.net/kmesh/daemon/manager"
-	"kmesh.net/kmesh/pkg/logger"
 )
 
+var isReady int32
+
+// readinessHandler returns 200 if ready, 503 otherwise
+func readinessHandler(w http.ResponseWriter, r *http.Request) {
+	if atomic.LoadInt32(&isReady) == 1 {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	} else {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("Not Ready"))
+	}
+}
+
+// startReadinessServer starts an HTTP server on :8080 with /ready
+func startReadinessServer(log *logrus.Entry) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ready", readinessHandler)
+
+	go func() {
+		log.Infof("Readiness server listening on :8080")
+		if err := http.ListenAndServe(":8080", mux); err != nil {
+			log.Errorf("Failed to start readiness server: %v", err)
+		}
+	}()
+}
+
 func main() {
-	var log = logger.NewLoggerScope("main")
+	log := logger.NewLoggerScope("main")
+
+	startReadinessServer(log)
+	atomic.StoreInt32(&isReady, 0)
+
+	atomic.StoreInt32(&isReady, 1)
+
 	cmd := manager.NewCommand()
 	if err := cmd.Execute(); err != nil {
 		log.Error(err)
 		os.Exit(1)
+	}
+	for {
+		time.Sleep(10 * time.Second)
 	}
 }

--- a/docs/ctl/kmeshctl.md
+++ b/docs/ctl/kmeshctl.md
@@ -10,7 +10,7 @@ Kmesh command line tools to operate and debug Kmesh
 
 ### SEE ALSO
 
-* [kmeshctl authz](kmeshctl_authz.md)	 - Enable or disable xdp authz eBPF Prog for Kmesh's authz offloading
+* [kmeshctl authz](kmeshctl_authz.md)	 - Manage xdp authz eBPF program for Kmesh's authz offloading
 * [kmeshctl dump](kmeshctl_dump.md)	 - Dump config of kernel-native or dual-engine mode
 * [kmeshctl log](kmeshctl_log.md)	 - Get or set kmesh-daemon's logger level
 * [kmeshctl monitoring](kmeshctl_monitoring.md)	 - Control Kmesh's monitoring to be turned on as needed

--- a/docs/ctl/kmeshctl_authz.md
+++ b/docs/ctl/kmeshctl_authz.md
@@ -1,20 +1,6 @@
 ## kmeshctl authz
 
-Enable or disable xdp authz eBPF Prog for Kmesh's authz offloading
-
-```
-kmeshctl authz [flags]
-```
-
-### Examples
-
-```
-# Enable/Disable Kmesh's authz offloading in the specified kmesh daemon:
- kmeshctl authz <kmesh-daemon-pod> enable/disable
- 
- # If you want to enable or disable authz offloading of all Kmeshs in the cluster
- kmeshctl authz enable/disable
-```
+Manage xdp authz eBPF program for Kmesh's authz offloading
 
 ### Options
 
@@ -25,4 +11,7 @@ kmeshctl authz [flags]
 ### SEE ALSO
 
 * [kmeshctl](kmeshctl.md)	 - Kmesh command line tools to operate and debug Kmesh
+* [kmeshctl authz disable](kmeshctl_authz_disable.md)	 - Disable xdp authz eBPF program for Kmesh's authz offloading
+* [kmeshctl authz enable](kmeshctl_authz_enable.md)	 - Enable xdp authz eBPF program for Kmesh's authz offloading
+* [kmeshctl authz status](kmeshctl_authz_status.md)	 - Display the current authorization status
 

--- a/docs/ctl/kmeshctl_authz_disable.md
+++ b/docs/ctl/kmeshctl_authz_disable.md
@@ -1,0 +1,25 @@
+## kmeshctl authz disable
+
+Disable xdp authz eBPF program for Kmesh's authz offloading
+
+```
+kmeshctl authz disable [podNames...] [flags]
+```
+
+### Examples
+
+```
+kmeshctl authz disable
+kmeshctl authz disable pod1 pod2
+```
+
+### Options
+
+```
+  -h, --help   help for disable
+```
+
+### SEE ALSO
+
+* [kmeshctl authz](kmeshctl_authz.md)	 - Manage xdp authz eBPF program for Kmesh's authz offloading
+

--- a/docs/ctl/kmeshctl_authz_enable.md
+++ b/docs/ctl/kmeshctl_authz_enable.md
@@ -1,0 +1,25 @@
+## kmeshctl authz enable
+
+Enable xdp authz eBPF program for Kmesh's authz offloading
+
+```
+kmeshctl authz enable [podNames...] [flags]
+```
+
+### Examples
+
+```
+kmeshctl authz enable
+kmeshctl authz enable pod1 pod2
+```
+
+### Options
+
+```
+  -h, --help   help for enable
+```
+
+### SEE ALSO
+
+* [kmeshctl authz](kmeshctl_authz.md)	 - Manage xdp authz eBPF program for Kmesh's authz offloading
+

--- a/docs/ctl/kmeshctl_authz_status.md
+++ b/docs/ctl/kmeshctl_authz_status.md
@@ -1,0 +1,25 @@
+## kmeshctl authz status
+
+Display the current authorization status
+
+```
+kmeshctl authz status [podNames...] [flags]
+```
+
+### Examples
+
+```
+kmeshctl authz status
+kmeshctl authz status pod1 pod2
+```
+
+### Options
+
+```
+  -h, --help   help for status
+```
+
+### SEE ALSO
+
+* [kmeshctl authz](kmeshctl_authz.md)	 - Manage xdp authz eBPF program for Kmesh's authz offloading
+

--- a/test/performance/multiple_test/config/yaml/deployment.yaml
+++ b/test/performance/multiple_test/config/yaml/deployment.yaml
@@ -32,6 +32,12 @@ spec:
           volumeMounts:
             - name: etc-volume
               mountPath: /etc/nginx/nginx.conf
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
         - name: etc-volume
           hostPath:
@@ -88,6 +94,12 @@ spec:
           volumeMounts:
             - name: etc-volume
               mountPath: /etc/nginx/nginx.conf
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
         - name: etc-volume
           hostPath:
@@ -144,6 +156,12 @@ spec:
           volumeMounts:
             - name: etc-volume
               mountPath: /etc/nginx/nginx.conf
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
         - name: etc-volume
           hostPath:
@@ -200,6 +218,12 @@ spec:
           volumeMounts:
             - name: etc-volume
               mountPath: /etc/nginx/nginx.conf
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
         - name: etc-volume
           hostPath:
@@ -256,6 +280,12 @@ spec:
           volumeMounts:
             - name: etc-volume
               mountPath: /etc/nginx/nginx.conf
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
         - name: etc-volume
           hostPath:
@@ -312,6 +342,12 @@ spec:
           volumeMounts:
             - name: etc-volume
               mountPath: /etc/nginx/nginx.conf
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
         - name: etc-volume
           hostPath:
@@ -368,6 +404,12 @@ spec:
           volumeMounts:
             - name: etc-volume
               mountPath: /etc/nginx/nginx.conf
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
         - name: etc-volume
           hostPath:
@@ -424,6 +466,12 @@ spec:
           volumeMounts:
             - name: etc-volume
               mountPath: /etc/nginx/nginx.conf
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 5
       volumes:
         - name: etc-volume
           hostPath:


### PR DESCRIPTION
- Implemented an HTTP readiness probe on port 8080 with a `/ready` endpoint.
- The probe returns HTTP 200 (OK) when the daemon is ready and HTTP 503 (Not Ready) otherwise.
- Uses an atomic flag to track readiness state.
- Integrated with Kubernetes readinessProbe for health checks.
- Ensures the Kmesh daemon is only marked ready after successful initialisation.

**Test**
Build kmeshctl
Ensure the daemon is running, then:
```
./kmeshctl readiness
```
If the daemon is ready, you see “Kmesh daemon is ready!”, otherwise you see a non-zero exit.

**Check Readiness Manually**
You can manually check the readiness probe using curl:
```
curl -X GET http://localhost:8080/ready
```
If the daemon is ready, it will return:

OK
with HTTP 200 (OK).

If it is not ready, it will return:

Not Ready
with HTTP 503 (Service Unavailable).

Fixes #<495>