### PR TITLE
add channel for Rbac when Kmesh restart

### DIFF
--- a/pkg/controller/workload/workload_controller.go
+++ b/pkg/controller/workload/workload_controller.go
@@ -68,16 +68,16 @@ func NewController(bpfWorkload *bpfwl.BpfWorkload, enableMonitoring, enablePerfM
 func (c *Controller) Run(ctx context.Context) {
 	go func() {
 		var addressReady, authzReady bool
-		for {
-			select {
-			case <-c.Processor.addressDone:
-				addressReady = true
-			case <-c.Processor.authzDone:
-				authzReady = true
-			}
-			if addressReady && authzReady {
-				go c.Rbac.Run(ctx, c.bpfWorkloadObj.SockOps.KmAuthReq, c.bpfWorkloadObj.XdpAuth.KmAuthRes)
-			}
+		select {
+		case <-c.Processor.addressDone:
+			addressReady = true
+			close(c.Processor.addressDone)
+		case <-c.Processor.authzDone:
+			authzReady = true
+			close(c.Processor.authzDone)
+		}
+		if addressReady && authzReady {
+			go c.Rbac.Run(ctx, c.bpfWorkloadObj.SockOps.KmAuthReq, c.bpfWorkloadObj.XdpAuth.KmAuthRes)
 		}
 	}()
 	go c.MetricController.Run(ctx, c.bpfWorkloadObj.SockConn.KmTcpProbe)

--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -121,10 +121,20 @@ func (p *Processor) processWorkloadResponse(rsp *service_discovery_v3.DeltaDisco
 	switch rsp.GetTypeUrl() {
 	case AddressType:
 		err = p.handleAddressTypeResponse(rsp)
-		p.addressDone <- struct{}{}
+		if p.addressDone != nil {
+			select {
+			case p.addressDone <- struct{}{}:
+			default:
+			}
+		}
 	case AuthorizationType:
 		err = p.handleAuthorizationTypeResponse(rsp, rbac)
-		p.authzDone <- struct{}{}
+		if p.authzDone != nil {
+			select {
+			case p.authzDone <- struct{}{}:
+			default:
+			}
+		}
 	default:
 		err = fmt.Errorf("unsupported type url %s", rsp.GetTypeUrl())
 	}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #1265 

**Special notes for your reviewer**:
When Kmesh is restarted, one thing to ensure is that the workload's xds configuration has been delivered before executing Rbac, otherwise, Rbac will reject the app request.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
