### PR TITLE
Fix: assert.Equal argument order in status server test files

### DIFF
--- a/pkg/status/status_server_test.go
+++ b/pkg/status/status_server_test.go
@@ -451,21 +451,21 @@ func TestServerMetricHandler(t *testing.T) {
 		w = httptest.NewRecorder()
 		server.accesslogHandler(w, req)
 
-		assert.Equal(t, server.xdsClient.WorkloadController.GetAccesslogTrigger(), false)
+		assert.Equal(t, false, server.xdsClient.WorkloadController.GetAccesslogTrigger())
 
 		url = fmt.Sprintf("%s?enable=%s", patternWorkloadMetrics, "false")
 		req = httptest.NewRequest(http.MethodPost, url, nil)
 		w = httptest.NewRecorder()
 		server.workloadMetricHandler(w, req)
 
-		assert.Equal(t, server.xdsClient.WorkloadController.GetWorklaodMetricTrigger(), false)
+		assert.Equal(t, false, server.xdsClient.WorkloadController.GetWorklaodMetricTrigger())
 
 		url = fmt.Sprintf("%s?enable=%s", patternConnectionMetrics, "false")
 		req = httptest.NewRequest(http.MethodPost, url, nil)
 		w = httptest.NewRecorder()
 		server.connectionMetricHandler(w, req)
 
-		assert.Equal(t, server.xdsClient.WorkloadController.GetConnectionMetricTrigger(), false)
+		assert.Equal(t, false, server.xdsClient.WorkloadController.GetConnectionMetricTrigger())
 	})
 
 	t.Run("when monitoring is disable, cannot enable accesslog, workload metrics and connection metrics", func(t *testing.T) {
@@ -493,28 +493,28 @@ func TestServerMetricHandler(t *testing.T) {
 		w := httptest.NewRecorder()
 		server.monitoringHandler(w, req)
 
-		assert.Equal(t, server.xdsClient.WorkloadController.GetMonitoringTrigger(), false)
+		assert.Equal(t, false, server.xdsClient.WorkloadController.GetMonitoringTrigger())
 
 		url = fmt.Sprintf("%s?enable=%s", patternAccesslog, "true")
 		req = httptest.NewRequest(http.MethodPost, url, nil)
 		w = httptest.NewRecorder()
 		server.accesslogHandler(w, req)
 
-		assert.Equal(t, server.xdsClient.WorkloadController.GetAccesslogTrigger(), false)
+		assert.Equal(t, false, server.xdsClient.WorkloadController.GetAccesslogTrigger())
 
 		url = fmt.Sprintf("%s?enable=%s", patternWorkloadMetrics, "true")
 		req = httptest.NewRequest(http.MethodPost, url, nil)
 		w = httptest.NewRecorder()
 		server.workloadMetricHandler(w, req)
 
-		assert.Equal(t, server.xdsClient.WorkloadController.GetWorklaodMetricTrigger(), false)
+		assert.Equal(t, false, server.xdsClient.WorkloadController.GetWorklaodMetricTrigger())
 
 		url = fmt.Sprintf("%s?enable=%s", patternConnectionMetrics, "true")
 		req = httptest.NewRequest(http.MethodPost, url, nil)
 		w = httptest.NewRecorder()
 		server.connectionMetricHandler(w, req)
 
-		assert.Equal(t, server.xdsClient.WorkloadController.GetConnectionMetricTrigger(), false)
+		assert.Equal(t, false, server.xdsClient.WorkloadController.GetConnectionMetricTrigger())
 	})
 }
 
@@ -544,8 +544,8 @@ func TestServerMonitoringHandler(t *testing.T) {
 		w := httptest.NewRecorder()
 		server.monitoringHandler(w, req)
 
-		assert.Equal(t, server.xdsClient.WorkloadController.GetMonitoringTrigger(), true)
-		assert.Equal(t, server.xdsClient.WorkloadController.GetAccesslogTrigger(), true)
+		assert.Equal(t, true, server.xdsClient.WorkloadController.GetMonitoringTrigger())
+		assert.Equal(t, true, server.xdsClient.WorkloadController.GetAccesslogTrigger())
 		enableMonitoring := l.GetEnableMonitoring()
 		assert.Equal(t, constants.ENABLED, enableMonitoring)
 	})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
refactored assert.Equal in status server test files to make it compatible with argument order. 
**Which issue(s) this PR fixes**:
Fixes #1338 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
