### PR TITLE
fix log cannot print in kernel 5.10 by bpf_trace_printk

### DIFF
--- a/bpf/kmesh/ads/include/cluster.h
+++ b/bpf/kmesh/ads/include/cluster.h
@@ -311,13 +311,9 @@ static inline int cluster_handle_loadbalance(Cluster__Cluster *cluster, address_
         return -EAGAIN;
     }
 
-    BPF_LOG(
-        INFO,
-        CLUSTER,
-        "cluster=\"%s\", loadbalance to addr=[%s:%u]\n",
-        name,
-        ip2str(&sock_addr->ipv4, 1),
-        bpf_ntohs(sock_addr->port));
+    // Since bpf_trace_printk cannot print two %s, the name and ipv4 are printed separately.
+    BPF_LOG(INFO, CLUSTER, "cluster=\"%s\"\n", name);
+    BPF_LOG(INFO, CLUSTER, "loadbalance to addr=[%s:%u]\n", ip2str(&sock_addr->ipv4, 1), bpf_ntohs(sock_addr->port));
     SET_CTX_ADDRESS(ctx, sock_addr);
     return 0;
 }

--- a/bpf/kmesh/workload/xdp.c
+++ b/bpf/kmesh/workload/xdp.c
@@ -48,28 +48,6 @@ static inline int should_shutdown(struct xdp_info *info, struct bpf_sock_tuple *
     return AUTH_PASS;
 }
 
-static inline int xdp_deny_packet(struct xdp_info *info, struct bpf_sock_tuple *tuple_info)
-{
-    if (info->iph != NULL && info->iph->version == 4) {
-        BPF_LOG(
-            INFO,
-            XDP,
-            "auth denied, src ip: %s, dst ip %s, dst port: %u\n",
-            ip2str(&tuple_info->ipv4.saddr, true),
-            ip2str(&tuple_info->ipv4.daddr, true),
-            bpf_ntohs(tuple_info->ipv4.dport));
-    } else {
-        BPF_LOG(
-            INFO,
-            XDP,
-            "auth denied, src ip: %s, dst ip %s, dst port: %u\n",
-            ip2str(&tuple_info->ipv6.saddr[0], false),
-            ip2str(&tuple_info->ipv6.daddr[0], false),
-            bpf_ntohs(tuple_info->ipv6.dport));
-    }
-    return XDP_DROP;
-}
-
 volatile __u32 authz_offload = 1;
 
 static bool is_authz_offload_enabled()


### PR DESCRIPTION
bpf_trace_printk cannot print two %s, need to fix

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
bpf_trace_printk cannot print two %s, need to fix

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
