### PR TITLE
refactored updateConnectionMetricCache to report connection-metrics correctly

### DIFF
--- a/pkg/controller/telemetry/metric.go
+++ b/pkg/controller/telemetry/metric.go
@@ -521,7 +521,7 @@ func (m *MetricController) Run(ctx context.Context, mapOfTcpInfo *ebpf.Map) {
 			}
 			m.updateServiceMetricCache(reqMetric, serviceLabels, tcpConns[reqMetric.conSrcDstInfo])
 			if m.EnableConnectionMetric.Load() && reqMetric.duration > LONG_CONN_METRIC_THRESHOLD {
-				m.updateConnectionMetricCache(reqMetric, tcpConns[reqMetric.conSrcDstInfo], connectionLabels)
+				m.updateConnectionMetricCache(reqMetric, connectionLabels)
 			}
 			m.mutex.Unlock()
 
@@ -907,7 +907,7 @@ func (m *MetricController) updateServiceMetricCache(reqMetric requestMetric, lab
 	}
 }
 
-func (m *MetricController) updateConnectionMetricCache(reqMetric requestMetric, connMetric connMetric, labels connectionMetricLabels) {
+func (m *MetricController) updateConnectionMetricCache(reqMetric requestMetric, labels connectionMetricLabels) {
 	v, ok := m.connectionMetricCache[labels]
 	if ok {
 		v.ConnSentBytes = v.ConnSentBytes + float64(reqMetric.sentBytes)
@@ -916,10 +916,10 @@ func (m *MetricController) updateConnectionMetricCache(reqMetric requestMetric, 
 		v.ConnTotalRetrans = v.ConnTotalRetrans + float64(reqMetric.totalRetrans)
 	} else {
 		newConnectionMetricInfo := connectionMetricInfo{}
-		newConnectionMetricInfo.ConnSentBytes = float64(connMetric.sentBytes)
-		newConnectionMetricInfo.ConnReceivedBytes = float64(connMetric.receivedBytes)
-		newConnectionMetricInfo.ConnPacketLost = float64(connMetric.packetLost)
-		newConnectionMetricInfo.ConnTotalRetrans = float64(connMetric.totalRetrans)
+		newConnectionMetricInfo.ConnSentBytes = float64(reqMetric.sentBytes)
+		newConnectionMetricInfo.ConnReceivedBytes = float64(reqMetric.receivedBytes)
+		newConnectionMetricInfo.ConnPacketLost = float64(reqMetric.packetLost)
+		newConnectionMetricInfo.ConnTotalRetrans = float64(reqMetric.totalRetrans)
 		m.connectionMetricCache[labels] = &newConnectionMetricInfo
 	}
 	if reqMetric.state == TCP_CLOSED {

--- a/pkg/controller/telemetry/metric_test.go
+++ b/pkg/controller/telemetry/metric_test.go
@@ -491,9 +491,8 @@ func TestBuildServiceMetricsToPrometheus(t *testing.T) {
 
 func TestBuildConnectionMetricsToPrometheus(t *testing.T) {
 	type args struct {
-		data     requestMetric
-		labels   connectionMetricLabels
-		tcpConns map[connectionSrcDst]connMetric
+		data   requestMetric
+		labels connectionMetricLabels
 	}
 	tests := []struct {
 		id   int32
@@ -541,26 +540,6 @@ func TestBuildConnectionMetricsToPrometheus(t *testing.T) {
 					requestProtocol:              "tcp",
 					responseFlags:                "-",
 					connectionSecurityPolicy:     "mutual_tls",
-				},
-				tcpConns: map[connectionSrcDst]connMetric{
-					{
-						src:       [4]uint32{183763210, 0, 0, 0},
-						dst:       [4]uint32{183762951, 0, 0, 0},
-						direction: constants.INBOUND,
-					}: {
-						sentBytes:     0x0000003,
-						receivedBytes: 0x0000004,
-						packetLost:    0x0000001,
-						totalRetrans:  0x0000002,
-						totalReports:  1,
-					},
-					{
-						src:       [4]uint32{183763210, 0, 0, 0},
-						dst:       [4]uint32{183762951, 0, 0, 0},
-						direction: constants.OUTBOUND,
-					}: {
-						totalReports: 3,
-					},
 				},
 			},
 			want: []float64{
@@ -610,26 +589,6 @@ func TestBuildConnectionMetricsToPrometheus(t *testing.T) {
 					requestProtocol:              "tcp",
 					responseFlags:                "-",
 					connectionSecurityPolicy:     "mutual_tls",
-				},
-				tcpConns: map[connectionSrcDst]connMetric{
-					{
-						src:       [4]uint32{183763210, 0, 0, 0},
-						dst:       [4]uint32{183762951, 0, 0, 0},
-						direction: constants.INBOUND,
-					}: {
-						sentBytes:     0x0000003,
-						receivedBytes: 0x0000004,
-						packetLost:    0x0000001,
-						totalRetrans:  0x0000002,
-						totalReports:  1,
-					},
-					{
-						src:       [4]uint32{183763210, 0, 0, 0},
-						dst:       [4]uint32{183762951, 0, 0, 0},
-						direction: constants.OUTBOUND,
-					}: {
-						totalReports: 3,
-					},
 				},
 			},
 			want: []float64{
@@ -681,7 +640,7 @@ func TestBuildConnectionMetricsToPrometheus(t *testing.T) {
 			}
 
 			deleteConnection = []*connectionMetricLabels{}
-			m.updateConnectionMetricCache(tt.args.data, tt.args.tcpConns[tt.args.data.conSrcDstInfo], tt.args.labels)
+			m.updateConnectionMetricCache(tt.args.data, tt.args.labels)
 			assert.Equal(t, m.connectionMetricCache[tt.args.labels].ConnSentBytes, tt.want[0])
 			assert.Equal(t, m.connectionMetricCache[tt.args.labels].ConnReceivedBytes, tt.want[1])
 			assert.Equal(t, m.connectionMetricCache[tt.args.labels].ConnPacketLost, tt.want[2])


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
refactored updateConnectionMetricCache to report connection-metrics correctly
**Which issue(s) this PR fixes**:
Fixes #1370

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```
correct long_conn metrics 

```
