### PR TITLE
optimizie xdp auth

### DIFF
--- a/bpf/kmesh/workload/include/authz.h
+++ b/bpf/kmesh/workload/include/authz.h
@@ -574,6 +574,9 @@ int policies_check(struct xdp_md *ctx)
     }
     policy = map_lookup_authz(policyId);
     if (!policy) {
+        // Currently, authz in xdp only support ip and port,
+        // if any principal or namespace type policy is configured,
+        // we need to tailcall to userspace.
         if (match_ctx->need_tailcall_to_userspace) {
             bpf_tail_call(ctx, &map_of_xdp_tailcall, TAIL_CALL_AUTH_IN_USER_SPACE);
             return XDP_PASS;

--- a/bpf/kmesh/workload/xdp.c
+++ b/bpf/kmesh/workload/xdp.c
@@ -132,6 +132,7 @@ int xdp_authz(struct xdp_md *ctx)
         match_ctx.policies = policies;
         match_ctx.need_tailcall_to_userspace = false;
         match_ctx.policy_index = 0;
+        match_ctx.auth_result = XDP_PASS;
         ret = bpf_map_update_elem(&kmesh_tc_args, &tuple_key, &match_ctx, BPF_ANY);
         if (ret < 0) {
             BPF_LOG(ERR, AUTH, "Failed to update map, error: %d", ret);


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1207 
```
Previously, since the xdp program only supports ip and port, policies configured with ns and principal types need to be
switched to user mode. However, the logic for determining whether to switch to user mode was wrong. The previous logic
was that when policy_index is greater than `MAX_MEMBER_NUM_PER_POLICY`, it will determine whether to switch to
user mode. However, `MAX_MEMBER_NUM_PER_POLICY` is a fixed value, and the number of deployed policies may be
less than this number.
The correct logic should be to traverse all policies in xdp. In each policy, if the policy does not match, the result of authz
will be stored in `match_ctx->auth_result`. If all policies are traversed and ns or principal rules are deployed, switch to
user mode. If it is not necessary to switch to user mode, return directly according to `match_ctx->auth_result`
```

###authz explanation and cases
#### B → C Traffic Authorization Policy Result

| Case  | Policy Scope             | Policy Rules          | Result  | Logic Description                   |
|-------|--------------------------|-----------------------|---------|--------------------------------------|
| 1     | Single B-targeted       | `allow B`             | PASS    | Direct match                        |
| 2     | Single B-targeted       | `deny B`              | DROP    | Direct match                        |
| 3     | Single non-B target     | `allow A`             | DROP    | Non-target defaults to deny         |
| 4     | Single non-B target     | `deny A`              | PASS    | Non-target defaults to allow        |
| 5     | Mixed (contains B)      | `allow B` + `deny A`  | PASS    | B-target priority                   |
| 6     | Mixed (contains B)      | `deny B` + `allow A`  | DROP    | B-target priority                   |
| 7     | Multi-B (ordered)       | `allow B` → `deny B`  | PASS    | First-match execution               |
| 8     | Multi-B (ordered)       | `deny B` → `allow B`  | DROP    | First-match execution               |


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
