### PR TITLE
Fix: make format with too many containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tools/vagrant/.vagrant/
 .run/
 # Visual Studio Code
 .vscode/
+.local/
 # Bazel
 /bazel-*
 # vi swap files
@@ -40,6 +41,7 @@ coverage.out
 # build artifacts
 *.so
 *.o
+*.o.tmp
 
 kernel/**/*.ko
 kernel/**/*.cmd

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,1 @@
+linux-bpf.h

--- a/hack/format.sh
+++ b/hack/format.sh
@@ -33,5 +33,9 @@ install_shell_format
 shfmt -w -s -ln=bash ./
 
 if [ -z "$GITHUB_ACTIONS" ]; then
-	docker run -u 0 -w /workspace -v "$PWD":/workspace davidanson/markdownlint-cli2:v0.18.1 "**/*.md" "--fix"
+	docker run --rm \
+		-v "$PWD":/workspace \
+		-w /workspace \
+		davidanson/markdownlint-cli2:v0.18.1 \
+		markdownlint-cli2 --fix "**/*.md"
 fi

--- a/kmesh_compile_env_pre.sh
+++ b/kmesh_compile_env_pre.sh
@@ -12,7 +12,6 @@ function install_libboundscheck() {
 }
 
 function dependency_pkg_install() {
-
 	if command -v apt >/dev/null; then
 		echo "Checking for required packages on a Debian-based system..."
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

/kind enhancement

**What this PR does / why we need it**:

`make format` will create a `markdownlint-cli2` container with random name every time, which needs to be fix.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
