### PR TITLE
pretty print bpf dump

### DIFF
--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -108,6 +108,10 @@ func (p *Processor) GetBpfCache() *bpf.Cache {
 	return p.bpf
 }
 
+func (p *Processor) GetHashName() *utils.HashName {
+	return p.hashName
+}
+
 func (p *Processor) processWorkloadResponse(rsp *service_discovery_v3.DeltaDiscoveryResponse, rbac *auth.Rbac) {
 	var err error
 

--- a/pkg/nets/nets.go
+++ b/pkg/nets/nets.go
@@ -56,6 +56,14 @@ func ConvertPortToBigEndian(little uint32) uint32 {
 	return uint32(big16)
 }
 
+// ConvertPortToLittleEndian convert port to host order
+func ConvertPortToLittleEndian(big uint32) uint32 {
+	tmp := make([]byte, 2)
+	binary.LittleEndian.PutUint16(tmp, uint16(big))
+	little16 := binary.BigEndian.Uint16(tmp)
+	return uint32(little16)
+}
+
 func CopyIpByteFromSlice(dst *[16]byte, src []byte) {
 	len := len(src)
 	if len != 4 && len != 16 {

--- a/pkg/nets/nets_test.go
+++ b/pkg/nets/nets_test.go
@@ -118,3 +118,21 @@ func TestCompareIpByte(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertPortToLittleEndian(t *testing.T) {
+	tests := []struct {
+		input    uint32
+		expected uint32
+	}{
+		{8080, 8080},
+		{0x5678, 0x5678},
+	}
+
+	for _, test := range tests {
+		input := ConvertPortToBigEndian(test.input)
+		actual := ConvertPortToLittleEndian(input)
+		if actual != test.expected {
+			t.Errorf("ConvertPortToLittleEndian(%#x) = %#x; expected %#x", test.input, actual, test.expected)
+		}
+	}
+}

--- a/pkg/status/api.go
+++ b/pkg/status/api.go
@@ -17,10 +17,16 @@
 package status
 
 import (
+	"encoding/json"
+	"fmt"
 	"net"
+	"strings"
 
 	"kmesh.net/kmesh/api/v2/workloadapi"
 	"kmesh.net/kmesh/api/v2/workloadapi/security"
+	"kmesh.net/kmesh/pkg/controller/workload/bpfcache"
+	"kmesh.net/kmesh/pkg/nets"
+	"kmesh.net/kmesh/pkg/utils"
 )
 
 type Workload struct {
@@ -182,4 +188,170 @@ func ConvertAuthorizationPolicy(p *security.Authorization) *AuthorizationPolicy 
 	}
 
 	return out
+}
+
+type prettyArray[T any] []T
+
+func (a prettyArray[T]) MarshalJSON() ([]byte, error) {
+	prettified := make([]string, len(a))
+	for i, elem := range a {
+		prettified[i] = fmt.Sprintf("%v", elem)
+	}
+
+	return json.Marshal(strings.Join(prettified, ", "))
+}
+
+type BpfServiceValue struct {
+	// EndpointCount is the number of endpoints for each priority.
+	EndpointCount prettyArray[uint32] `json:"endpointCount"`
+	LbPolicy      string              `json:"lbPolicy"`
+	ServicePort   prettyArray[uint32] `json:"servicePort,omitempty"`
+	TargetPort    prettyArray[uint32] `json:"targetPort,omitempty"`
+	WaypointAddr  prettyArray[byte]   `json:"waypointAddr,omitempty"`
+	WaypointPort  uint32              `json:"waypointPort,omitempty"`
+}
+
+type BpfBackendValue struct {
+	Ip           prettyArray[byte] `json:"ip"`
+	ServiceCount uint32            `json:"serviceCount"`
+	Services     []string          `json:"services"`
+	WaypointAddr prettyArray[byte] `json:"waypointAddr,omitempty"`
+	WaypointPort uint32            `json:"waypointPort,omitempty"`
+}
+
+type BpfFrontendValue struct {
+	UpstreamId string `json:"upstreamId,omitempty"`
+}
+
+type BpfWorkloadPolicyValue struct {
+	PolicyIds []string `json:"policyIds,omitempty"`
+}
+
+type BpfEndpointValue struct {
+	BackendUid string `json:"backendUid,omitempty"`
+}
+
+type WorkloadBpfDump struct {
+	hashName *utils.HashName
+
+	WorkloadPolicies []BpfWorkloadPolicyValue `json:"workloadPolicies"`
+	Backends         []BpfBackendValue        `json:"backends"`
+	Endpoints        []BpfEndpointValue       `json:"endpoints"`
+	Frontends        []BpfFrontendValue       `json:"frontends"`
+	Services         []BpfServiceValue        `json:"services"`
+}
+
+func NewWorkloadBpfDump(hashName *utils.HashName) WorkloadBpfDump {
+	return WorkloadBpfDump{hashName: hashName}
+}
+
+func (wd WorkloadBpfDump) WithWorkloadPolicies(workloadPolicies []bpfcache.WorkloadPolicyValue) WorkloadBpfDump {
+	converted := make([]BpfWorkloadPolicyValue, 0, len(workloadPolicies))
+	for _, policy := range workloadPolicies {
+		policyIds := []string{}
+		for _, id := range policy.PolicyIds {
+			policyIds = append(policyIds, wd.hashName.NumToStr(id))
+		}
+		converted = append(converted, BpfWorkloadPolicyValue{
+			PolicyIds: policyIds,
+		})
+	}
+	wd.WorkloadPolicies = converted
+	return wd
+}
+
+func (wd WorkloadBpfDump) WithBackends(backends []bpfcache.BackendValue) WorkloadBpfDump {
+	converted := make([]BpfBackendValue, 0, len(backends))
+	for _, backend := range backends {
+		ip := []byte{}
+		for _, b := range backend.Ip {
+			ip = append(ip, b)
+		}
+		waypointAddr := []byte{}
+		if backend.WaypointAddr != [16]byte{} {
+			for _, b := range backend.WaypointAddr {
+				waypointAddr = append(waypointAddr, b)
+			}
+		}
+		bac := BpfBackendValue{
+			Ip:           ip,
+			ServiceCount: backend.ServiceCount,
+			WaypointAddr: waypointAddr,
+			WaypointPort: nets.ConvertPortToLittleEndian(backend.WaypointPort),
+		}
+		services := make([]string, 0, len(backend.Services))
+		for _, s := range backend.Services {
+			svc := wd.hashName.NumToStr(s)
+			if svc == "" {
+				continue
+			}
+			services = append(services, wd.hashName.NumToStr(s))
+		}
+		bac.Services = services
+		converted = append(converted, bac)
+	}
+	wd.Backends = converted
+	return wd
+}
+
+func (wd WorkloadBpfDump) WithEndpoints(endpoints []bpfcache.EndpointValue) WorkloadBpfDump {
+	converted := make([]BpfEndpointValue, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		converted = append(converted, BpfEndpointValue{
+			BackendUid: wd.hashName.NumToStr(endpoint.BackendUid),
+		})
+	}
+	wd.Endpoints = converted
+	return wd
+}
+
+func (wd WorkloadBpfDump) WithFrontends(frontends []bpfcache.FrontendValue) WorkloadBpfDump {
+	converted := make([]BpfFrontendValue, 0, len(frontends))
+	for _, frontend := range frontends {
+		converted = append(converted, BpfFrontendValue{
+			UpstreamId: wd.hashName.NumToStr(frontend.UpstreamId),
+		})
+	}
+	wd.Frontends = converted
+	return wd
+}
+
+func (wd WorkloadBpfDump) WithServices(services []bpfcache.ServiceValue) WorkloadBpfDump {
+	converted := make([]BpfServiceValue, 0, len(services))
+	for _, s := range services {
+		waypointAddr := []byte{}
+		if s.WaypointAddr != [16]byte{} {
+			for _, b := range s.WaypointAddr {
+				waypointAddr = append(waypointAddr, b)
+			}
+		}
+		svc := BpfServiceValue{
+			EndpointCount: []uint32{},
+			LbPolicy:      workloadapi.LoadBalancing_Mode_name[int32(s.LbPolicy)],
+			WaypointAddr:  waypointAddr,
+			WaypointPort:  nets.ConvertPortToLittleEndian(s.WaypointPort),
+		}
+
+		for _, c := range s.EndpointCount {
+			svc.EndpointCount = append(svc.EndpointCount, c)
+		}
+
+		for _, p := range s.ServicePort {
+			if p == 0 {
+				continue
+			}
+			svc.ServicePort = append(svc.ServicePort, nets.ConvertPortToLittleEndian(p))
+		}
+
+		for _, p := range s.TargetPort {
+			if p == 0 {
+				continue
+			}
+			svc.TargetPort = append(svc.TargetPort, nets.ConvertPortToLittleEndian(p))
+		}
+
+		converted = append(converted, svc)
+	}
+	wd.Services = converted
+	return wd
 }


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
/kind enhancement

**Which issue(s) this PR fixes**:
Fixes #1270. Pretty print the bpf dump by:
- Print array in one line instead of multiple lines
- Restore hashed id to the original name. `backendUid`, `upstreamUid` e.g.
- Convert port to host byte order.

And there is one issue remains unresolved. I tried to print ip in string format instead of [16]byte, however, I can not distinguish whether the ip is ipv4 or ipv6 since they all stored in [16]byte. Is there any good way to resolve this?

Now the config dump looks like:

```json
{
    "workloadPolicies": [],
    "backends": [
        {
            "ip": "10, 244, 1, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "172, 18, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "172, 18, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "10, 244, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "172, 18, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "172, 18, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "172, 18, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "10, 244, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 1,
            "services": [
                "kube-system/kube-dns.kube-system.svc.cluster.local"
            ]
        },
        {
            "ip": "172, 18, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "10, 244, 2, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 1,
            "services": [
                "istio-system/istiod.istio-system.svc.cluster.local"
            ]
        },
        {
            "ip": "10, 244, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "172, 18, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "172, 18, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "172, 18, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 1,
            "services": [
                "default/kubernetes.default.svc.cluster.local"
            ]
        },
        {
            "ip": "172, 18, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "10, 244, 2, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "10, 244, 2, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "10, 244, 0, 9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "172, 18, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "10, 244, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "172, 18, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "10, 244, 0, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 1,
            "services": [
                "kube-system/kube-dns.kube-system.svc.cluster.local"
            ]
        },
        {
            "ip": "172, 18, 0, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        },
        {
            "ip": "172, 18, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0",
            "serviceCount": 0,
            "services": []
        }
    ],
    "endpoints": [
        {
            "backendUid": "Kubernetes//Pod/kube-system/coredns-7c65d6cfc9-z7r8q"
        },
        {
            "backendUid": "Kubernetes//Pod/kube-system/coredns-7c65d6cfc9-78txj"
        },
        {
            "backendUid": "Kubernetes//Pod/istio-system/istiod-7dd9797b4f-n7dmw"
        },
        {
            "backendUid": "Kubernetes/discovery.k8s.io/EndpointSlice/default/kubernetes/172.18.0.6"
        }
    ],
    "frontends": [
        {
            "upstreamId": "Kubernetes//Pod/istio-system/ztunnel-6n42j"
        },
        {
            "upstreamId": "Kubernetes//Pod/kube-system/coredns-7c65d6cfc9-z7r8q"
        },
        {
            "upstreamId": "Kubernetes//Pod/istio-system/istiod-7dd9797b4f-n7dmw"
        },
        {
            "upstreamId": "Kubernetes//Pod/kmesh-system/kmesh-fttb5"
        },
        {
            "upstreamId": "Kubernetes//Pod/kmesh-system/kmesh-9hb24"
        },
        {
            "upstreamId": "Kubernetes//Pod/kmesh-system/kmesh-vm7xd"
        },
        {
            "upstreamId": "kube-system/kube-dns.kube-system.svc.cluster.local"
        },
        {
            "upstreamId": "Kubernetes//Pod/istio-system/ztunnel-h2x5q"
        },
        {
            "upstreamId": "Kubernetes//Pod/istio-system/ztunnel-n4zcw"
        },
        {
            "upstreamId": "default/kubernetes.default.svc.cluster.local"
        },
        {
            "upstreamId": "Kubernetes//Pod/kube-system/coredns-7c65d6cfc9-78txj"
        },
        {
            "upstreamId": "Kubernetes//Pod/local-path-storage/local-path-provisioner-57c5987fd4-b4pfn"
        },
        {
            "upstreamId": "istio-system/istiod.istio-system.svc.cluster.local"
        }
    ],
    "services": [
        {
            "endpointCount": "1, 0, 0, 0, 0, 0, 0",
            "lbPolicy": "UNSPECIFIED_MODE",
            "servicePort": "443",
            "targetPort": "6443"
        },
        {
            "endpointCount": "1, 0, 0, 0, 0, 0, 0",
            "lbPolicy": "UNSPECIFIED_MODE",
            "servicePort": "15010, 15012, 443, 15014",
            "targetPort": "15010, 15012, 15017, 15014"
        },
        {
            "endpointCount": "2, 0, 0, 0, 0, 0, 0",
            "lbPolicy": "UNSPECIFIED_MODE",
            "servicePort": "53, 53, 9153",
            "targetPort": "53, 53, 9153"
        }
    ]
}
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
