### PR TITLE
new kernel bugfix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,8 +82,7 @@ ifeq ($(TAG),)
   $(error "TAG cannot be empty")
 endif
 
-TMP_FILES := bpf/kmesh/bpf2go/bpf2go.go \
-	config/kmesh_marcos_def.h \
+TMP_FILES := config/kmesh_marcos_def.h \
 	mk/api-v2-c.pc \
 	mk/bpf.pc \
 	bpf/include/bpf_helper_defs_ext.h \

--- a/bpf/include/bpf_common.h
+++ b/bpf/include/bpf_common.h
@@ -223,4 +223,86 @@ static inline void *get_ptr_val_from_map(void *map, __u8 map_type, const void *p
         val_tmp;                                                                                                       \
     })
 
+static inline void record_kmesh_managed_ip(__u32 family, __u32 ip4, __u32 *ip6)
+{
+    int err;
+    __u32 value = 0;
+    struct manager_key key = {0};
+    if (family == AF_INET)
+        key.addr.ip4 = ip4;
+    if (family == AF_INET6 && ip6)
+        IP6_COPY(key.addr.ip6, ip6);
+
+    err = bpf_map_update_elem(&map_of_manager, &key, &value, BPF_ANY);
+    if (err)
+        BPF_LOG(ERR, KMESH, "record ip failed!, err is %d\n", err);
+}
+
+static inline void remove_kmesh_managed_ip(__u32 family, __u32 ip4, __u32 *ip6)
+{
+    struct manager_key key = {0};
+    if (family == AF_INET)
+        key.addr.ip4 = ip4;
+    if (family == AF_INET6 && ip6)
+        IP6_COPY(key.addr.ip6, ip6);
+
+    int err = bpf_map_delete_elem(&map_of_manager, &key);
+    if (err && err != -ENOENT)
+        BPF_LOG(ERR, KMESH, "remove ip failed!, err is %d\n", err);
+}
+
+static inline bool conn_from_sim(struct bpf_sock_ops *skops, __u32 ip, __u16 port)
+{
+    __u16 remote_port = GET_SKOPS_REMOTE_PORT(skops);
+    if (bpf_ntohs(remote_port) != port)
+        return false;
+
+    if (skops->family == AF_INET)
+        return (bpf_ntohl(skops->remote_ip4) == ip);
+
+    return (
+        skops->remote_ip6[0] == 0 && skops->remote_ip6[1] == 0 && skops->remote_ip6[2] == 0
+        && bpf_ntohl(skops->remote_ip6[3]) == ip);
+}
+
+static inline bool skops_conn_from_cni_sim_add(struct bpf_sock_ops *skops)
+{
+    // cni sim connect CONTROL_CMD_IP:929(0x3a1)
+    // 0x3a1 is the specific port handled by the cni to enable Kmesh
+    return conn_from_sim(skops, CONTROL_CMD_IP, ENABLE_KMESH_PORT);
+}
+
+static inline bool skops_conn_from_cni_sim_delete(struct bpf_sock_ops *skops)
+{
+    // cni sim connect CONTROL_CMD_IP:930(0x3a2)
+    // 0x3a2 is the specific port handled by the cni to disable Kmesh
+    return conn_from_sim(skops, CONTROL_CMD_IP, DISABLE_KMESH_PORT);
+}
+
+static inline void skops_handle_kmesh_managed_process(struct bpf_sock_ops *skops)
+{
+    if (skops_conn_from_cni_sim_add(skops))
+        record_kmesh_managed_ip(skops->family, skops->local_ip4, skops->local_ip6);
+    if (skops_conn_from_cni_sim_delete(skops))
+        remove_kmesh_managed_ip(skops->family, skops->local_ip4, skops->local_ip6);
+}
+
+static inline bool is_managed_by_kmesh(struct bpf_sock_ops *skops)
+{
+    struct manager_key key = {0};
+    if (skops->family == AF_INET)
+        key.addr.ip4 = skops->local_ip4;
+    if (skops->family == AF_INET6) {
+        if (is_ipv4_mapped_addr(skops->local_ip6))
+            key.addr.ip4 = skops->local_ip6[3];
+        else
+            IP6_COPY(key.addr.ip6, skops->local_ip6);
+    }
+
+    int *value = bpf_map_lookup_elem(&map_of_manager, &key);
+    if (!value)
+        return false;
+    return (*value == 0);
+}
+
 #endif

--- a/bpf/kmesh/ads/sockops.c
+++ b/bpf/kmesh/ads/sockops.c
@@ -19,7 +19,13 @@ int sockops_prog(struct bpf_sock_ops *skops)
         return BPF_OK;
 
     switch (skops->op) {
+    case BPF_SOCK_OPS_TCP_CONNECT_CB:
+        skops_handle_kmesh_managed_process(skops);
+        break;
     case BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB:
+        if (!is_managed_by_kmesh(skops))
+            break;
+
         if (bpf_sock_ops_cb_flags_set(skops, BPF_SOCK_OPS_STATE_CB_FLAG) != 0) {
             BPF_LOG(ERR, SOCKOPS, "set sockops cb failed!\n");
         } else {

--- a/bpf/kmesh/workload/sockops.c
+++ b/bpf/kmesh/workload/sockops.c
@@ -29,24 +29,6 @@ struct {
     __uint(map_flags, 0);
 } map_of_kmesh_socket SEC(".maps");
 
-static inline bool is_managed_by_kmesh(struct bpf_sock_ops *skops)
-{
-    struct manager_key key = {0};
-    if (skops->family == AF_INET)
-        key.addr.ip4 = skops->local_ip4;
-    if (skops->family == AF_INET6) {
-        if (is_ipv4_mapped_addr(skops->local_ip6))
-            key.addr.ip4 = skops->local_ip6[3];
-        else
-            IP6_COPY(key.addr.ip6, skops->local_ip6);
-    }
-
-    int *value = bpf_map_lookup_elem(&map_of_manager, &key);
-    if (!value)
-        return false;
-    return (*value == 0);
-}
-
 static inline bool skip_specific_probe(struct bpf_sock_ops *skops)
 {
     struct kmesh_config *data = {0};
@@ -180,70 +162,6 @@ static inline void enable_encoding_metadata(struct bpf_sock_ops *skops)
     err = bpf_sock_hash_update(skops, &map_of_kmesh_socket, &tuple_info, BPF_ANY);
     if (err)
         BPF_LOG(ERR, SOCKOPS, "enable encoding metadata failed!, err is %d", err);
-}
-
-static inline void record_kmesh_managed_ip(__u32 family, __u32 ip4, __u32 *ip6)
-{
-    int err;
-    __u32 value = 0;
-    struct manager_key key = {0};
-    if (family == AF_INET)
-        key.addr.ip4 = ip4;
-    if (family == AF_INET6 && ip6)
-        IP6_COPY(key.addr.ip6, ip6);
-
-    err = bpf_map_update_elem(&map_of_manager, &key, &value, BPF_ANY);
-    if (err)
-        BPF_LOG(ERR, KMESH, "record ip failed!, err is %d\n", err);
-}
-
-static inline void remove_kmesh_managed_ip(__u32 family, __u32 ip4, __u32 *ip6)
-{
-    struct manager_key key = {0};
-    if (family == AF_INET)
-        key.addr.ip4 = ip4;
-    if (family == AF_INET6 && ip6)
-        IP6_COPY(key.addr.ip6, ip6);
-
-    int err = bpf_map_delete_elem(&map_of_manager, &key);
-    if (err && err != -ENOENT)
-        BPF_LOG(ERR, KMESH, "remove ip failed!, err is %d\n", err);
-}
-
-static inline bool conn_from_sim(struct bpf_sock_ops *skops, __u32 ip, __u16 port)
-{
-    __u16 remote_port = GET_SKOPS_REMOTE_PORT(skops);
-    if (bpf_ntohs(remote_port) != port)
-        return false;
-
-    if (skops->family == AF_INET)
-        return (bpf_ntohl(skops->remote_ip4) == ip);
-
-    return (
-        skops->remote_ip6[0] == 0 && skops->remote_ip6[1] == 0 && skops->remote_ip6[2] == 0
-        && bpf_ntohl(skops->remote_ip6[3]) == ip);
-}
-
-static inline bool skops_conn_from_cni_sim_add(struct bpf_sock_ops *skops)
-{
-    // cni sim connect CONTROL_CMD_IP:929(0x3a1)
-    // 0x3a1 is the specific port handled by the cni to enable Kmesh
-    return conn_from_sim(skops, CONTROL_CMD_IP, ENABLE_KMESH_PORT);
-}
-
-static inline bool skops_conn_from_cni_sim_delete(struct bpf_sock_ops *skops)
-{
-    // cni sim connect CONTROL_CMD_IP:930(0x3a2)
-    // 0x3a2 is the specific port handled by the cni to disable Kmesh
-    return conn_from_sim(skops, CONTROL_CMD_IP, DISABLE_KMESH_PORT);
-}
-
-static inline void skops_handle_kmesh_managed_process(struct bpf_sock_ops *skops)
-{
-    if (skops_conn_from_cni_sim_add(skops))
-        record_kmesh_managed_ip(skops->family, skops->local_ip4, skops->local_ip6);
-    if (skops_conn_from_cni_sim_delete(skops))
-        remove_kmesh_managed_ip(skops->family, skops->local_ip4, skops->local_ip6);
 }
 
 SEC("sockops")

--- a/kmesh_compile_env_pre.sh
+++ b/kmesh_compile_env_pre.sh
@@ -109,15 +109,6 @@ function kmesh_set_env(){
     export EXTRA_CFLAGS="-O0 -g"
 }
 
-# adjust the range of BPF code compilation based on the kernel is enhanced
-function bpf_compile_range_adjust() {
-    if [ "$ENHANCED_KERNEL" == "enhanced" ]; then
-            sed -i '/ads\/sockops\.c/s/\(.*\)generate/\/\/go:generate/' bpf/kmesh/bpf2go/bpf2go.go
-    else
-            sed -i '/ads\/sockops\.c/s/\(.*\)generate/\/\/not go:generate/' bpf/kmesh/bpf2go/bpf2go.go
-    fi
-}
-
 function set_enhanced_kernel_env() {
     # we use /usr/include/linux/bpf.h to determine the runtime environment’s
     # support for kmesh. Considering the case of online image compilation, a
@@ -149,5 +140,4 @@ function prepare() {
     kmesh_set_env
     bash kmesh_macros_env.sh
     bash kmesh_bpf_env.sh
-    bpf_compile_range_adjust
 }

--- a/pkg/bpf/ads/loader.go
+++ b/pkg/bpf/ads/loader.go
@@ -39,11 +39,17 @@ var log = logger.NewLoggerScope("bpf_ads")
 
 type BpfAds struct {
 	SockConn BpfSockConn
+	SockOps  BpfSockOps
 	Tc       *general.BpfTCGeneral
 }
 
 func NewBpfAds(cfg *options.BpfConfig) (*BpfAds, error) {
 	sc := &BpfAds{}
+
+	if err := sc.SockOps.NewBpf(cfg); err != nil {
+		return nil, err
+	}
+
 	if err := sc.SockConn.NewBpf(cfg); err != nil {
 		return nil, err
 	}
@@ -105,6 +111,10 @@ func (sc *BpfAds) Load() error {
 		return err
 	}
 
+	if err := sc.SockOps.Load(); err != nil {
+		return err
+	}
+
 	if err := sc.Tc.LoadTC(); err != nil {
 		return err
 	}
@@ -142,6 +152,10 @@ func (sc *BpfAds) ApiEnvCfg() error {
 }
 
 func (sc *BpfAds) Attach() error {
+	if err := sc.SockOps.Attach(); err != nil {
+		return err
+	}
+
 	if err := sc.SockConn.Attach(); err != nil {
 		return err
 	}
@@ -150,9 +164,14 @@ func (sc *BpfAds) Attach() error {
 }
 
 func (sc *BpfAds) Detach() error {
+	if err := sc.SockOps.Detach(); err != nil {
+		return err
+	}
+
 	if err := sc.SockConn.Detach(); err != nil {
 		return err
 	}
+
 	if err := sc.Tc.Close(); err != nil {
 		return err
 	}

--- a/pkg/bpf/ads/sock_ops.go
+++ b/pkg/bpf/ads/sock_ops.go
@@ -1,6 +1,3 @@
-//go:build enhanced
-// +build enhanced
-
 /*
  * Copyright The Kmesh Authors.
  *


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
After the ads mode adopts the new kernel modification solution, some adaptability work is not fully considered and needs to be fixed:
 1.bpf2go files no longer distinguish between enhanced and unenhanced, sockops files are now always required
 2.In the sockops hook point, it is necessary to determine whether it is managed by kmesh. Previously, the sockops hook point added to the ko file would come in and set the state_cb tag》The is_kmesh_manage function of sockops in the workload is mentioned in kmesh_common.h

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
