### PR TITLE
add ipsec controller unit test

### DIFF
--- a/pkg/controller/encryption/ipsec/ipsec_controller.go
+++ b/pkg/controller/encryption/ipsec/ipsec_controller.go
@@ -292,7 +292,9 @@ func (c *IPSecController) handleKNIDelete(obj interface{}) {
 			c.ipsecHandler.mutex.Lock()
 			err := c.ipsecHandler.Clean(targetIP)
 			c.ipsecHandler.mutex.Unlock()
-			return err
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	}

--- a/pkg/controller/encryption/ipsec/ipsec_controller.go
+++ b/pkg/controller/encryption/ipsec/ipsec_controller.go
@@ -290,12 +290,17 @@ func (c *IPSecController) handleKNIDelete(obj interface{}) {
 	deleteFunc := func(netns.NetNS) error {
 		for _, targetIP := range node.Spec.Addresses {
 			c.ipsecHandler.mutex.Lock()
-			_ = c.ipsecHandler.Clean(targetIP)
+			err := c.ipsecHandler.Clean(targetIP)
 			c.ipsecHandler.mutex.Unlock()
+			return err
 		}
 		return nil
 	}
-	_ = netns.WithNetNSPath(nodeNsPath, deleteFunc)
+	err := netns.WithNetNSPath(nodeNsPath, deleteFunc)
+	if err != nil {
+		log.Errorf("failed to delete ipsec for node %s: %v", node.Name, err)
+		return
+	}
 	for _, podCIDR := range node.Spec.PodCIDRs {
 		c.deleteKNIMapCIDR(podCIDR, c.kniMap)
 	}
@@ -441,6 +446,7 @@ func (c *IPSecController) processNextItem() bool {
 			log.Errorf("failed to handle other node %s err: %v, giving up", name, err)
 			c.queue.Forget(key)
 		}
+		return true
 	}
 
 	c.queue.Forget(key)

--- a/pkg/controller/encryption/ipsec/ipsec_controller_test.go
+++ b/pkg/controller/encryption/ipsec/ipsec_controller_test.go
@@ -323,10 +323,10 @@ func TestHandleKNIEvents(t *testing.T) {
 				deleteMapCalled = true
 			})
 
-			// Call handleKNIDelete - should still process map deletions even if network operations fail
+			// Call handleKNIDelete - should not process map deletions when network operations fail
 			controller.handleKNIDelete(testRemoteNodeInfo)
 
-			// Verify that deleteKNIMapCIDR was still called despite network namespace failure
+			// Verify that deleteKNIMapCIDR will not called when network namespace fail
 			assert.False(t, deleteMapCalled, "deleteKNIMapCIDR should not be called if network operations fail")
 		})
 	})

--- a/pkg/controller/encryption/ipsec/ipsec_controller_test.go
+++ b/pkg/controller/encryption/ipsec/ipsec_controller_test.go
@@ -266,7 +266,7 @@ func TestHandleKNIEvents(t *testing.T) {
 		assert.Equal(t, 1, controller.queue.Len())
 	})
 
-	// handleKNIDelete tests move to TestIPSecController_MapOperations, because it operates on map
+	// handleKNIDelete tests move to TestMapOperations, because it operates on map
 }
 
 func getLoader(t *testing.T) (*bpf.BpfLoader, test.CleanupFn) {

--- a/pkg/controller/encryption/ipsec/ipsec_controller_test.go
+++ b/pkg/controller/encryption/ipsec/ipsec_controller_test.go
@@ -1,0 +1,605 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ipsec
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/cilium/ebpf"
+
+	netns "github.com/containernetworking/plugins/pkg/ns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"kmesh.net/kmesh/daemon/options"
+	"kmesh.net/kmesh/pkg/bpf"
+	"kmesh.net/kmesh/pkg/constants"
+	"kmesh.net/kmesh/pkg/kube"
+	v1alpha1 "kmesh.net/kmesh/pkg/kube/apis/kmeshnodeinfo/v1alpha1"
+	fakeKmeshClientset "kmesh.net/kmesh/pkg/kube/nodeinfo/clientset/versioned/fake"
+	"kmesh.net/kmesh/pkg/utils/test"
+)
+
+var (
+	testLocalNodeInfo = &v1alpha1.KmeshNodeInfo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-local-node",
+			Namespace: "kmesh-system",
+		},
+		Spec: v1alpha1.KmeshNodeInfoSpec{
+			SPI:       123,
+			Addresses: []string{"10.0.0.1", "192.168.1.1"},
+			BootID:    "test-boot-id",
+			PodCIDRs:  []string{"10.244.0.1/24", "10.244.0.2/24"},
+		},
+	}
+
+	testRemoteNodeInfo = &v1alpha1.KmeshNodeInfo{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-remote-node",
+			Namespace: "kmesh-system",
+		},
+		Spec: v1alpha1.KmeshNodeInfoSpec{
+			SPI:       456,
+			Addresses: []string{"10.0.0.2"},
+			BootID:    "test-boot-id-2",
+			PodCIDRs:  []string{"10.244.1.1/24", "10.244.1.2/24"},
+		},
+	}
+
+	testK8sNode = &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-local-node",
+		},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{Type: corev1.NodeInternalIP, Address: "10.0.0.1"},
+				{Type: corev1.NodeExternalIP, Address: "192.168.1.1"},
+			},
+			NodeInfo: corev1.NodeSystemInfo{
+				BootID: "test-boot-id",
+			},
+		},
+		Spec: corev1.NodeSpec{
+			PodCIDRs: []string{"10.244.0.1/24", "10.244.0.2/24"},
+		},
+	}
+
+	testKey = IpSecKey{
+		Spi:         1,
+		AeadKeyName: "rfc4106(gcm(aes))",
+		AeadKey:     DecodeHex("abc9410d7cd6b324461bf16db518646594276c5362c30fc476ebca3f1a394b6ed4462161"),
+		Length:      128,
+	}
+)
+
+func prepareForController(t *testing.T) error {
+	// Create temporary directory and file for testing
+	tempDir := t.TempDir()
+	tempFile := filepath.Join(tempDir, "kmesh-ipsec", "ipSec")
+	err := os.MkdirAll(filepath.Dir(tempFile), 0755)
+	if err != nil {
+		return err
+	}
+
+	// Create a simple valid ipSec file content
+	keyJson, err := json.Marshal(testKey)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(tempFile, keyJson, 0644) // create ./kmesh-ipsec/ipSec
+	if err != nil {
+		return err
+	}
+
+	// chang workdir to tmpdir to read ipsec key file, to avoid none file error
+	oldDir, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	err = os.Chdir(tempDir)
+	if err != nil {
+		return err
+	}
+
+	old := os.Getenv("NODE_NAME")
+	os.Setenv("NODE_NAME", "test-local-node")
+	t.Cleanup(func() {
+		os.Chdir(oldDir)
+		os.Setenv("NODE_NAME", old)
+	})
+	return nil
+}
+
+func TestNewIPsecController(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupEnv      func() func()
+		setupMocks    func() *gomonkey.Patches
+		expectedError bool
+		errorContains string
+	}{
+		{
+			name: "successful_creation",
+			setupEnv: func() func() {
+				return func() {
+					err := prepareForController(t)
+					assert.NoError(t, err)
+				}
+			},
+			expectedError: false,
+		},
+		{
+			name: "missing_node_name_env",
+			setupEnv: func() func() {
+				return func() {
+					os.Setenv("NODE_NAME", "")
+				}
+			},
+			expectedError: true,
+			errorContains: "failed to get kmesh node info from k8s",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Setup environment
+			setupEnv := tt.setupEnv()
+			setupEnv()
+
+			// Setup patches
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+
+			// Create fake clients
+			k8sClient := fake.NewSimpleClientset(testK8sNode)
+			kmeshClient := fakeKmeshClientset.NewSimpleClientset(testLocalNodeInfo)
+
+			// Create mock eBPF components
+			mockMap := &ebpf.Map{}
+			mockProg := &ebpf.Program{}
+
+			// Apply patches for kube.GetKmeshNodeInfoClient to return our fake client
+			clientPatches := gomonkey.NewPatches()
+			clientPatches.ApplyFuncReturn(kube.GetKmeshNodeInfoClient, kmeshClient, nil)
+			defer clientPatches.Reset()
+
+			controller, err := NewIPsecController(k8sClient, mockMap, mockProg)
+
+			if tt.expectedError {
+				assert.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+				assert.Nil(t, controller)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, controller)
+				assert.Equal(t, "test-local-node", controller.kmeshNodeInfo.Name)
+			}
+		})
+	}
+}
+
+func TestHandleKNIEvents(t *testing.T) {
+	err := prepareForController(t)
+	require.NoError(t, err)
+	// Setup patches
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	// Create fake clients
+	k8sClient := fake.NewSimpleClientset(testK8sNode)
+	kmeshClient := fakeKmeshClientset.NewSimpleClientset()
+	patches.ApplyFuncReturn(kube.GetKmeshNodeInfoClient, kmeshClient, nil)
+
+	// Create mock eBPF components
+	mockMap := &ebpf.Map{}
+	mockProg := &ebpf.Program{}
+	controller, err := NewIPsecController(k8sClient, mockMap, mockProg)
+	require.NoError(t, err)
+	require.NotNil(t, controller)
+
+	t.Run("handleKNIAdd", func(t *testing.T) {
+		// Reset queue
+		controller.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]())
+
+		// Test adding a remote node (should be added to queue)
+		controller.handleKNIAdd(testRemoteNodeInfo)
+		time.Sleep(50 * time.Millisecond) // wait for item to be added, need to be longer than the maximum retry delay, basedelay 5 ms, maxretries 5, maxdelay 5 + x ns
+		assert.Equal(t, 1, controller.queue.Len())
+
+		// Test adding local node (should be ignored)
+		controller.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]()) // Reset queue
+		controller.handleKNIAdd(testLocalNodeInfo)
+		time.Sleep(50 * time.Millisecond) // wait for queue to be added
+		assert.Equal(t, 0, controller.queue.Len())
+	})
+
+	t.Run("handleKNIUpdate", func(t *testing.T) {
+		controller.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]()) // Reset queue
+
+		// Test updating with same spec (should be ignored)
+		controller.handleKNIUpdate(testRemoteNodeInfo, testRemoteNodeInfo)
+		time.Sleep(50 * time.Millisecond) // wait for queue to be updated
+		assert.Equal(t, 0, controller.queue.Len())
+
+		// Test updating local node (should be ignored)
+		controller.handleKNIUpdate(testLocalNodeInfo, testLocalNodeInfo)
+		time.Sleep(50 * time.Millisecond) // wait for queue to be updated
+		assert.Equal(t, 0, controller.queue.Len())
+
+		// Test updating with different spec (should be added to queue)
+		updatedNode := testRemoteNodeInfo.DeepCopy()
+		updatedNode.Spec.SPI = 789
+		controller.handleKNIUpdate(testRemoteNodeInfo, updatedNode)
+		time.Sleep(50 * time.Millisecond) // wait for queue to be updated
+		assert.Equal(t, 1, controller.queue.Len())
+	})
+
+	// handleKNIDelete tests move to TestIPSecController_MapOperations, because it operates on map
+}
+
+func getLoader(t *testing.T) (*bpf.BpfLoader, test.CleanupFn) {
+	config := options.BpfConfig{
+		Mode:        constants.DualEngineMode,
+		BpfFsPath:   "/sys/fs/bpf",
+		Cgroup2Path: "/mnt/kmesh_cgroup2",
+		EnableIPsec: true,
+	}
+	cleanfn, loader := test.InitBpfMap(t, config)
+
+	return loader, cleanfn
+}
+
+func TestMapOperations(t *testing.T) {
+	loader, cleanfn := getLoader(t)
+	t.Cleanup(cleanfn)
+	kniMap := loader.GetBpfWorkload().Tc.KmeshTcMarkEncryptObjects.KmNodeinfo
+	decryptProg := loader.GetBpfWorkload().Tc.KmeshTcMarkDecryptPrograms.TcMarkDecrypt
+
+	err := prepareForController(t)
+	require.NoError(t, err)
+	// Setup patches
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	// Create fake clients
+	k8sClient := fake.NewSimpleClientset(testK8sNode)
+	kmeshClient := fakeKmeshClientset.NewSimpleClientset()
+	patches.ApplyFuncReturn(kube.GetKmeshNodeInfoClient, kmeshClient, nil)
+
+	// Create controller
+	controller, err := NewIPsecController(k8sClient, kniMap, decryptProg)
+	require.NoError(t, err)
+	require.NotNil(t, controller)
+
+	// test multiple address
+	testCases := []struct {
+		name     string
+		cidr     string
+		expected bool
+	}{
+		{"valid_ipv4_cidr", "192.168.1.0/24", true},
+		{"valid_ipv4_cidr_32", "10.0.0.1/32", true},
+		{"valid_ipv6_cidr", "2001:db8::/64", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// add CIDR to KNI map
+			err := controller.updateKNIMapCIDR(tc.cidr, kniMap)
+			if tc.expected {
+				require.NoError(t, err)
+
+				// varify add success
+				key, err := controller.generalKNIMapKey(tc.cidr)
+				require.NoError(t, err)
+				var value uint32
+				err = kniMap.Lookup(key, &value)
+				require.NoError(t, err)
+				assert.Equal(t, uint32(1), value)
+
+				// delete CIDR
+				controller.deleteKNIMapCIDR(tc.cidr, kniMap)
+
+				// varify delete success
+				err = kniMap.Lookup(key, &value)
+				assert.Error(t, err) // not found
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+// Test update local kmesh node info and sync all node info
+func TestNodeOperations(t *testing.T) {
+	err := prepareForController(t)
+	require.NoError(t, err)
+
+	// Create clients
+	k8sClient := fake.NewSimpleClientset(testK8sNode)
+	kmeshClient := fakeKmeshClientset.NewSimpleClientset()
+
+	// Patch kube.GetKmeshNodeInfoClient to return our fake client
+	clientPatches := gomonkey.NewPatches()
+	clientPatches.ApplyFuncReturn(kube.GetKmeshNodeInfoClient, kmeshClient, nil)
+	defer clientPatches.Reset()
+
+	// Create mock eBPF components
+	mockMap := &ebpf.Map{}
+	mockProg := &ebpf.Program{}
+
+	t.Run("createAndUpdateLocalKmeshNodeInfo", func(t *testing.T) {
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+		controller, err := NewIPsecController(k8sClient, mockMap, mockProg)
+		assert.NoError(t, err)
+		assert.NotNil(t, controller)
+		go controller.informer.Run(stopCh)
+		if !cache.WaitForCacheSync(stopCh, controller.informer.HasSynced) {
+			t.Fatal("timed out waiting for caches to sync")
+		}
+		// no node info
+		node, err := controller.lister.KmeshNodeInfos("kmesh-system").Get("test-local-node")
+		assert.Error(t, err)
+		assert.Nil(t, node)
+
+		err = controller.updateLocalKmeshNodeInfo()
+		assert.NoError(t, err)
+
+		// wait for get node info
+		err = wait.PollUntilContextTimeout(context.Background(), 20*time.Millisecond, 200*time.Millisecond, false, func(context.Context) (bool, error) {
+			_, err := controller.lister.KmeshNodeInfos("kmesh-system").Get("test-local-node")
+			return err == nil, nil
+		})
+		assert.NoError(t, err)
+
+		node, err = controller.lister.KmeshNodeInfos("kmesh-system").Get("test-local-node")
+		assert.NoError(t, err)
+		assert.NotNil(t, node)
+		assert.Equal(t, "test-local-node", node.Name)
+		assert.Equal(t, 1, node.Spec.SPI) // should be same to testKey
+
+		// test update local node info
+		// new node info
+		controller.kmeshNodeInfo.Spec.SPI = 2
+
+		err = controller.updateLocalKmeshNodeInfo()
+		assert.NoError(t, err)
+
+		// wait for node info update
+		err = wait.PollUntilContextTimeout(context.Background(), 20*time.Millisecond, 200*time.Millisecond, false, func(context.Context) (bool, error) {
+			nodeinfo, err := controller.lister.KmeshNodeInfos("kmesh-system").Get("test-local-node")
+			if nodeinfo != nil && nodeinfo.Spec.SPI == 2 {
+				return true, nil
+			}
+			if err != nil {
+				return false, err
+			}
+			return false, nil
+		})
+		assert.NoError(t, err)
+
+		// lister can get new node info
+		node, err = controller.lister.KmeshNodeInfos("kmesh-system").Get("test-local-node")
+		assert.NoError(t, err)
+		assert.NotNil(t, node)
+		assert.Equal(t, 2, node.Spec.SPI) // new spi
+	})
+
+	t.Run("syncAllNodeInfo", func(t *testing.T) {
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+		controller, err := NewIPsecController(k8sClient, mockMap, mockProg)
+		assert.NoError(t, err)
+		assert.NotNil(t, controller)
+
+		// Create remote node
+		_, err = kmeshClient.KmeshV1alpha1().KmeshNodeInfos("kmesh-system").Create(context.TODO(), testRemoteNodeInfo, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		// Patch handleOneNodeInfo
+		syncPatch := gomonkey.NewPatches()
+		syncPatch.ApplyPrivateMethod(reflect.TypeOf(&IPSecController{}), "handleOneNodeInfo", func(c *IPSecController, node *v1alpha1.KmeshNodeInfo) error {
+			if node.Name == testRemoteNodeInfo.Name { // test if get remote node info and ignore local node info
+				return nil
+			}
+			return fmt.Errorf("failed to get remote node info")
+		})
+		defer syncPatch.Reset()
+
+		go controller.informer.Run(stopCh)
+		if !cache.WaitForCacheSync(stopCh, controller.informer.HasSynced) {
+			t.Fatal("timed out waiting for caches to sync")
+		}
+
+		err = controller.syncAllNodeInfo()
+		assert.NoError(t, err)
+	})
+
+	// test handle testRemoteNodeInfo
+	t.Run("handleOneNodeInfo", func(t *testing.T) {
+		stopCh := make(chan struct{})
+		defer close(stopCh)
+		controller, err := NewIPsecController(k8sClient, mockMap, mockProg)
+		assert.NoError(t, err)
+		assert.NotNil(t, controller)
+
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+		podCIDRSet := make(map[string]bool)
+
+		for _, podCIDR := range testRemoteNodeInfo.Spec.PodCIDRs {
+			podCIDRSet[podCIDR] = true
+		}
+		patches.ApplyPrivateMethod(&IpSecHandler{}, "CreateXfrmRule", func(_ *IpSecHandler, localNode *v1alpha1.KmeshNodeInfo, remoteNode *v1alpha1.KmeshNodeInfo) error {
+			// mock, remote node info should be same with testRemoteNodeInfo
+			for _, podCIDR := range remoteNode.Spec.PodCIDRs {
+				if !podCIDRSet[podCIDR] {
+					return fmt.Errorf("remote node info podCIDRs is not equal")
+				}
+			}
+			return nil
+		})
+		patches.ApplyPrivateMethod(&IPSecController{}, "updateKNIMapCIDR", func(c *IPSecController, remoteCIDR string, mapfd *ebpf.Map) error {
+			// mock, remote node info should be same with testRemoteNodeInfo
+			if !podCIDRSet[remoteCIDR] {
+				return fmt.Errorf("remote node info podCIDRs is not equal")
+			}
+			return nil
+		})
+
+		patches.ApplyFunc(netns.WithNetNSPath, func(nspath string, toRun func(netns.NetNS) error) error {
+			return nil
+		})
+
+		err = controller.handleOneNodeInfo(testRemoteNodeInfo)
+		assert.NoError(t, err)
+	})
+}
+
+func TestProcessNextItem(t *testing.T) {
+	err := prepareForController(t)
+	require.NoError(t, err)
+
+	// Setup patches
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+
+	// Create clients
+	k8sClient := fake.NewSimpleClientset(testK8sNode)
+	kmeshClient := fakeKmeshClientset.NewSimpleClientset()
+
+	// Create the remote node in the client
+	_, err = kmeshClient.KmeshV1alpha1().KmeshNodeInfos("kmesh-system").Create(context.TODO(), testRemoteNodeInfo, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// Apply patches for kube.GetKmeshNodeInfoClient to return our fake client
+	clientPatches := gomonkey.NewPatches()
+	clientPatches.ApplyFuncReturn(kube.GetKmeshNodeInfoClient, kmeshClient, nil)
+	defer clientPatches.Reset()
+
+	// Create mock eBPF components
+	mockMap := &ebpf.Map{}
+	mockProg := &ebpf.Program{}
+
+	controller, err := NewIPsecController(k8sClient, mockMap, mockProg)
+	require.NoError(t, err)
+	require.NotNil(t, controller)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go controller.informer.Run(stopCh)
+	if !cache.WaitForCacheSync(stopCh, controller.informer.HasSynced) {
+		t.Fatal("timed out waiting for caches to sync")
+	}
+	t.Run("successful_processing", func(t *testing.T) {
+		// Reset queue
+		controller.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]())
+
+		// Add remote node to queue
+		controller.queue.Add("test-remote-node")
+
+		// Mock handleOneNodeInfo to avoid complex IPsec operations
+		handlerPatches := gomonkey.NewPatches()
+		handlerPatches.ApplyPrivateMethod(reflect.TypeOf(&IPSecController{}), "handleOneNodeInfo", func(_ *IPSecController, _ *v1alpha1.KmeshNodeInfo) error {
+			return nil // Simulate success
+		})
+		defer handlerPatches.Reset()
+
+		// Process the item
+		result := controller.processNextItem()
+		controller.queue.Done("test-remote-node")
+		assert.True(t, result)                     // Should return true indicating continue processing
+		assert.Equal(t, 0, controller.queue.Len()) // Item should be removed from queue
+	})
+
+	t.Run("non_existent_node", func(t *testing.T) {
+		// Reset queue
+		controller.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]())
+
+		// Test with non-existent node
+		controller.queue.Add("non-existent-node")
+		result := controller.processNextItem()
+		controller.queue.Done("non-existent-node")
+		assert.True(t, result)                     // Should still return true
+		assert.Equal(t, 0, controller.queue.Len()) // Item should be removed from queue
+	})
+
+	t.Run("handleOneNodeInfo_err_within_retry_limit", func(t *testing.T) {
+		// Reset queue
+		controller.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]())
+
+		controller.queue.Add("test-local-node")
+		failPatches := gomonkey.NewPatches()
+		failPatches.ApplyPrivateMethod(reflect.TypeOf(&IPSecController{}), "handleOneNodeInfo", func(_ *IPSecController, _ *v1alpha1.KmeshNodeInfo) error {
+			return fmt.Errorf("test error") // Simulate failure
+		})
+		defer failPatches.Reset()
+
+		// Create local node info
+		controller.knclient.Create(context.TODO(), &controller.kmeshNodeInfo, metav1.CreateOptions{})
+		// controller.updateLocalKmeshNodeInfo()
+		assert.NoError(t, err)
+
+		time.Sleep(time.Second)
+
+		result := controller.processNextItem()
+		assert.True(t, result) // Should still return true
+		assert.Equal(t, 0, controller.queue.NumRequeues("test-local-node"))
+	})
+
+	t.Run("handleOneNodeInfo_err_exceed_limit", func(t *testing.T) {
+		// Reset queue
+		controller.queue = workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[any]())
+
+		controller.queue.Add("test-local-node")
+		failPatches := gomonkey.NewPatches()
+		failPatches.ApplyPrivateMethod(reflect.TypeOf(&IPSecController{}), "handleOneNodeInfo", func(_ *IPSecController, _ *v1alpha1.KmeshNodeInfo) error {
+			return fmt.Errorf("test error") // Simulate failure
+		})
+		for range 5 {
+			controller.queue.AddRateLimited("test-local-node") // increment numrequeues
+		}
+
+		controller.knclient.Create(context.TODO(), &controller.kmeshNodeInfo, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		time.Sleep(time.Second)
+		assert.NoError(t, err)
+
+		controller.processNextItem()
+		assert.Equal(t, 0, controller.queue.NumRequeues("test-local-node"))
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement
/kind security

**What this PR does / why we need it**:
Add ipsec controller unit test. 
*Main content introduction as follows:*

1. TestNewIPsecController: Tests IPsec controller initialization including:
    
    - Successful instance creation with proper environment setup
    - Failure scenarios when required environment variables are missing

2. TestHandleKNIEvents: Validates KmeshNodeInfo event handling logic including:

    -  handleKNIAdd: Tests adding remote nodes to workqueue while ignoring local nodes
    - handleKNIUpdate: Verifies no queue addition for unchanged specs and SPI field updates triggering queue addition

3. TestMapOperations: Tests BPF map operations including:
    - CIDR address add/delete operations

4. TestNodeOperations: Validates node synchronization functionality including:

    - Local node info creation/update
    - All node info synchronization
    -  Xfrm rule and KNI map association with handleOneNodeInfo

5. TestProcessNextItem: Validates workqueue processing logic including:

    - Normal node processing flow
    - Handling non-existent nodes
    -  Function handleOneNodeInfo error in function processNextItem and retry mechanisms (within and beyond retry limits)

6. TestHandleTc: Validates the IPsec controller's TC (Traffic Control) program attachment/detachment logic

*changes in ipsec_controller.go*
1. Fixed a bug in processNextItem function https://github.com/kmesh-net/kmesh/issues/1462
2. Added error handling for WithNetNSPath in handleKNIDelete to ensure consistency between KNIMap and xfrm states/policies  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
