### PR TITLE
eBPF unit test: add workload sockops ut

### DIFF
--- a/hack/run-ebpf-ut.sh
+++ b/hack/run-ebpf-ut.sh
@@ -4,8 +4,8 @@ ROOT_DIR=$(git rev-parse --show-toplevel)
 
 . $ROOT_DIR/hack/utils.sh
 
-DOCKER_EBPF_TEST_COMMAND="make -C /kmesh/test/bpf_ut run"
-LOCAL_EBPF_TEST_COMMAND="make -C $ROOT_DIR/test/bpf_ut run"
+DOCKER_EBPF_TEST_COMMAND="make -C /kmesh/test/bpf_ut clean;make -C /kmesh/test/bpf_ut run"
+LOCAL_EBPF_TEST_COMMAND="make -C $ROOT_DIR/test/bpf_ut clean;make -C $ROOT_DIR/test/bpf_ut run"
 
 function docker_run_ebpf_ut() {
     local container_id=$1

--- a/test/bpf_ut/Makefile
+++ b/test/bpf_ut/Makefile
@@ -26,14 +26,14 @@ CLANG_FLAGS += -MD
 
 .PHONY: all clean run
 
-all: xdp_shutdown_in_userspace_test.o xdp_authz_offload_test.o workload_sockops.o
+all: xdp_shutdown_in_userspace_test.o xdp_authz_offload_test.o workload_sockops_test.o
 
 XDP_FLAGS = -I$(ROOT_DIR)/bpf/kmesh/ -I$(ROOT_DIR)/bpf/kmesh/workload/include -I$(ROOT_DIR)/api/v2-c
 xdp_%.o: xdp_%.c
 	$(QUIET) $(CLANG) $(CLANG_FLAGS) $(XDP_FLAGS) -c $< -o $@
 
 WORKLOAD_SOCKOPS_FLAGS = -I$(ROOT_DIR)/bpf/kmesh/ -I$(ROOT_DIR)/bpf/kmesh/probes -I$(ROOT_DIR)/bpf/kmesh/workload/include -I$(ROOT_DIR)/api/v2-c
-workload_sockops.o: workload_sockops.c
+workload_sockops_test.o: workload_sockops_test.c
 	$(QUIET) $(CLANG) $(CLANG_FLAGS) $(WORKLOAD_SOCKOPS_FLAGS) -c $< -o $@
 
 clean:

--- a/test/bpf_ut/Makefile
+++ b/test/bpf_ut/Makefile
@@ -24,7 +24,7 @@ CLANG_FLAGS += -Wimplicit-fallthrough
 # Create dependency files for each .o file.
 CLANG_FLAGS += -MD
 
-.PHONY: all clean run build
+.PHONY: all clean run
 
 all: xdp_shutdown_in_userspace_test.o xdp_authz_offload_test.o workload_sockops.o
 
@@ -71,7 +71,6 @@ ifdef BPF_TEST_FILE
 endif
 
 run: all
-	$(QUIET) echo "rebuild and run bpf tests"
 	$(GO) test ./bpftest -bpf-ut-path $(ROOT_DIR)/test/bpf_ut $(BPF_TEST_FLAGS)
 
 -include $(TEST_OBJECTS:.o=.d)

--- a/test/bpf_ut/Makefile
+++ b/test/bpf_ut/Makefile
@@ -24,16 +24,17 @@ CLANG_FLAGS += -Wimplicit-fallthrough
 # Create dependency files for each .o file.
 CLANG_FLAGS += -MD
 
-.PHONY: all clean run
+.PHONY: all clean run build
 
-TEST_OBJECTS = xdp_shutdown_in_userspace_test.o xdp_authz_offload_test.o
+all: xdp_shutdown_in_userspace_test.o xdp_authz_offload_test.o workload_sockops.o
 
 XDP_FLAGS = -I$(ROOT_DIR)/bpf/kmesh/ -I$(ROOT_DIR)/bpf/kmesh/workload/include -I$(ROOT_DIR)/api/v2-c
-xdp_%.o: xdp_%.c clean
+xdp_%.o: xdp_%.c
 	$(QUIET) $(CLANG) $(CLANG_FLAGS) $(XDP_FLAGS) -c $< -o $@
 
-
-all: $(TEST_OBJECTS)
+WORKLOAD_SOCKOPS_FLAGS = -I$(ROOT_DIR)/bpf/kmesh/ -I$(ROOT_DIR)/bpf/kmesh/probes -I$(ROOT_DIR)/bpf/kmesh/workload/include -I$(ROOT_DIR)/api/v2-c
+workload_sockops.o: workload_sockops.c
+	$(QUIET) $(CLANG) $(CLANG_FLAGS) $(WORKLOAD_SOCKOPS_FLAGS) -c $< -o $@
 
 clean:
 	$(QUIET) rm -f $(wildcard *.o)
@@ -70,7 +71,7 @@ ifdef BPF_TEST_FILE
 endif
 
 run: all
-	$(QUIET)echo "rebuild and run bpf tests"
+	$(QUIET) echo "rebuild and run bpf tests"
 	$(GO) test ./bpftest -bpf-ut-path $(ROOT_DIR)/test/bpf_ut $(BPF_TEST_FLAGS)
 
 -include $(TEST_OBJECTS:.o=.d)

--- a/test/bpf_ut/bpftest/bpf_test.go
+++ b/test/bpf_ut/bpftest/bpf_test.go
@@ -38,6 +38,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"kmesh.net/kmesh/pkg/bpf/factory"
+	"kmesh.net/kmesh/pkg/constants"
 	"kmesh.net/kmesh/pkg/logger"
 	"kmesh.net/kmesh/pkg/utils"
 )
@@ -47,17 +48,21 @@ var (
 	dumpCtx  = flag.Bool("dump-ctx", false, "If set, the program context will be dumped after a CHECK and SETUP run.")
 )
 
-type unitTest struct {
+type IunitTest interface {
+	run() func(t *testing.T)
+}
+
+type unitTest_BPF_PROG_TEST_RUN struct {
 	name             string
 	setupInUserSpace func(t *testing.T, coll *ebpf.Collection) // Builds test environment in user space, used for operations that cannot be completed in kernel space (e.g., cannot pass the eBPF verifier)
 }
 
-type unitTests struct {
+type unitTests_BPF_PROG_TEST_RUN struct {
 	objFilename string
-	uts         []unitTest
+	uts         []unitTest_BPF_PROG_TEST_RUN
 }
 
-func (uts *unitTests) run() func(t *testing.T) {
+func (uts *unitTests_BPF_PROG_TEST_RUN) run() func(t *testing.T) {
 	return func(t *testing.T) {
 		for _, ut := range uts.uts {
 			t.Run(ut.name, func(t *testing.T) {
@@ -67,6 +72,27 @@ func (uts *unitTests) run() func(t *testing.T) {
 	}
 }
 
+type unitTest_BUILD_CONTEXT struct {
+	name     string
+	workFunc func(t *testing.T, cgroupPath, elfPath string)
+}
+
+type unitTests_BUILD_CONTEXT struct {
+	objFilename string
+	uts         []unitTest_BUILD_CONTEXT
+}
+
+func (uts *unitTests_BUILD_CONTEXT) run() func(t *testing.T) {
+	return func(t *testing.T) {
+		for _, ut := range uts.uts {
+			t.Run(ut.name, func(t *testing.T) {
+				if ut.workFunc != nil {
+					ut.workFunc(t, constants.Cgroup2Path, uts.objFilename)
+				}
+			})
+		}
+	}
+}
 func TestBPF(t *testing.T) {
 	if testPath == nil || *testPath == "" {
 		t.Skip("Set -bpf-ut-path to run BPF tests")
@@ -81,7 +107,7 @@ func TestBPF(t *testing.T) {
 
 // common functions
 
-func loadAndRunSpec(t *testing.T, objFilename string, tt *unitTest) {
+func loadAndRunSpec(t *testing.T, objFilename string, tt *unitTest_BPF_PROG_TEST_RUN) {
 	elfPath := path.Join(*testPath, objFilename)
 	t.Logf("Running test %s", elfPath)
 
@@ -130,7 +156,7 @@ func loadAndRunSpec(t *testing.T, objFilename string, tt *unitTest) {
 	}
 
 	// Ensure test that has a jump program also has a check program
-	if programs.checkProg == nil {
+	if programs.jumpProg != nil && programs.checkProg == nil {
 		t.Fatalf(
 			"File '%s' contains a jump program in section '%s' but no check program.",
 			elfPath,
@@ -138,16 +164,21 @@ func loadAndRunSpec(t *testing.T, objFilename string, tt *unitTest) {
 		)
 	}
 
-	if !utils.KernelVersionLowerThan5_13() {
-		// TODO: use t.Context() instead of context.Background() when go 1.24 is required
-		logger.StartLogReader(context.Background(), coll.Maps["km_log_event"])
-	}
+	startLogReader(coll)
+
 	if tt.setupInUserSpace != nil {
 		tt.setupInUserSpace(t, coll)
 	}
 
 	// run the test
 	subTest(t, programs, coll.Maps[suiteResultMap])
+}
+
+func startLogReader(coll *ebpf.Collection) {
+	if !utils.KernelVersionLowerThan5_13() {
+		// TODO: use t.Context() instead of context.Background() when go 1.24 is required
+		logger.StartLogReader(context.Background(), coll.Maps["km_log_event"])
+	}
 }
 
 // loadAndPrepSpec loads an eBPF Collection Specification from the provided ELF file
@@ -177,7 +208,7 @@ func loadAndPrepSpec(t *testing.T, elfPath string) *ebpf.CollectionSpec {
 	for n, p := range spec.Programs {
 		switch p.Type {
 		// https://docs.ebpf.io/linux/syscall/BPF_PROG_TEST_RUN/
-		case ebpf.XDP, ebpf.SchedACT, ebpf.SchedCLS, ebpf.SocketFilter, ebpf.CGroupSKB:
+		case ebpf.XDP, ebpf.SchedACT, ebpf.SchedCLS, ebpf.SocketFilter, ebpf.CGroupSKB, ebpf.SockOps:
 			continue
 		}
 
@@ -192,11 +223,15 @@ func loadAndPrepSpec(t *testing.T, elfPath string) *ebpf.CollectionSpec {
 // based on the provided GlobalBpfConfig. It sets the log level and authorization
 // offload settings.
 func setBpfConfig(t *testing.T, coll *ebpf.Collection, config *factory.GlobalBpfConfig) {
-	if err := coll.Variables["bpf_log_level"].Set(&config.BpfLogLevel); err != nil {
-		t.Fatalf("failed to set bpf_log_level: %v", err)
+	if v, ok := coll.Variables["bpf_log_level"]; ok {
+		if err := v.Set(&config.BpfLogLevel); err != nil {
+			t.Fatalf("failed to set bpf_log_level: %v", err)
+		}
 	}
-	if err := coll.Variables["authz_offload"].Set(&config.AuthzOffload); err != nil {
-		t.Fatalf("failed to set authz_offload: %v", err)
+	if v, ok := coll.Variables["authz_offload"]; ok {
+		if err := v.Set(&config.AuthzOffload); err != nil {
+			t.Fatalf("failed to set authz_offload: %v", err)
+		}
 	}
 }
 

--- a/test/bpf_ut/bpftest/workload_test.go
+++ b/test/bpf_ut/bpftest/workload_test.go
@@ -19,9 +19,18 @@
 package bpftests
 
 import (
+	"encoding/binary"
+	"errors"
+	"net"
+	"os"
+	"path"
+	"strconv"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
 
 	"kmesh.net/kmesh/api/v2/workloadapi/security"
 	bpf2go "kmesh.net/kmesh/bpf/kmesh/bpf2go/dualengine"
@@ -37,13 +46,14 @@ import (
 
 func testWorkload(t *testing.T) {
 	t.Run("XDP", testXDP)
+	t.Run("SockOps", testSockOps)
 }
 
 func testXDP(t *testing.T) {
-	XDPtests := []unitTests{
+	XDPtests := []unitTests_BPF_PROG_TEST_RUN{
 		{
 			objFilename: "xdp_shutdown_in_userspace_test.o",
-			uts: []unitTest{
+			uts: []unitTest_BPF_PROG_TEST_RUN{
 				{
 					name: "1_shutdown_in_userspace__should_shutdown",
 					setupInUserSpace: func(t *testing.T, coll *ebpf.Collection) {
@@ -68,7 +78,7 @@ func testXDP(t *testing.T) {
 		},
 		{
 			objFilename: "xdp_authz_offload_test.o",
-			uts: []unitTest{
+			uts: []unitTest_BPF_PROG_TEST_RUN{
 				{
 					name: "3_deny_policy_matched",
 					setupInUserSpace: func(t *testing.T, coll *ebpf.Collection) {
@@ -278,4 +288,165 @@ func workload_setMapsEnv(t *testing.T, coll *ebpf.Collection) {
 	if err := bpfUtils.SetEnvByBpfMapId(coll.Maps["kmesh_map1600"], "KmeshMap1600"); err != nil {
 		t.Fatalf("SetEnvByBpfMapId failed: %v", err)
 	}
+}
+
+func testSockOps(t *testing.T) {
+	tests := []unitTests_BUILD_CONTEXT{
+		{
+			objFilename: "workload_sockops.o",
+			uts: []unitTest_BUILD_CONTEXT{
+				{
+					name: "BPF_SOCK_OPS_TCP_CONNECT_CB",
+					workFunc: func(t *testing.T, cgroupPath, objFilePath string) {
+						// mount cgroup2
+						mount_and_enter_cgroup2(t, cgroupPath)
+						defer syscall.Unmount(cgroupPath, 0)
+
+						// load the eBPF program
+						coll, lk := load_bpf_2_cgroup(t, objFilePath, cgroupPath)
+						defer coll.Close()
+						defer lk.Close()
+
+						// Set the BPF configuration
+						setBpfConfig(t, coll, &factory.GlobalBpfConfig{
+							BpfLogLevel:  constants.BPF_LOG_DEBUG,
+							AuthzOffload: constants.DISABLED,
+						})
+						startLogReader(coll)
+
+						// record_kmesh_managed_ip
+						enableAddr := constants.ControlCommandIp4 + ":" + strconv.Itoa(int(constants.OperEnableControl))
+						net.DialTimeout("tcp", enableAddr, 2*time.Second)
+
+						// Execute bpftool map dump and log the results (optional, for debugging)
+						// cmd := exec.Command("bpftool", "map", "dump", "name", "km_manage")
+						// output, err := cmd.CombinedOutput()
+						// if err != nil {
+						// 	t.Logf("Failed to execute bpftool command: %v", err)
+						// } else {
+						// 	// Log the raw output from bpftool for comparison
+						// 	t.Logf("bpftool map dump name km_manage output:\n%s", string(output))
+						// }
+
+						// Get the km_manage map from the collection
+						kmManageMap := coll.Maps["km_manage"]
+						if kmManageMap == nil {
+							t.Fatal("Failed to get km_manage map from collection")
+						}
+
+						var (
+							keyBytes [16]byte // sizeof(struct manager_key)
+							value    uint32
+							count    uint32
+							iter     *ebpf.MapIterator
+						)
+
+						iter = kmManageMap.Iterate()
+						for iter.Next(&keyBytes, &value) {
+							ip4HostOrder := binary.LittleEndian.Uint32(keyBytes[0:8])
+							ipStr := net.IPv4(
+								byte(ip4HostOrder),
+								byte(ip4HostOrder>>8),
+								byte(ip4HostOrder>>16),
+								byte(ip4HostOrder>>24)).String()
+							t.Logf("km_manage[%s] = %d", ipStr, value)
+							count++
+						}
+
+						if err := iter.Err(); err != nil {
+							t.Fatalf("Map iteration failed: %v", err)
+						}
+
+						if count != 1 {
+							t.Fatalf("Expected 1 entry in km_manage map, but got %d", count)
+						}
+
+						// remove_kmesh_managed_ip
+						disableAddr := constants.ControlCommandIp4 + ":" + strconv.Itoa(int(constants.OperDisableControl))
+						net.DialTimeout("tcp", disableAddr, 2*time.Second)
+
+						iter = kmManageMap.Iterate()
+						count = 0
+						for iter.Next(&keyBytes, &value) {
+							count++
+						}
+
+						if err := iter.Err(); err != nil {
+							t.Fatalf("Map iteration failed: %v", err)
+						}
+
+						if count != 0 {
+							t.Fatalf("Expected 0 entry in km_manage map, but got %d", count)
+						}
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.objFilename, tt.run())
+	}
+}
+
+func mount_and_enter_cgroup2(t *testing.T, cgroupPath string) {
+	var err error
+
+	// mount cgroup2
+	if err = os.MkdirAll(cgroupPath, 0755); err != nil {
+		t.Logf("Failed to create cgroup directory %s (might already exist): %v", cgroupPath, err)
+	}
+	err = syscall.Mount("none", cgroupPath, "cgroup2", 0, "")
+	if err != nil {
+		errno, ok := err.(syscall.Errno)
+		if ok && errno == syscall.EBUSY {
+			t.Logf("Cgroup v2 already mounted at %s", cgroupPath)
+		} else {
+			t.Fatalf("Failed to mount cgroup2 at %s: %v. Ensure test is run with sudo.", cgroupPath, err)
+		}
+	}
+
+	// Write PID to the cgroup.procs file to move the current process
+	cgroupProcsFile := path.Join(cgroupPath, "cgroup.procs")
+	if err = os.WriteFile(cgroupProcsFile, []byte(strconv.Itoa(os.Getpid())), 0644); err != nil {
+		t.Logf("Warning: Failed to write PID to %s: %v. Proceeding with connection attempt.", cgroupProcsFile, err)
+	}
+}
+
+func load_bpf_2_cgroup(t *testing.T, objFilename string, cgroupPath string) (*ebpf.Collection, link.Link) {
+	if cgroupPath == "" {
+		t.Fatal("cgroupPath is empty")
+	}
+	if objFilename == "" {
+		t.Fatal("objFilename is empty")
+	}
+
+	// load the eBPF program
+	spec := loadAndPrepSpec(t, path.Join(*testPath, objFilename))
+	var (
+		coll *ebpf.Collection
+		err  error
+	)
+
+	// Load the eBPF collection into the kernel
+	coll, err = ebpf.NewCollection(spec)
+	if err != nil {
+		var ve *ebpf.VerifierError
+		if errors.As(err, &ve) {
+			t.Fatalf("verifier error: %+v", ve)
+		} else {
+			t.Fatal("loading collection:", err)
+		}
+	}
+
+	lk, err := link.AttachCgroup(link.CgroupOptions{
+		Path:    constants.Cgroup2Path,
+		Attach:  spec.Programs["sockops_prog"].AttachType,
+		Program: coll.Programs["sockops_prog"],
+	})
+	if err != nil {
+		coll.Close()
+		t.Fatalf("Failed to attach cgroup: %v", err)
+	}
+	return coll, lk
 }

--- a/test/bpf_ut/workload_sockops.c
+++ b/test/bpf_ut/workload_sockops.c
@@ -1,0 +1,1 @@
+#include "workload/sockops.c"

--- a/test/bpf_ut/workload_sockops.c
+++ b/test/bpf_ut/workload_sockops.c
@@ -1,1 +1,0 @@
-#include "workload/sockops.c"

--- a/test/bpf_ut/workload_sockops_test.c
+++ b/test/bpf_ut/workload_sockops_test.c
@@ -1,0 +1,23 @@
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include "bpf_log.h"
+#include "bpf_common.h"
+
+// mock bpf_sk_storage_get
+struct sock_storage_data mock_storage = {
+    .via_waypoint = 1,
+};
+
+static void *mock_bpf_sk_storage_get(void *map, void *sk, void *value, __u64 flags)
+{
+    void *storage = NULL;
+    storage = bpf_sk_storage_get(map, sk, value, flags);
+    if (!storage && map == &map_of_sock_storage) {
+        storage = &mock_storage;
+    }
+    return storage;
+}
+
+#define bpf_sk_storage_get mock_bpf_sk_storage_get
+
+#include "workload/sockops.c"


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind security
/kind documentation
/kind feature

-->
/kind enhancement

**What this PR does / why we need it**:

```shell
> make ebpf_unit_test V=1 -j
... build
go test ./bpftest -bpf-ut-path /root/github/kmesh/test/bpf_ut -test.v
=== RUN   TestBPF
=== RUN   TestBPF/Workload
... XDP ut
=== RUN   TestBPF/Workload/SockOps
=== RUN   TestBPF/Workload/SockOps/workload_sockops_test.o
=== RUN   TestBPF/Workload/SockOps/workload_sockops_test.o/BPF_SOCK_OPS_TCP_CONNECT_CB
    workload_test.go:357: km_manage[192.168.0.86] = 0
=== RUN   TestBPF/Workload/SockOps/workload_sockops_test.o/BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB__enable_encoding_metadata
    workload_test.go:440: Connect success: 192.168.0.86:12345 -> 192.168.0.86:54321
    workload_test.go:465: km_socket get key[192.168.0.86:12345->192.168.0.86:54321], test success.
=== RUN   TestBPF/Workload/SockOps/workload_sockops_test.o/BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB__auth_ip_tuple
    workload_test.go:520: Connect success: 192.168.0.86:12345 -> 192.168.0.86:54321
    workload_test.go:551: Received km_auth_req ringbuf_msg: type=0, src=192.168.0.86:12345, dst=192.168.0.86:54321
=== RUN   TestBPF/Workload/SockOps/workload_sockops_test.o/BPF_SOCK_OPS_STATE_CB__clean_auth_map
    workload_test.go:632: Connect success: 192.168.0.86:12345 -> 192.168.0.86:54321
    workload_test.go:648: km_auth_res map entry was successfully cleaned up
--- PASS: TestBPF (14.65s)
    --- PASS: TestBPF/Workload (14.65s)
        --- PASS: TestBPF/Workload/XDP (1.25s)
            --- PASS: TestBPF/Workload/XDP/xdp_shutdown_in_userspace_test.o (0.58s)
                --- PASS: TestBPF/Workload/XDP/xdp_shutdown_in_userspace_test.o/1_shutdown_in_userspace__should_shutdown (0.29s)
                --- PASS: TestBPF/Workload/XDP/xdp_shutdown_in_userspace_test.o/2_shutdown_in_userspace__should_not_shutdown (0.29s)
            --- PASS: TestBPF/Workload/XDP/xdp_authz_offload_test.o (0.67s)
                --- PASS: TestBPF/Workload/XDP/xdp_authz_offload_test.o/3_deny_policy_matched (0.38s)
                --- PASS: TestBPF/Workload/XDP/xdp_authz_offload_test.o/4_allow_policy_matched (0.29s)
        --- PASS: TestBPF/Workload/SockOps (13.40s)
            --- PASS: TestBPF/Workload/SockOps/workload_sockops_test.o (13.40s)
                --- PASS: TestBPF/Workload/SockOps/workload_sockops_test.o/BPF_SOCK_OPS_TCP_CONNECT_CB (4.18s)
                --- PASS: TestBPF/Workload/SockOps/workload_sockops_test.o/BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB__enable_encoding_metadata (3.07s)
                --- PASS: TestBPF/Workload/SockOps/workload_sockops_test.o/BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB__auth_ip_tuple (3.07s)
                --- PASS: TestBPF/Workload/SockOps/workload_sockops_test.o/BPF_SOCK_OPS_STATE_CB__clean_auth_map (3.07s)
PASS
ok      kmesh.net/kmesh/test/bpf_ut/bpftest     14.791s
```

**Which issue(s) this PR fixes**:
Fixes #1209

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
