### PR TITLE
Fix typo : Duel to Dual

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -19,7 +19,7 @@ labels: kind/bug
 **Environment**:
 
 - Kmesh version:
-- Kmesh mode(kmesh has `Kernel-Native Mode` and `Duel-Engine Mode`):
+- Kmesh mode(kmesh has `Kernel-Native Mode` and `Dual-Engine Mode`):
 - Istio version:
 - Kernel version:
 - Others:

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -17,7 +17,7 @@ Please make sure you have read the FAQ and searched the issue list.
 **Environment**:
 
 - Kmesh version:
-- Kmesh mode(kmesh has `Kernel-Native Mode` and `Duel-Engine Mode`):
+- Kmesh mode(kmesh has `Kernel-Native Mode` and `Dual-Engine Mode`):
 - Istio version:
 - Kernel version:
 - Others:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Kmesh innovatively sinks Layer 4 and Simple Layer 7 (HTTP) traffic governance to
 Kmesh also provide a Dual-Engine Mode, which makes use of eBPF and waypoint to process L4 and L7 traffic separately, thus allow you to adopt Kmesh incrementally, enabling a smooth transition from no mesh, to a secure L4, to full L7 processing.
 
 <div align="center">
-    <img src="docs/pics/dual-engine-mode.png" alt="duel-engine-mode" width="800" />
+    <img src="docs/pics/dual-engine-mode.png" alt="dual-engine-mode" width="800" />
     <p>Dual-Engine Mode</p>
 </div>
 

--- a/docs/en/kmesh_support.md
+++ b/docs/en/kmesh_support.md
@@ -4,9 +4,9 @@ Kmesh requires kernel eBPF functionality and sizeable eBPF Instruction Sets, so 
 
 Kmesh uses istiod as a control plane and therefore Kmesh has some dependencies on istio versions and kubernetes versions.
 
-Kmesh has two different modes, `Kernel-Native Mode` and `Duel-Engine Mode`. While there is no difference in the OS kernel version required for the two modes, the supported istio versions differ. Therefore we explain them separately.
+Kmesh has two different modes, `Kernel-Native Mode` and `Dual-Engine Mode`. While there is no difference in the OS kernel version required for the two modes, the supported istio versions differ. Therefore we explain them separately.
 
-- **Kmesh Duel-Engine Mode:**
+- **Kmesh Dual-Engine Mode:**
 
 | Version | Request Kernel Version | Supported Istio Version | Support Kubernetes Version |
 | :-------------: | :-------------: | :-------------: | :-------------: |
@@ -15,7 +15,7 @@ Kmesh has two different modes, `Kernel-Native Mode` and `Duel-Engine Mode`. Whil
 | 0.4.x | >=5.10 | 1.22, 1.23 | 1.26, 1.27, 1.28, 1.29, 1.30 |
 | 0.3.x | >=5.10 | 1.22 | 1.26, 1.27, 1.28, 1.29, 1.30 |
 
-**Note:** Kmesh's Duel-Engine Mode requires the setting of `pilot.env.PILOT_ENABLE_AMBIENT=true` in istiod. so 1.22+ istio is required!
+**Note:** Kmesh's Dual-Engine Mode requires the setting of `pilot.env.PILOT_ENABLE_AMBIENT=true` in istiod. so 1.22+ istio is required!
 
 - **Kmesh Kernel-Native Mode:**
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:
Fixes a typo by replacing duel with dual in the following files:
* [README.md#L43](https://github.com/kmesh-net/kmesh/blob/73ea8402d1610ccbc77392827b0d66922cc52d22/README.md?plain=1#L43)
* [.github/ISSUE\_TEMPLATE/bug-report.md#L22](https://github.com/kmesh-net/kmesh/blob/73ea8402d1610ccbc77392827b0d66922cc52d22/.github/ISSUE_TEMPLATE/bug-report.md?plain=1#L22)
* [.github/ISSUE\_TEMPLATE/question.md#L20](https://github.com/kmesh-net/kmesh/blob/73ea8402d1610ccbc77392827b0d66922cc52d22/.github/ISSUE_TEMPLATE/question.md?plain=1#L20)
* [docs/en/kmesh\_support.md#L7](https://github.com/kmesh-net/kmesh/blob/73ea8402d1610ccbc77392827b0d66922cc52d22/docs/en/kmesh_support.md?plain=1#L7)
* [docs/en/kmesh\_support.md#L9](https://github.com/kmesh-net/kmesh/blob/73ea8402d1610ccbc77392827b0d66922cc52d22/docs/en/kmesh_support.md?plain=1#L9)
* [docs/en/kmesh\_support.md#L18](https://github.com/kmesh-net/kmesh/blob/73ea8402d1610ccbc77392827b0d66922cc52d22/docs/en/kmesh_support.md?plain=1#L18)

**Which issue(s) this PR fixes**:
Fixes #1482 

**Special notes for your reviewer**:
updated the specified markdown files, correcting the typo

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
