### PR TITLE
eBPF unit test: add general tc ut

### DIFF
--- a/bpf/kmesh/general/tc_mark_encrypt.c
+++ b/bpf/kmesh/general/tc_mark_encrypt.c
@@ -22,7 +22,7 @@ int tc_mark_encrypt(struct __sk_buff *ctx)
     if (!nodeinfo) {
         return TC_ACT_OK;
     }
-    // 0x00d0 mean need encryption in ipsec
+    // 0x00e0 mean need encryption in ipsec
     ctx->mark = 0x00e0;
     return TC_ACT_OK;
 }

--- a/test/bpf_ut/Makefile
+++ b/test/bpf_ut/Makefile
@@ -26,7 +26,12 @@ CLANG_FLAGS += -MD
 
 .PHONY: all clean run
 
-all: xdp_shutdown_in_userspace_test.o xdp_authz_offload_test.o workload_sockops_test.o
+all: xdp_shutdown_in_userspace_test.o \
+		xdp_authz_offload_test.o          \
+		workload_sockops_test.o           \
+		tc_mark_encrypt_test.o            \
+		tc_mark_decrypt_test.o
+
 
 XDP_FLAGS = -I$(ROOT_DIR)/bpf/kmesh/ -I$(ROOT_DIR)/bpf/kmesh/workload/include -I$(ROOT_DIR)/api/v2-c
 xdp_%.o: xdp_%.c
@@ -35,6 +40,12 @@ xdp_%.o: xdp_%.c
 WORKLOAD_SOCKOPS_FLAGS = -I$(ROOT_DIR)/bpf/kmesh/ -I$(ROOT_DIR)/bpf/kmesh/probes -I$(ROOT_DIR)/bpf/kmesh/workload/include -I$(ROOT_DIR)/api/v2-c
 workload_sockops_test.o: workload_sockops_test.c
 	$(QUIET) $(CLANG) $(CLANG_FLAGS) $(WORKLOAD_SOCKOPS_FLAGS) -c $< -o $@
+
+TC_FLAGS = -I$(ROOT_DIR)/bpf/kmesh/ -I$(ROOT_DIR)/bpf/kmesh/general/include -I$(ROOT_DIR)/bpf/kmesh/general -I$(ROOT_DIR)/api/v2-c
+tc_mark_encrypt_test.o: tc_mark_encrypt_test.c
+	$(QUIET) $(CLANG) $(CLANG_FLAGS) $(TC_FLAGS) -c $< -o $@
+tc_mark_decrypt_test.o: tc_mark_decrypt_test.c
+	$(QUIET) $(CLANG) $(CLANG_FLAGS) $(TC_FLAGS) -c $< -o $@
 
 clean:
 	$(QUIET) rm -f $(wildcard *.o)

--- a/test/bpf_ut/bpftest/bpf_test.go
+++ b/test/bpf_ut/bpftest/bpf_test.go
@@ -103,6 +103,7 @@ func TestBPF(t *testing.T) {
 	}
 
 	t.Run("Workload", testWorkload)
+	t.Run("GeneralTC", testGeneralTC)
 }
 
 // common functions
@@ -284,7 +285,7 @@ const (
 )
 
 func subTest(t *testing.T, progSet programSet, resultMap *ebpf.Map) {
-	// create ctx with the max allowed size(4k - head room - tailroom)
+	// create data payload with the max allowed size(4k - head room - tailroom)
 	data := make([]byte, 4096-256-320)
 
 	// ctx is only used for tc programs

--- a/test/bpf_ut/bpftest/general_test.go
+++ b/test/bpf_ut/bpftest/general_test.go
@@ -1,0 +1,63 @@
+//go:build linux && (amd64 || arm64) && !aix && !ppc64
+
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bpftests
+
+import (
+	"testing"
+
+	"github.com/cilium/ebpf"
+
+	"kmesh.net/kmesh/pkg/bpf/factory"
+	"kmesh.net/kmesh/pkg/constants"
+)
+
+func testGeneralTC(t *testing.T) {
+	TCtests := []unitTests_BPF_PROG_TEST_RUN{
+		{
+			objFilename: "tc_mark_encrypt_test.o",
+			uts: []unitTest_BPF_PROG_TEST_RUN{
+				{
+					name: "tc_mark_encrypt",
+					setupInUserSpace: func(t *testing.T, coll *ebpf.Collection) {
+						setBpfConfig(t, coll, &factory.GlobalBpfConfig{
+							BpfLogLevel: constants.BPF_LOG_DEBUG,
+						})
+					},
+				},
+			},
+		},
+		{
+			objFilename: "tc_mark_decrypt_test.o",
+			uts: []unitTest_BPF_PROG_TEST_RUN{
+				{
+					name: "tc_mark_decrypt",
+					setupInUserSpace: func(t *testing.T, coll *ebpf.Collection) {
+						setBpfConfig(t, coll, &factory.GlobalBpfConfig{
+							BpfLogLevel: constants.BPF_LOG_DEBUG,
+						})
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range TCtests {
+		t.Run(tt.objFilename, tt.run())
+	}
+}

--- a/test/bpf_ut/include/tc_common.h
+++ b/test/bpf_ut/include/tc_common.h
@@ -1,0 +1,128 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause) */
+/* Copyright Authors of Kmesh */
+
+#pragma once
+
+#define build_tc_packet(ctx, p_ethhdr, p_iphdr, p_tcphdr, body, body_len)                                              \
+    ({                                                                                                                 \
+        int __ret = TEST_PASS;                                                                                         \
+                                                                                                                       \
+        void *data = (void *)(long)((ctx)->data);                                                                      \
+        void *data_end = (void *)(long)((ctx)->data_end);                                                              \
+                                                                                                                       \
+        /* Set Ethernet header */                                                                                      \
+        if (data + sizeof(struct ethhdr) > data_end)                                                                   \
+            return TEST_ERROR;                                                                                         \
+        if (p_ethhdr) {                                                                                                \
+            bpf_memcpy(data, (p_ethhdr), sizeof(struct ethhdr));                                                       \
+        } else {                                                                                                       \
+            /* Default Ethernet header */                                                                              \
+            __maybe_unused const struct ethhdr default_eth = {                                                         \
+                .h_source = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF},                                                      \
+                .h_dest = {0x12, 0x23, 0x34, 0x45, 0x56, 0x67},                                                        \
+                .h_proto = bpf_htons(ETH_P_IP)};                                                                       \
+            bpf_memcpy(data, &default_eth, sizeof(struct ethhdr));                                                     \
+        }                                                                                                              \
+        data += sizeof(struct ethhdr);                                                                                 \
+                                                                                                                       \
+        /* Set IP header */                                                                                            \
+        if (data + sizeof(struct iphdr) > data_end)                                                                    \
+            return TEST_ERROR;                                                                                         \
+        if (p_iphdr) {                                                                                                 \
+            bpf_memcpy(data, (p_iphdr), sizeof(struct iphdr));                                                         \
+        } else {                                                                                                       \
+            /* Default IP header */                                                                                    \
+            __maybe_unused const unsigned int ip_payload_size = sizeof(struct tcphdr) + (body ? body_len : 0);         \
+            __maybe_unused const struct iphdr default_ip = {                                                           \
+                .version = 4,                                                                                          \
+                .ihl = 5,                                                                                              \
+                .tot_len = bpf_htons(sizeof(struct iphdr) + ip_payload_size),                                          \
+                .id = 0x5438,                                                                                          \
+                .frag_off = bpf_htons(IP_DF),                                                                          \
+                .ttl = 64,                                                                                             \
+                .protocol = IPPROTO_TCP,                                                                               \
+                .saddr = 0x0F00000A, /* 10.0.0.15 */                                                                   \
+                .daddr = 0x0100000A  /* 10.0.0.1 - assuming DEST_IP */                                                 \
+            };                                                                                                         \
+            bpf_memcpy(data, &default_ip, sizeof(struct iphdr));                                                       \
+        }                                                                                                              \
+        data += sizeof(struct iphdr);                                                                                  \
+                                                                                                                       \
+        /* Set TCP header */                                                                                           \
+        if (data + sizeof(struct tcphdr) > data_end)                                                                   \
+            return TEST_ERROR;                                                                                         \
+        if (p_tcphdr) {                                                                                                \
+            bpf_memcpy(data, (p_tcphdr), sizeof(struct tcphdr));                                                       \
+        } else {                                                                                                       \
+            /* Default TCP header */                                                                                   \
+            __maybe_unused const struct tcphdr default_tcp = {                                                         \
+                .source = bpf_htons(23445),                                                                            \
+                .dest = bpf_htons(80), /* assuming DEST_PORT */                                                        \
+                .seq = 2922048129,                                                                                     \
+                .doff = 5, /* 5 * 4 = 20 bytes, no options */                                                          \
+                .syn = 1,                                                                                              \
+                .window = 64240};                                                                                      \
+            bpf_memcpy(data, &default_tcp, sizeof(struct tcphdr));                                                     \
+        }                                                                                                              \
+        data += sizeof(struct tcphdr);                                                                                 \
+                                                                                                                       \
+        /* Set payload data */                                                                                         \
+        if (body && body_len > 0) {                                                                                    \
+            if (data + body_len > data_end)                                                                            \
+                return TEST_ERROR;                                                                                     \
+            bpf_memcpy(data, body, body_len);                                                                          \
+            data += body_len;                                                                                          \
+        }                                                                                                              \
+        /* Shrink data payload to the exact size we used */                                                            \
+        bpf_skb_change_tail(ctx, data - (void *)(long)((ctx)->data), 0);                                               \
+        __ret;                                                                                                         \
+    })
+
+#define check_tc_packet(ctx, exp_status_code, exp_ethhdr, exp_iphdr, exp_tcphdr, exp_body, exp_body_len)               \
+    do {                                                                                                               \
+        void *data = (void *)(long)((ctx)->data);                                                                      \
+        void *data_end = (void *)(long)((ctx)->data_end);                                                              \
+                                                                                                                       \
+        if (data + sizeof(__u32) > data_end)                                                                           \
+            test_fatal("status code out of bounds");                                                                   \
+        if (exp_status_code) {                                                                                         \
+            __u32 *status_code = (__u32 *)data;                                                                        \
+            if (*status_code != *(exp_status_code))                                                                    \
+                test_fatal("status code mismatch, expected %u, got %u", *(exp_status_code), *status_code);             \
+        }                                                                                                              \
+        data += sizeof(__u32);                                                                                         \
+                                                                                                                       \
+        if (data + sizeof(struct ethhdr) > data_end)                                                                   \
+            test_fatal("ethhdr out of bounds");                                                                        \
+        if (exp_ethhdr) {                                                                                              \
+            struct ethhdr *eth = (struct ethhdr *)data;                                                                \
+            if (memcmp(eth, (exp_ethhdr), sizeof(struct ethhdr)) != 0)                                                 \
+                test_fatal("ethhdr mismatch");                                                                         \
+        }                                                                                                              \
+        data += sizeof(struct ethhdr);                                                                                 \
+                                                                                                                       \
+        if (data + sizeof(struct iphdr) > data_end)                                                                    \
+            test_fatal("iphdr out of bounds");                                                                         \
+        if (exp_iphdr) {                                                                                               \
+            struct iphdr *ip = (struct iphdr *)data;                                                                   \
+            if (memcmp(ip, (exp_iphdr), sizeof(struct iphdr)) != 0)                                                    \
+                test_fatal("iphdr mismatch");                                                                          \
+        }                                                                                                              \
+        data += sizeof(struct iphdr);                                                                                  \
+                                                                                                                       \
+        if (data + sizeof(struct tcphdr) > data_end)                                                                   \
+            test_fatal("tcphdr out of bounds");                                                                        \
+        if (exp_tcphdr) {                                                                                              \
+            struct tcphdr *tcp = (struct tcphdr *)data;                                                                \
+            if (memcmp(tcp, (exp_tcphdr), sizeof(struct tcphdr)) != 0)                                                 \
+                test_fatal("tcphdr mismatch");                                                                         \
+        }                                                                                                              \
+        data += sizeof(struct tcphdr);                                                                                 \
+        if (data + exp_body_len > data_end)                                                                            \
+            test_fatal("body out of bounds");                                                                          \
+        if (exp_body) {                                                                                                \
+            char *body = (char *)data;                                                                                 \
+            if (memcmp(body, (exp_body), exp_body_len) != 0)                                                           \
+                test_fatal("body mismatch");                                                                           \
+        }                                                                                                              \
+    } while (0)

--- a/test/bpf_ut/tc_mark_decrypt_test.c
+++ b/test/bpf_ut/tc_mark_decrypt_test.c
@@ -1,0 +1,87 @@
+#include "ut_common.h"
+#include "tc_common.h"
+
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+#include <netinet/tcp.h>
+
+#include "general/tc_mark_decrypt.c"
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __uint(key_size, sizeof(__u32));
+    __uint(max_entries, 2);
+    __array(values, int());
+} entry_call_map SEC(".maps") = {
+    .values =
+        {
+            [0] = &tc_mark_decrypt,
+        },
+};
+
+/* 10.0.0.15:23445 -> 10.1.0.15:80 */
+#define SRC_IP    0x0F00000A /* 10.0.0.15 */
+#define SRC_PORT  23445
+#define DEST_IP   0x0F00010A /* 10.1.0.15 */
+#define DEST_PORT 80
+
+const struct ethhdr l2 = {
+    .h_source = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF},
+    .h_dest = {0x12, 0x23, 0x34, 0x45, 0x56, 0x67},
+    .h_proto = bpf_htons(ETH_P_IP)};
+
+const struct iphdr l3 = {
+    .version = 4,
+    .ihl = 5,
+    .tot_len = 40, /* 20 bytes l3 + 20 bytes l4 + 20 bytes data */
+    .id = 0x5438,
+    .frag_off = bpf_htons(IP_DF),
+    .ttl = 64,
+    .protocol = IPPROTO_TCP,
+    .saddr = SRC_IP,
+    .daddr = DEST_IP,
+};
+
+const struct tcphdr l4 = {
+    .source = bpf_htons(SRC_PORT),
+    .dest = bpf_htons(DEST_PORT),
+    .seq = 2922048129,
+    .doff = 0,
+    .syn = 1,
+    .window = 64240,
+};
+const char body[20] = "Should not change!!";
+
+PKTGEN("tc", "tc_mark_decrypt")
+int test1_pktgen(struct __sk_buff *ctx)
+{
+    return build_tc_packet(ctx, &l2, &l3, &l4, body, (uint)sizeof(body));
+}
+
+JUMP("tc", "tc_mark_decrypt")
+int test1_jump(struct __sk_buff *ctx)
+{
+    // build context
+    struct lpm_key key = {0};
+    key.trie_key.prefixlen = 32;
+    key.ip.ip4 = SRC_IP;
+    __u32 value = 1;
+    bpf_map_update_elem(&map_of_nodeinfo, &key, &value, BPF_ANY);
+
+    bpf_tail_call(ctx, &entry_call_map, 0);
+    return TEST_ERROR;
+}
+
+CHECK("tc", "tc_mark_decrypt")
+int test1_check(struct __sk_buff *ctx)
+{
+    const __u32 expected_status_code = TC_ACT_OK;
+
+    test_init();
+
+    check_tc_packet(ctx, &expected_status_code, &l2, &l3, &l4, body, (uint)sizeof(body));
+    if (ctx->mark != 0x00d0)
+        test_fatal("ctx->mark mismatch, expected 0x00d0, got %u", ctx->mark);
+
+    test_finish();
+}

--- a/test/bpf_ut/tc_mark_encrypt_test.c
+++ b/test/bpf_ut/tc_mark_encrypt_test.c
@@ -1,0 +1,87 @@
+#include "ut_common.h"
+#include "tc_common.h"
+
+#include <linux/bpf.h>
+#include <linux/if_ether.h>
+#include <netinet/tcp.h>
+
+#include "general/tc_mark_encrypt.c"
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __uint(key_size, sizeof(__u32));
+    __uint(max_entries, 2);
+    __array(values, int());
+} entry_call_map SEC(".maps") = {
+    .values =
+        {
+            [0] = &tc_mark_encrypt,
+        },
+};
+
+/* 10.0.0.15:23445 -> 10.1.0.15:80 */
+#define SRC_IP    0x0F00000A /* 10.0.0.15 */
+#define SRC_PORT  23445
+#define DEST_IP   0x0F00010A /* 10.1.0.15 */
+#define DEST_PORT 80
+
+const struct ethhdr l2 = {
+    .h_source = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF},
+    .h_dest = {0x12, 0x23, 0x34, 0x45, 0x56, 0x67},
+    .h_proto = bpf_htons(ETH_P_IP)};
+
+const struct iphdr l3 = {
+    .version = 4,
+    .ihl = 5,
+    .tot_len = 40, /* 20 bytes l3 + 20 bytes l4 + 20 bytes data */
+    .id = 0x5438,
+    .frag_off = bpf_htons(IP_DF),
+    .ttl = 64,
+    .protocol = IPPROTO_TCP,
+    .saddr = SRC_IP,
+    .daddr = DEST_IP,
+};
+
+const struct tcphdr l4 = {
+    .source = bpf_htons(SRC_PORT),
+    .dest = bpf_htons(DEST_PORT),
+    .seq = 2922048129,
+    .doff = 0,
+    .syn = 1,
+    .window = 64240,
+};
+const char body[20] = "Should not change!!";
+
+PKTGEN("tc", "tc_mark_encrypt")
+int test1_pktgen(struct __sk_buff *ctx)
+{
+    return build_tc_packet(ctx, &l2, &l3, &l4, body, (uint)sizeof(body));
+}
+
+JUMP("tc", "tc_mark_encrypt")
+int test1_jump(struct __sk_buff *ctx)
+{
+    // build context
+    struct lpm_key key = {0};
+    key.trie_key.prefixlen = 32;
+    key.ip.ip4 = DEST_IP;
+    __u32 value = 1;
+    bpf_map_update_elem(&map_of_nodeinfo, &key, &value, BPF_ANY);
+
+    bpf_tail_call(ctx, &entry_call_map, 0);
+    return TEST_ERROR;
+}
+
+CHECK("tc", "tc_mark_encrypt")
+int test1_check(struct __sk_buff *ctx)
+{
+    const __u32 expected_status_code = TC_ACT_OK;
+
+    test_init();
+
+    check_tc_packet(ctx, &expected_status_code, &l2, &l3, &l4, body, (uint)sizeof(body));
+    if (ctx->mark != 0x00e0)
+        test_fatal("ctx->mark mismatch, expected 0x00e0, got %u", ctx->mark);
+
+    test_finish();
+}


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind security
/kind documentation
/kind feature

-->
/kind enhancement

**What this PR does / why we need it**:

```shell
> make ebpf_unit_test V=1 -j
... build
go test ./bpftest -bpf-ut-path /root/github/kmesh/test/bpf_ut -test.v
go test ./bpftest -bpf-ut-path /root/github/kmesh/test/bpf_ut -test.v
=== RUN   TestBPF
=== RUN   TestBPF/Workload
=== RUN   TestBPF/Workload/XDP
=== RUN   TestBPF/Workload/XDP/xdp_shutdown_in_userspace_test.o
=== RUN   TestBPF/Workload/XDP/xdp_shutdown_in_userspace_test.o/1_shutdown_in_userspace__should_shutdown
    bpf_test.go:113: Running test /root/github/kmesh/test/bpf_ut/xdp_shutdown_in_userspace_test.o
    bpf_test.go:264: Successfully registered tail call policies_check -> km_xdp_tailcall[0]
    bpf_test.go:264: Successfully registered tail call policy_check -> km_xdp_tailcall[1]
    bpf_test.go:264: Successfully registered tail call xdp_shutdown_in_userspace -> km_xdp_tailcall[2]
time="2025-05-06T14:46:29+08:00" level=info msg="[XDP] INFO: auth denied, src ip: 10.0.0.15, port: 23445\n" subsys=ebpf
=== RUN   TestBPF/Workload/XDP/xdp_shutdown_in_userspace_test.o/2_shutdown_in_userspace__should_not_shutdown
    bpf_test.go:113: Running test /root/github/kmesh/test/bpf_ut/xdp_shutdown_in_userspace_test.o
    bpf_test.go:264: Successfully registered tail call policies_check -> km_xdp_tailcall[0]
    bpf_test.go:264: Successfully registered tail call policy_check -> km_xdp_tailcall[1]
    bpf_test.go:264: Successfully registered tail call xdp_shutdown_in_userspace -> km_xdp_tailcall[2]
=== RUN   TestBPF/Workload/XDP/xdp_authz_offload_test.o
=== RUN   TestBPF/Workload/XDP/xdp_authz_offload_test.o/3_deny_policy_matched
    bpf_test.go:113: Running test /root/github/kmesh/test/bpf_ut/xdp_authz_offload_test.o
    bpf_test.go:264: Successfully registered tail call policies_check -> km_xdp_tailcall[0]
    bpf_test.go:264: Successfully registered tail call policy_check -> km_xdp_tailcall[1]
    bpf_test.go:264: Successfully registered tail call xdp_shutdown_in_userspace -> km_xdp_tailcall[2]
time="2025-05-06T14:46:30+08:00" level=info msg="[AUTH] DEBUG: policy bpfut_deny__10.0.0.15->10.1.0.15:80 matched" subsys=ebpf
time="2025-05-06T14:46:30+08:00" level=info msg="[AUTH] DEBUG: src ip: 10.0.0.15, src port:23445" subsys=ebpf
time="2025-05-06T14:46:30+08:00" level=info msg="[AUTH] DEBUG: dst ip: 10.1.0.15, dst port:80\n" subsys=ebpf
=== RUN   TestBPF/Workload/XDP/xdp_authz_offload_test.o/4_allow_policy_matched
    bpf_test.go:113: Running test /root/github/kmesh/test/bpf_ut/xdp_authz_offload_test.o
    bpf_test.go:264: Successfully registered tail call policies_check -> km_xdp_tailcall[0]
    bpf_test.go:264: Successfully registered tail call policy_check -> km_xdp_tailcall[1]
    bpf_test.go:264: Successfully registered tail call xdp_shutdown_in_userspace -> km_xdp_tailcall[2]
time="2025-05-06T14:46:30+08:00" level=info msg="[AUTH] DEBUG: policy bpfut_allow__10.0.0.15->10.1.0.15:80 matched" subsys=ebpf
time="2025-05-06T14:46:30+08:00" level=info msg="[AUTH] DEBUG: src ip: 10.0.0.15, src port:23445" subsys=ebpf
time="2025-05-06T14:46:30+08:00" level=info msg="[AUTH] DEBUG: dst ip: 10.1.0.15, dst port:80\n" subsys=ebpf
=== RUN   TestBPF/Workload/SockOps
=== RUN   TestBPF/Workload/SockOps/workload_sockops_test.o
=== RUN   TestBPF/Workload/SockOps/workload_sockops_test.o/BPF_SOCK_OPS_TCP_CONNECT_CB__modify_kmesh_managed_ip
    workload_test.go:357: km_manage[192.168.0.86] = 0
=== RUN   TestBPF/Workload/SockOps/workload_sockops_test.o/BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB__enable_encoding_metadata
    workload_test.go:440: Connect success: 192.168.0.86:12345 -> 192.168.0.86:54321
    workload_test.go:465: km_socket get key[192.168.0.86:12345->192.168.0.86:54321], test success.
=== RUN   TestBPF/Workload/SockOps/workload_sockops_test.o/BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB__auth_ip_tuple
    workload_test.go:520: Connect success: 192.168.0.86:12345 -> 192.168.0.86:54321
    workload_test.go:551: Received km_auth_req ringbuf_msg: type=0, src=192.168.0.86:12345, dst=192.168.0.86:54321
=== RUN   TestBPF/Workload/SockOps/workload_sockops_test.o/BPF_SOCK_OPS_STATE_CB__clean_auth_map
    workload_test.go:632: Connect success: 192.168.0.86:12345 -> 192.168.0.86:54321
    workload_test.go:648: km_auth_res map entry was successfully cleaned up
=== RUN   TestBPF/GeneralTC
=== RUN   TestBPF/GeneralTC/tc_mark_encrypt_test.o
=== RUN   TestBPF/GeneralTC/tc_mark_encrypt_test.o/tc_mark_encrypt
    bpf_test.go:113: Running test /root/github/kmesh/test/bpf_ut/tc_mark_encrypt_test.o
=== RUN   TestBPF/GeneralTC/tc_mark_decrypt_test.o
=== RUN   TestBPF/GeneralTC/tc_mark_decrypt_test.o/tc_mark_decrypt
    bpf_test.go:113: Running test /root/github/kmesh/test/bpf_ut/tc_mark_decrypt_test.o
time="2025-05-06T14:46:43+08:00" level=error msg="ringbuf new reader from rb map failed:add fd to epoll: bad file descriptor" subsys=ebpf
--- PASS: TestBPF (14.50s)
    --- PASS: TestBPF/Workload (14.50s)
        --- PASS: TestBPF/Workload/XDP (1.25s)
            --- PASS: TestBPF/Workload/XDP/xdp_shutdown_in_userspace_test.o (0.59s)
                --- PASS: TestBPF/Workload/XDP/xdp_shutdown_in_userspace_test.o/1_shutdown_in_userspace__should_shutdown (0.29s)
                --- PASS: TestBPF/Workload/XDP/xdp_shutdown_in_userspace_test.o/2_shutdown_in_userspace__should_not_shutdown (0.30s)
            --- PASS: TestBPF/Workload/XDP/xdp_authz_offload_test.o (0.66s)
                --- PASS: TestBPF/Workload/XDP/xdp_authz_offload_test.o/3_deny_policy_matched (0.34s)
                --- PASS: TestBPF/Workload/XDP/xdp_authz_offload_test.o/4_allow_policy_matched (0.32s)
        --- PASS: TestBPF/Workload/SockOps (13.25s)
            --- PASS: TestBPF/Workload/SockOps/workload_sockops_test.o (13.25s)
                --- PASS: TestBPF/Workload/SockOps/workload_sockops_test.o/BPF_SOCK_OPS_TCP_CONNECT_CB__modify_kmesh_managed_ip (4.03s)
                --- PASS: TestBPF/Workload/SockOps/workload_sockops_test.o/BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB__enable_encoding_metadata (3.07s)
                --- PASS: TestBPF/Workload/SockOps/workload_sockops_test.o/BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB__auth_ip_tuple (3.07s)
                --- PASS: TestBPF/Workload/SockOps/workload_sockops_test.o/BPF_SOCK_OPS_STATE_CB__clean_auth_map (3.08s)
    --- PASS: TestBPF/GeneralTC (0.00s)
        --- PASS: TestBPF/GeneralTC/tc_mark_encrypt_test.o (0.00s)
            --- PASS: TestBPF/GeneralTC/tc_mark_encrypt_test.o/tc_mark_encrypt (0.00s)
        --- PASS: TestBPF/GeneralTC/tc_mark_decrypt_test.o (0.00s)
            --- PASS: TestBPF/GeneralTC/tc_mark_decrypt_test.o/tc_mark_decrypt (0.00s)
PASS
ok      kmesh.net/kmesh/test/bpf_ut/bpftest     14.547s
make[1]: Leaving directory '/root/github/kmesh/test/bpf_ut'
```

**Which issue(s) this PR fixes**:
Fixes #1209

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
