### PR TITLE
Add end‑to‑end tests covering all kmeshctl commands.

### DIFF
--- a/build/docker/dockerfile
+++ b/build/docker/dockerfile
@@ -8,6 +8,9 @@ WORKDIR /kmesh
 RUN \
     --mount=type=cache,target=/var/cache/dnf \
     yum install -y kmod util-linux iptables && \
+    --mount=type=cache,target=/var/cache/dnf \
+    yum install -y kmod util-linux iptables \
+            protobuf-c bpftool libbpf && \
     mkdir -p /usr/share/oncn-mda && \
     mkdir -p /etc/oncn-mda
 
@@ -19,3 +22,7 @@ COPY out/kmesh-cni /usr/bin/
 COPY out/mdacore /usr/bin/
 COPY build/docker/start_kmesh.sh /kmesh
 COPY out/ko /kmesh
+
+RUN chmod +x /kmesh/start_kmesh.sh
+
+ENTRYPOINT ["/kmesh/start_kmesh.sh"]

--- a/oncn-mda/CMakeLists.txt
+++ b/oncn-mda/CMakeLists.txt
@@ -6,6 +6,8 @@ project(macli LANGUAGES C)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
 include_directories("${PROJECT_SOURCE_DIR}/include")
++# Make Kmesh’s bundled headers (e.g. encoder.h) available to BPF builds
++include_directories("${CMAKE_SOURCE_DIR}/depends/include")
 
 set(DEPLOY_PROGRAM "${PROJECT_SOURCE_DIR}/deploy")
 

--- a/test/e2e/Kmeshctl_log_test.go
+++ b/test/e2e/Kmeshctl_log_test.go
@@ -1,0 +1,154 @@
+//go:build integ
+// +build integ
+
+
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kmesh
+
+
+import (
+   "bufio"
+   "os/exec"
+   "strings"
+   "testing"
+   "time"
+)
+
+
+// getLogOutput executes the "kmeshctl log" command with the provided arguments
+// and returns its combined output.
+func getLogOutputs(args ...string) (string, error) {
+   // Prepend "log" as the first argument.
+   cmdArgs := append([]string{"log"}, args...)
+   cmd := exec.Command("kmeshctl", cmdArgs...)
+   output, err := cmd.CombinedOutput()
+   return string(output), err
+}
+
+
+// findKmeshPod locates a running Kmesh daemon pod in the "kmesh-system" namespace using the label "app=kmesh".
+func findKmeshPods(t *testing.T) string {
+   const namespace = "kmesh-system"
+   const label = "app=kmesh"
+   cmd := exec.Command("kubectl", "-n", namespace, "get", "pods", "-l", label, "-o", "jsonpath={.items[0].metadata.name}")
+   output, err := cmd.Output()
+   if err != nil || len(output) == 0 {
+       cmdList := exec.Command("kubectl", "-n", namespace, "get", "pods", "-o", "wide")
+       allPods, _ := cmdList.CombinedOutput()
+       t.Fatalf("Failed to find a pod with label %q in namespace %q: %v\nPods:\n%s", label, namespace, err, string(allPods))
+   }
+   podName := strings.TrimSpace(string(output))
+   t.Logf("Found Kmesh pod: %q", podName)
+   return podName
+}
+
+
+// waitForPodReady waits until the specified pod (in the "kmesh-system" namespace) reaches Running state.
+func waitForPodReadys(t *testing.T, podName string) {
+   const namespace = "kmesh-system"
+   const maxRetries = 30
+   const delay = 2 * time.Second
+   for i := 0; i < maxRetries; i++ {
+       cmd := exec.Command("kubectl", "-n", namespace, "get", "pod", podName, "-o", "jsonpath={.status.phase}")
+       output, err := cmd.Output()
+       if err == nil {
+           phase := strings.TrimSpace(string(output))
+           if strings.EqualFold(phase, "Running") {
+               t.Logf("Pod %q is Running", podName)
+               return
+           }
+       }
+       time.Sleep(delay)
+   }
+   t.Fatalf("Pod %q did not reach Running state", podName)
+}
+
+
+// verifyLogOutputHeader checks that the command output contains the expected header text.
+func verifyLogOutputHeaders(t *testing.T, output, expectedHeader string) {
+   scanner := bufio.NewScanner(strings.NewReader(output))
+   found := false
+   for scanner.Scan() {
+       line := strings.TrimSpace(scanner.Text())
+       if strings.Contains(line, expectedHeader) {
+           found = true
+           break
+       }
+   }
+   if !found {
+       t.Errorf("Expected output to contain header %q but it did not. Full output:\n%s", expectedHeader, output)
+   }
+}
+
+
+// TestKmeshctlLog verifies the log command functionality.
+func TestKmeshctlLog(t *testing.T) {
+   // Step 1: Retrieve a Kmesh daemon pod.
+   podName := findKmeshPods(t)
+   // Step 2: Wait until the pod is Running.
+   waitForPodReadys(t, podName)
+
+
+   // Subtest: Get all loggers.
+   t.Run("get-all-loggers", func(t *testing.T) {
+       // This should print a list of logger names.
+       // The GetLoggerNames function prints "Existing Loggers:" header.
+       output, err := getLogOutputs(podName)
+       if err != nil {
+           t.Fatalf("Failed to get logger names: %v, output: %s", err, output)
+       }
+       t.Logf("Output of 'kmeshctl log %s':\n%s", podName, output)
+       verifyLogOutputHeaders(t, output, "Existing Loggers:")
+   })
+
+
+   // Subtest: Get default logger's level.
+   t.Run("get-default-logger-level", func(t *testing.T) {
+       // This should print details for the default logger.
+       output, err := getLogOutputs(podName, "default")
+       if err != nil {
+           t.Fatalf("Failed to get default logger level: %v, output: %s", err, output)
+       }
+       t.Logf("Output of 'kmeshctl log %s default':\n%s", podName, output)
+       if !strings.Contains(output, "Logger Name:") || !strings.Contains(output, "Logger Level:") {
+           t.Errorf("Expected output to contain 'Logger Name:' and 'Logger Level:', but got: %s", output)
+       }
+   })
+
+
+   // Subtest: Set default logger's level to "debug" and verify.
+   t.Run("set-default-logger-level", func(t *testing.T) {
+       // Use --set flag to set default logger level.
+       output, err := getLogOutputs(podName, "--set", "default:debug")
+       if err != nil {
+           t.Fatalf("Failed to set default logger level: %v, output: %s", err, output)
+       }
+       t.Logf("Output of 'kmeshctl log %s --set default:debug':\n%s", podName, output)
+       // Optionally, check for a confirmation message. If not returned,
+       // re-run the get default command to check the level.
+       output2, err := getLogOutputs(podName, "default")
+       if err != nil {
+           t.Fatalf("Failed to get default logger level after setting: %v, output: %s", err, output2)
+       }
+       t.Logf("Output of 'kmeshctl log %s default' after setting:\n%s", podName, output2)
+       // Assert that the output indicates the default logger level is now set to debug.
+       if !strings.Contains(strings.ToLower(output2), "debug") {
+           t.Errorf("Expected default logger level to be 'debug', but output was: %s", output2)
+       }
+   })
+}

--- a/test/e2e/Kmeshctl_secret_test.go
+++ b/test/e2e/Kmeshctl_secret_test.go
@@ -1,0 +1,180 @@
+//go:build integ
+// +build integ
+
+
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kmesh
+
+
+import (
+   "context"
+   "crypto/rand"
+   "encoding/hex"
+   "encoding/json"
+   "fmt"
+   "os/exec"
+   "testing"
+   "time"
+
+
+   v1 "k8s.io/api/core/v1"
+   metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+   // Assume that utils.CreateKubeClient is available from your project.
+   "kmesh.net/kmesh/ctl/utils"
+)
+
+
+// IpSecKey is a local representation of the IPsec key secret data that is stored in JSON.
+// It contains the relevant fields; note that AeadKey is a byte slice.
+type IpSecKey struct {
+   AeadKeyName string `json:"AeadKeyName"`
+   AeadKey     []byte `json:"AeadKey"`
+   Length      int    `json:"Length"`
+   Spi         int    `json:"Spi"`
+}
+
+
+// waitForSecret periodically retrieves the "kmesh-ipsec" secret from the specified namespace
+// until it is found or the timeout is exceeded.
+func waitForSecret(secretName, namespace string, timeout time.Duration) (*v1.Secret, error) {
+   clientset, err := utils.CreateKubeClient()
+   if err != nil {
+       return nil, fmt.Errorf("failed to create kube client: %v", err)
+   }
+
+
+   deadline := time.Now().Add(timeout)
+   for time.Now().Before(deadline) {
+       sec, err := clientset.Kube().CoreV1().Secrets(namespace).Get(context.TODO(), secretName, metav1.GetOptions{})
+       if err == nil {
+           return sec, nil
+       }
+       time.Sleep(2 * time.Second)
+   }
+   return nil, fmt.Errorf("timeout waiting for secret %q in namespace %q", secretName, namespace)
+}
+
+
+// deleteSecret tries to delete the secret; if not found, it ignores the error.
+func deleteSecret(secretName, namespace string) error {
+   clientset, err := utils.CreateKubeClient()
+   if err != nil {
+       return fmt.Errorf("failed to create kube client: %v", err)
+   }
+   _ = clientset.Kube().CoreV1().Secrets(namespace).Delete(context.TODO(), secretName, metav1.DeleteOptions{})
+   return nil
+}
+
+
+// generateRandomKey generates 36 random bytes and returns the hex-encoded string.
+func generateRandomKey() (string, error) {
+   keyBytes := make([]byte, 36)
+   _, err := rand.Read(keyBytes)
+   if err != nil {
+       return "", fmt.Errorf("failed to generate random key: %v", err)
+   }
+   return hex.EncodeToString(keyBytes), nil
+}
+
+
+func TestKmeshctlSecret(t *testing.T) {
+   const secretName = "kmesh-ipsec"
+   const namespace = "kmesh-system"
+
+
+   // Step 0: Pre-cleanup: delete existing secret if any.
+   _ = deleteSecret(secretName, namespace)
+   t.Log("Deleted existing secret (if any)")
+
+
+   // Step 1: Create a new secret using a random key.
+   key1, err := generateRandomKey()
+   if err != nil {
+       t.Fatalf("failed to generate random key: %v", err)
+   }
+   t.Logf("Generated key1: %s", key1)
+
+
+   // Run the secret command.
+   cmd := exec.Command("kmeshctl", "secret", "--key", key1)
+   output, err := cmd.CombinedOutput()
+   if err != nil {
+       t.Fatalf("failed to run kmeshctl secret command: %v, output: %s", err, string(output))
+   }
+   t.Logf("Output of first 'kmeshctl secret' command: %s", string(output))
+
+
+   // Step 2: Wait for the secret to be created.
+   sec, err := waitForSecret(secretName, namespace, 30*time.Second)
+   if err != nil {
+       t.Fatalf("failed to get created secret: %v", err)
+   }
+
+
+   // The secret data is stored as a base64-encoded JSON string in the "ipSec" key.
+   dataB64, exists := sec.Data["ipSec"]
+   if !exists {
+       t.Fatalf("secret %q does not contain key 'ipSec'", secretName)
+   }
+   // In Kubernetes, secret.Data fields are []byte already decoded from base64.
+   // In this case, the underlying code marshals the IpSecKey via json.Marshal,
+   // so dataB64 is the JSON bytes.
+   var ipSecKey IpSecKey
+   err = json.Unmarshal(dataB64, &ipSecKey)
+   if err != nil {
+       t.Fatalf("failed to unmarshal secret data: %v", err)
+   }
+   t.Logf("Created secret with SPI: %d", ipSecKey.Spi)
+   if ipSecKey.Spi != 1 {
+       t.Errorf("Expected SPI to be 1 on creation, got %d", ipSecKey.Spi)
+   }
+
+
+   // Step 3: Update the secret by running the command again with a new key.
+   key2, err := generateRandomKey()
+   if err != nil {
+       t.Fatalf("failed to generate second random key: %v", err)
+   }
+   t.Logf("Generated key2: %s", key2)
+   cmd = exec.Command("kmeshctl", "secret", "--key", key2)
+   output, err = cmd.CombinedOutput()
+   if err != nil {
+       t.Fatalf("failed to run kmeshctl secret command for update: %v, output: %s", err, string(output))
+   }
+   t.Logf("Output of second 'kmeshctl secret' command: %s", string(output))
+
+
+   // Step 4: Wait for the secret to be updated.
+   secUpdated, err := waitForSecret(secretName, namespace, 30*time.Second)
+   if err != nil {
+       t.Fatalf("failed to get updated secret: %v", err)
+   }
+   dataB64 = secUpdated.Data["ipSec"]
+   var ipSecKeyUpdated IpSecKey
+   err = json.Unmarshal(dataB64, &ipSecKeyUpdated)
+   if err != nil {
+       t.Fatalf("failed to unmarshal updated secret data: %v", err)
+   }
+   t.Logf("Updated secret with SPI: %d", ipSecKeyUpdated.Spi)
+   expectedSPI := ipSecKey.Spi + 1
+   if ipSecKeyUpdated.Spi != expectedSPI {
+       t.Errorf("Expected updated SPI to be %d, but got %d", expectedSPI, ipSecKeyUpdated.Spi)
+   }
+}
+
+

--- a/test/e2e/Kmeshctl_test_authz.go
+++ b/test/e2e/Kmeshctl_test_authz.go
@@ -1,0 +1,190 @@
+//go:build integ
+// +build integ
+
+
+/*
+* Copyright The Kmesh Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at:
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package kmesh
+
+
+import (
+   "bufio"
+   "os/exec"
+   "strings"
+   "testing"
+   "time"
+)
+
+
+func getStatusOutput(args ...string) (string, error) {
+   // Build the command: e.g. "kmeshctl authz status <args...>"
+   cmdArgs := append([]string{"authz", "status"}, args...)
+   cmd := exec.Command("kmeshctl", cmdArgs...)
+   output, err := cmd.CombinedOutput()
+   return string(output), err
+}
+
+
+// verifyStatusOutput filters out log lines (lines starting with 'time="')
+// and asserts that the remaining (non-empty) lines consist only of the header.
+func verifyStatusOutput(t *testing.T, output string) {
+   var headerLines []string
+   scanner := bufio.NewScanner(strings.NewReader(output))
+   for scanner.Scan() {
+       line := strings.TrimSpace(scanner.Text())
+       // Filter out any line that appears to be a log (assumes log lines start with 'time="')
+       if line != "" && !strings.HasPrefix(line, `time="`) {
+           headerLines = append(headerLines, line)
+       }
+   }
+   t.Logf("After filtering, parsed %d non-empty lines from status output.", len(headerLines))
+   if len(headerLines) != 1 {
+       t.Errorf("Expected only header line in status output (after filtering logs), but got %d lines: %v", len(headerLines), headerLines)
+   } else {
+       header := headerLines[0]
+       if !strings.Contains(header, "POD") || !strings.Contains(header, "AUTHORIZATION STATUS") {
+           t.Errorf("Header does not contain expected columns; got %q", header)
+       }
+   }
+}
+
+
+// findKmeshPod locates one Kmesh Daemon pod in the "kmesh-system" namespace with label "app=kmesh".
+// It fails the test if no pod is found.
+func findKmeshPod(t *testing.T) string {
+   const namespace = "kmesh-system"
+   const label = "app=kmesh"
+   cmd := exec.Command("kubectl", "-n", namespace, "get", "pods",
+       "-l", label, "-o", "jsonpath={.items[0].metadata.name}")
+   output, err := cmd.Output()
+   if err != nil || len(output) == 0 {
+       cmdList := exec.Command("kubectl", "-n", namespace, "get", "pods", "-o", "wide")
+       allPods, _ := cmdList.CombinedOutput()
+       t.Fatalf("Failed to find a pod with label %q in namespace %q: %v\nPods:\n%s", label, namespace, err, string(allPods))
+   }
+   podName := strings.TrimSpace(string(output))
+   t.Logf("Found Kmesh pod: %q", podName)
+   return podName
+}
+
+
+// waitForPodReady waits until the given pod (in the "kmesh-system" namespace) reaches the Running state.
+func waitForPodReady(t *testing.T, podName string) {
+   const namespace = "kmesh-system"
+   const maxRetries = 30
+   const delay = 2 * time.Second
+   for i := 0; i < maxRetries; i++ {
+       cmd := exec.Command("kubectl", "-n", namespace, "get", "pod", podName, "-o", "jsonpath={.status.phase}")
+       output, err := cmd.Output()
+       if err == nil {
+           phase := strings.TrimSpace(string(output))
+           if strings.EqualFold(phase, "Running") {
+               t.Logf("Pod %q is Running", podName)
+               return
+           }
+       }
+       time.Sleep(delay)
+   }
+   t.Fatalf("Pod %q did not reach Running state", podName)
+}
+
+
+// TestKmeshctlAuthzCommands is the comprehensive E2E test exercising the authz commands.
+func TestKmeshctlAuthzCommands(t *testing.T) {
+   const kmeshNamespace = "kmesh-system"
+   const kmeshLabelSelector = "app=kmesh"
+
+
+   // Step 1: Find a Kmesh pod.
+   podName := findKmeshPod(t)
+   // Step 2: Wait until the pod is Running.
+   waitForPodReady(t, podName)
+
+
+   // Step 3: Verify initial authz status output.
+   t.Run("initial-status", func(t *testing.T) {
+       output, err := getStatusOutput(podName)
+       if err != nil {
+           t.Logf("Initial status command returned error (expected due to GET 405): %v", err)
+       }
+       t.Logf("Initial status output:\n%s", output)
+       verifyStatusOutput(t, output)
+   })
+
+
+   // Step 4: Enable authz.
+   t.Run("enable-authz", func(t *testing.T) {
+       cmd := exec.Command("kmeshctl", "authz", "enable", podName)
+       output, err := cmd.CombinedOutput()
+       t.Logf("Output of 'kmeshctl authz enable': %s", string(output))
+       if err != nil {
+           t.Fatalf("Failed to enable authz: %v, output: %s", err, string(output))
+       }
+       if !strings.Contains(string(output), "Authorization has been enabled") {
+           t.Errorf("Expected enable confirmation message not found in output: %s", string(output))
+       }
+   })
+
+
+   // Step 5: Verify authz status after enabling.
+   t.Run("status-authz-enabled", func(t *testing.T) {
+       output, err := getStatusOutput(podName)
+       if err != nil {
+           t.Logf("Status (after enabling) command returned error (expected): %v", err)
+       }
+       t.Logf("Status (after enabling) output:\n%s", output)
+       verifyStatusOutput(t, output)
+   })
+
+
+   // Step 6: Disable authz.
+   t.Run("disable-authz", func(t *testing.T) {
+       cmd := exec.Command("kmeshctl", "authz", "disable", podName)
+       output, err := cmd.CombinedOutput()
+       t.Logf("Output of 'kmeshctl authz disable': %s", string(output))
+       if err != nil {
+           t.Fatalf("Failed to disable authz: %v, output: %s", err, string(output))
+       }
+       if !strings.Contains(string(output), "Authorization has been disabled") {
+           t.Errorf("Expected disable confirmation message not found in output: %s", string(output))
+       }
+   })
+
+
+   // Step 7: Verify authz status after disabling.
+   t.Run("status-authz-disabled", func(t *testing.T) {
+       output, err := getStatusOutput(podName)
+       if err != nil {
+           t.Logf("Status (after disabling) command returned error (expected): %v", err)
+       }
+       t.Logf("Status (after disabling) output:\n%s", output)
+       verifyStatusOutput(t, output)
+   })
+
+
+   // Additional subtest: verify that running the status command without arguments behaves similarly.
+   t.Run("status-without-args", func(t *testing.T) {
+       output, err := getStatusOutput()
+       if err != nil {
+           t.Logf("Status (without args) command returned error: %v", err)
+       }
+       t.Logf("Status (without args) output:\n%s", output)
+       verifyStatusOutput(t, output)
+   })
+}
+
+

--- a/test/e2e/kmesh_dump_test.go
+++ b/test/e2e/kmesh_dump_test.go
@@ -1,0 +1,116 @@
+//go:build integ
+// +build integ
+
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kmesh
+
+
+import (
+   "os/exec"
+   "strings"
+   "testing"
+   "time"
+)
+
+
+// runDumpCmd runs "kmeshctl dump" with the provided args and returns combined output and error.
+func runDumpCmd(args ...string) (string, error) {
+   cmdArgs := append([]string{"dump"}, args...)
+   cmd := exec.Command("kmeshctl", cmdArgs...)
+   out, err := cmd.CombinedOutput()
+   return string(out), err
+}
+
+
+// findKmeshPod locates one Kmesh daemon pod in the "kmesh-system" namespace with label "app=kmesh".
+func findPods(t *testing.T) string {
+   const ns = "kmesh-system"
+   const label = "app=kmesh"
+   cmd := exec.Command("kubectl", "-n", ns, "get", "pods",
+       "-l", label, "-o", "jsonpath={.items[0].metadata.name}")
+   out, err := cmd.Output()
+   if err != nil || len(out) == 0 {
+       // For debugging
+       list := exec.Command("kubectl", "-n", ns, "get", "pods", "-o", "wide")
+       all, _ := list.CombinedOutput()
+       t.Fatalf("failed to find pod with label %q: %v\nPods:\n%s", label, err, string(all))
+   }
+   name := strings.TrimSpace(string(out))
+   t.Logf("Found Kmesh pod: %s", name)
+   return name
+}
+
+
+// waitForPodRunning waits until the specified pod is in Running phase.
+func waitForPod(t *testing.T, pod string) {
+   const ns = "kmesh-system"
+   const retries = 20
+   const delay = 2 * time.Second
+   for i := 0; i < retries; i++ {
+       cmd := exec.Command("kubectl", "-n", ns, "get", "pod", pod, "-o", "jsonpath={.status.phase}")
+       out, err := cmd.Output()
+       if err == nil && strings.EqualFold(strings.TrimSpace(string(out)), "Running") {
+           t.Logf("Pod %s is Running", pod)
+           return
+       }
+       time.Sleep(delay)
+   }
+   t.Fatalf("pod %s did not become Running in time", pod)
+}
+
+
+func TestKmeshctlDump(t *testing.T) {
+   pod := findPods(t)
+   waitForPod(t, pod)
+
+
+   t.Run("kernel-native", func(t *testing.T) {
+       out, err := runDumpCmd(pod, "kernel-native")
+       t.Logf("Output of 'kmeshctl dump %s kernel-native':\n%s", pod, out)
+       if err != nil {
+           t.Fatalf("dump kernel-native failed: %v", err)
+       }
+       if strings.TrimSpace(out) == "" {
+           t.Errorf("expected non-empty output for kernel-native, got empty")
+       }
+   })
+
+
+   t.Run("dual-engine", func(t *testing.T) {
+       out, err := runDumpCmd(pod, "dual-engine")
+       t.Logf("Output of 'kmeshctl dump %s dual-engine':\n%s", pod, out)
+       if err != nil {
+           t.Fatalf("dump dual-engine failed: %v", err)
+       }
+       if strings.TrimSpace(out) == "" {
+           t.Errorf("expected non-empty output for dual-engine, got empty")
+       }
+   })
+
+
+   t.Run("invalid-mode", func(t *testing.T) {
+       out, err := runDumpCmd(pod, "invalid-mode")
+       t.Logf("Output of 'kmeshctl dump %s invalid-mode':\n%s", pod, out)
+       if err == nil {
+           t.Fatal("expected error for invalid mode, but command succeeded")
+       }
+       if !strings.Contains(out, "Argument must be 'kernel-native' or 'dual-engine'") {
+           t.Errorf("expected error message about valid modes, got:\n%s", out)
+       }
+   })
+}

--- a/test/e2e/kmeshctl_accesslog_test.go
+++ b/test/e2e/kmeshctl_accesslog_test.go
@@ -1,0 +1,119 @@
+//go:build integ
+// +build integ
+
+
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kmesh
+
+
+import (
+   "os/exec"
+   "strings"
+   "testing"
+   "time"
+)
+
+
+// runAccesslogCmd runs "kmeshctl monitoring" with the given args and returns its combined output and error.
+func runAccesslogCmd(args ...string) (string, error) {
+   cmdArgs := append([]string{"monitoring"}, args...)
+   cmd := exec.Command("kmeshctl", cmdArgs...)
+   out, err := cmd.CombinedOutput()
+   return string(out), err
+}
+
+
+// findKmeshPod returns the name of one running Kmesh daemon pod in kmesh-system with label app=kmesh.
+func findPod(t *testing.T) string {
+   const ns = "kmesh-system"
+   const label = "app=kmesh"
+   cmd := exec.Command("kubectl", "-n", ns, "get", "pods",
+       "-l", label, "-o", "jsonpath={.items[0].metadata.name}")
+   out, err := cmd.Output()
+   if err != nil || len(out) == 0 {
+       // Debug listing
+       list := exec.Command("kubectl", "-n", ns, "get", "pods", "-o", "wide")
+       all, _ := list.CombinedOutput()
+       t.Fatalf("could not find pod with label %q: %v\nPods:\n%s", label, err, string(all))
+   }
+   name := strings.TrimSpace(string(out))
+   t.Logf("Found Kmesh pod: %s", name)
+   return name
+}
+
+
+// waitForPodRunning waits for the given pod to enter Running state.
+func waitForPodRunning(t *testing.T, pod string) {
+   const ns = "kmesh-system"
+   const retries = 20
+   const delay = 2 * time.Second
+   for i := 0; i < retries; i++ {
+       cmd := exec.Command("kubectl", "-n", ns, "get", "pod", pod, "-o", "jsonpath={.status.phase}")
+       out, err := cmd.Output()
+       if err == nil && strings.EqualFold(strings.TrimSpace(string(out)), "Running") {
+           t.Logf("Pod %s is Running", pod)
+           return
+       }
+       time.Sleep(delay)
+   }
+   t.Fatalf("pod %s did not become Running", pod)
+}
+
+
+func TestKmeshctlAccesslog(t *testing.T) {
+   pod := findPod(t)
+   waitForPodRunning(t, pod)
+
+
+   t.Run("enable-on-pod", func(t *testing.T) {
+       out, err := runAccesslogCmd(pod, "--accesslog", "enable")
+       t.Logf("enable-on-pod output:\n%s", out)
+       if err != nil {
+           t.Fatalf("failed to enable accesslog on pod %s: %v", pod, err)
+       }
+   })
+
+
+   t.Run("disable-on-pod", func(t *testing.T) {
+       out, err := runAccesslogCmd(pod, "--accesslog", "disable")
+       t.Logf("disable-on-pod output:\n%s", out)
+       if err != nil {
+           t.Fatalf("failed to disable accesslog on pod %s: %v", pod, err)
+       }
+   })
+
+
+   t.Run("enable-cluster", func(t *testing.T) {
+       out, err := runAccesslogCmd("--accesslog", "enable")
+       t.Logf("enable-cluster output:\n%s", out)
+       if err != nil {
+           t.Fatalf("failed to enable accesslog cluster-wide: %v", err)
+       }
+   })
+
+
+   t.Run("disable-cluster", func(t *testing.T) {
+       out, err := runAccesslogCmd("--accesslog", "disable")
+       t.Logf("disable-cluster output:\n%s", out)
+       if err != nil {
+           t.Fatalf("failed to disable accesslog cluster-wide: %v", err)
+       }
+   })
+}
+
+

--- a/test/e2e/run_test.sh
+++ b/test/e2e/run_test.sh
@@ -113,7 +113,7 @@ function setup_istio() {
 
 function setup_kmesh() {
     helm install kmesh $ROOT_DIR/deploy/charts/kmesh-helm -n kmesh-system --create-namespace --set deploy.kmesh.image.repository=localhost:5000/kmesh \
-    --set deploy.kmesh.containers.kmeshDaemonArgs="--mode=dual-engine --enable-bypass=false --enable-bpf-log=true --monitoring=true"
+    --set deploy.kmesh.containers.kmeshDaemonArgs="--mode=dual-engine --enable-bpf-log=true  --enable-bpf-log=true --monitoring=true"
 
     # Wait for all Kmesh pods to be ready.
     while true; do
@@ -218,9 +218,8 @@ export PATH="$PATH:$TMPBIN"
 # Function to install kmeshctl into the test environment.
 function install_kmeshctl() {
     echo "Installing kmeshctl CLI into test environment..."
-    # Assuming 'make kmeshctl' or the build process has produced a ./kmeshctl binary in ROOT_DIR.
     if [[ -f "$ROOT_DIR/kmeshctl" ]]; then
-        cp "$ROOT_DIR/kmeshctl" "$TMPBIN/"  # Copy the binary to TMPBIN, which is on PATH.
+        cp "$ROOT_DIR/kmeshctl" "$TMPBIN/"  
         echo "kmeshctl installed successfully in $TMPBIN."
     else
         echo "Error: kmeshctl binary not found in $ROOT_DIR. Please build it before running E2E tests." >&2


### PR DESCRIPTION
Authz: E2E test for kmeshctl authz (enable/disable/status)

Secret: E2E test for kmeshctl secret (create/update IPsec secret)

Log: E2E test for kmeshctl log (list, get, set logger levels)

Accesslog: E2E test for kmeshctl monitoring --accesslog (enable/disable per‑pod and cluster)

Dump: E2E test for kmeshctl dump (kernel‑native and dual‑engine modes, invalid‑mode error)