### PR TITLE
Fix: unexpected log when pod is shutting down

### DIFF
--- a/bpf/kmesh/probes/probe.h
+++ b/bpf/kmesh/probes/probe.h
@@ -77,7 +77,7 @@ static inline void observe_on_close(struct bpf_sock *sk)
 
     storage = bpf_sk_storage_get(&map_of_sock_storage, sk, 0, 0);
     if (!storage) {
-        BPF_LOG(ERR, PROBE, "on close: bpf_sk_storage_get failed\n");
+        // maybe the connection is established before kmesh start
         return;
     }
 
@@ -95,10 +95,9 @@ static inline void observe_on_data(struct bpf_sock *sk)
     if (!tcp_sock)
         return;
 
-    // Use BPF_LOCAL_STORAGE_GET_F_CREATE in case a connection being established before kmesh start.
-    storage = bpf_sk_storage_get(&map_of_sock_storage, sk, 0, BPF_LOCAL_STORAGE_GET_F_CREATE);
+    storage = bpf_sk_storage_get(&map_of_sock_storage, sk, 0, 0);
     if (!storage) {
-        BPF_LOG(ERR, PROBE, "on data: bpf_sk_storage_get failed dst  %u \n", bpf_ntohs(sk->dst_port));
+        // maybe the connection is established before kmesh start
         return;
     }
     __u64 now = bpf_ktime_get_ns();

--- a/bpf/kmesh/probes/tcp_probe.h
+++ b/bpf/kmesh/probes/tcp_probe.h
@@ -110,15 +110,9 @@ static inline void get_tcp_probe_info(struct bpf_tcp_sock *tcp_sock, struct tcp_
 
 // construct_orig_dst_info try to read the dst_info from map_of_sock_storage first
 // if not found, use the tuple info for orig_dst
-static inline void construct_orig_dst_info(struct bpf_sock *sk, struct tcp_probe_info *info)
+static inline void
+construct_orig_dst_info(struct bpf_sock *sk, struct sock_storage_data *storage, struct tcp_probe_info *info)
 {
-    struct sock_storage_data *storage = NULL;
-    storage = bpf_sk_storage_get(&map_of_sock_storage, sk, 0, 0);
-    if (!storage) {
-        BPF_LOG(ERR, PROBE, "on close: bpf_sk_storage_get failed\n");
-        return;
-    }
-
     if (sk->family == AF_INET) {
         info->orig_dst.ipv4.addr = storage->sk_tuple.ipv4.daddr;
         info->orig_dst.ipv4.port = bpf_ntohs(storage->sk_tuple.ipv4.dport);
@@ -136,7 +130,6 @@ static inline void construct_orig_dst_info(struct bpf_sock *sk, struct tcp_probe
 static inline void
 tcp_report(struct bpf_sock *sk, struct bpf_tcp_sock *tcp_sock, struct sock_storage_data *storage, __u32 state)
 {
-    // struct connect_info *info = NULL;
     struct tcp_probe_info *info = NULL;
 
     // store tuple
@@ -157,7 +150,7 @@ tcp_report(struct bpf_sock *sk, struct bpf_tcp_sock *tcp_sock, struct sock_stora
         (*info).type = IPV4;
     }
 
-    construct_orig_dst_info(sk, info);
+    construct_orig_dst_info(sk, storage, info);
     info->last_report_ns = bpf_ktime_get_ns();
     info->duration = info->last_report_ns - storage->connect_ns;
     storage->last_report_ns = info->last_report_ns;

--- a/pkg/controller/manage/manage_controller.go
+++ b/pkg/controller/manage/manage_controller.go
@@ -160,6 +160,15 @@ func (c *KmeshManageController) handlePodAdd(obj interface{}) {
 }
 
 func (c *KmeshManageController) handlePodUpdate(_, newObj interface{}) {
+	pod, ok := newObj.(*corev1.Pod)
+	if !ok {
+		log.Errorf("expected *corev1.Pod but got %T", newObj)
+		return
+	}
+	if pod.DeletionTimestamp != nil {
+		log.Debugf("pod %s/%s is being deleted, skip remanage", pod.Namespace, pod.Name)
+		return
+	}
 	c.handlePodAdd(newObj)
 }
 
@@ -229,7 +238,7 @@ func (c *KmeshManageController) enableKmeshManage(pod *corev1.Pod) {
 		log.Debugf("Pod %s/%s is not ready, skipping Kmesh manage enable", pod.GetNamespace(), pod.GetName())
 		return
 	}
-	log.Infof("%s/%s: enable Kmesh manage", pod.GetNamespace(), pod.GetName())
+	log.Debugf("%s/%s: enable Kmesh manage", pod.GetNamespace(), pod.GetName())
 	nspath, _ := ns.GetPodNSpath(pod)
 	if err := utils.HandleKmeshManage(nspath, true); err != nil {
 		log.Errorf("failed to enable Kmesh manage")


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:


For https://github.com/kmesh-net/kmesh/issues/1381

eliminate these logs during pod shutdown

```
time="2025-05-09T01:32:09Z" level=info msg="default/ws-server: enable Kmesh manage" subsys=manage_controller
time="2025-05-09T01:32:09Z" level=info msg="add annotation for pod default/ws-server" subsys=manage_controller
time="2025-05-09T01:32:09Z" level=info msg="default/ws-client: enable Kmesh manage" subsys=manage_controller
time="2025-05-09T01:32:09Z" level=info msg="add annotation for pod default/ws-client" subsys=manage_controller
```

```
// this is because the connection is established before kmesh starts
time="2025-05-09T01:32:39Z" level=info msg="[PROBE] ERR: on close: bpf_sk_storage_get failed\n" subsys=ebpf

```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
