### PR TITLE
fix: exclude k8s.io dependencies from dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: daily
-    groups:
-      k8s.io:
-        patterns:
-          - "k8s.io/*"
+    ignore:
+      - dependency-name: "k8s.io/*"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Excludes k8s.io/* packages from automatic dependabot updates to prevent compatibility breaking changes. 

**Which issue(s) this PR fixes**:
Fixes #1403

**Special notes for your reviewer**:
Changed from grouping k8s.io packages to completely ignoring them as suggested by the maintainer. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE

```
