### PR TITLE
feature(workflow): added Kmeshctl sycing workflow

### DIFF
--- a/.github/workflows/sync-kmeshctl-docs.yml
+++ b/.github/workflows/sync-kmeshctl-docs.yml
@@ -1,4 +1,4 @@
-name: Sync kmeshctl Docs to Website
+name: Sync kmeshctl Docs to Website (via PR)
 
 on:
   push:
@@ -17,15 +17,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kmesh-net/website
-          token: ${{ secrets.WEBSITE_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           path: website
+          ref: main
           fetch-depth: 1
 
       - name: 🧭 Checkout kmesh repository
         uses: actions/checkout@v4
         with:
           repository: kmesh-net/kmesh
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }} 
           path: kmesh
           fetch-depth: 1
 
@@ -39,67 +40,32 @@ jobs:
           echo "🔍 Source directory: $KMESH_CTL_DIR"
           echo "🎯 Target directory: $WEBSITE_KMESHCTL_DIR"
 
-          # ✅ Check if source directory exists
           if [ ! -d "$KMESH_CTL_DIR" ]; then
-            echo "❌ ERROR: Source directory $KMESH_CTL_DIR does not exist!"
-            ls -la /github/workspace/kmesh/docs/
+            echo "❌ ERROR: Source directory does not exist!"
             exit 1
           fi
 
-          # 📁 Create target directory if not exists
           if [ ! -d "$WEBSITE_KMESHCTL_DIR" ]; then
             echo "📁 Creating $WEBSITE_KMESHCTL_DIR..."
             mkdir -p "$WEBSITE_KMESHCTL_DIR"
           fi
 
-          # 🔍 LOG SOURCE FILES before sync
-          echo "📄 Files in SOURCE ($KMESH_CTL_DIR) before sync:"
-          if [ -d "$KMESH_CTL_DIR" ]; then
-            find "$KMESH_CTL_DIR" -type f | sort || echo "No files found"
-          else
-            echo "❌ Source directory missing!"
-            exit 1
-          fi
+          echo "📄 Files in SOURCE before sync:"
+          find "$KMESH_CTL_DIR" -type f | sort
 
-          # 🔍 LOG TARGET FILES before sync
-          echo "📄 Files in TARGET ($WEBSITE_KMESHCTL_DIR) before sync:"
-          if [ -d "$WEBSITE_KMESHCTL_DIR" ]; then
-            find "$WEBSITE_KMESHCTL_DIR" -type f | sort || echo "No files found"
-          else
-            echo "⚠️ Target directory empty or missing"
-          fi
+          echo "🔄 Syncing files with rsync..."
+          rsync -avc --delete --exclude='.git' --exclude='.*' "$KMESH_CTL_DIR/" "$WEBSITE_KMESHCTL_DIR/"
 
-          # 🔄 Run rsync to sync files with checksum for content changes
-          echo "🔄 Syncing files with rsync (using checksum for content comparison)..."
-          rsync -avc --delete --exclude='.git' --exclude='.*' "$KMESH_CTL_DIR/" "$WEBSITE_KMESHCTL_DIR/" || {
-            echo "❌ ERROR: rsync synchronization failed!"
-            exit 1
-          }
+          echo "📄 Files in TARGET after sync:"
+          find "$WEBSITE_KMESHCTL_DIR" -type f | sort
 
-          # 🔍 LOG TARGET FILES after sync
-          echo "📄 Files in TARGET ($WEBSITE_KMESHCTL_DIR) after sync:"
-          if [ -d "$WEBSITE_KMESHCTL_DIR" ]; then
-            find "$WEBSITE_KMESHCTL_DIR" -type f | sort || echo "No files copied"
-          else
-            echo "❌ ERROR: Target directory not created!"
-            exit 1
-          fi
-
-          # 🔀 Go into website repo
           cd /github/workspace/website
 
-          # 📥 Refresh Git index and stage all changes
-          echo "🔍 Refreshing Git index and staging changes in docs/kmeshctl/..."
-          git reset --hard
+          # Stage changes
           git add -A docs/kmeshctl/
 
-          # 🔍 Show what was staged
-          echo "📌 Staged changes:"
-          git diff --cached --name-only || echo "No changes staged"
-
-          # ✅ Check if there are any changes
           if git diff --cached --quiet; then
-            echo "✅ No changes detected. All docs are up to date."
+            echo "✅ No changes detected."
             exit 0
           else
             echo "✨ Changes detected. Creating commit..."
@@ -107,18 +73,24 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
 
-            git commit -m 'docs: sync kmeshctl docs from kmesh-net/kmesh' || {
-              echo "❌ ERROR: Commit failed!"
-              git status
-              exit 1
-            }
-
-            echo "📤 Pushing changes to kmesh-net/website..."
-            git push origin main || {
-              echo "❌ ERROR: Push failed!"
-              git status
-              exit 1
-            }
-
-            echo "🎉 Sync completed successfully!"
+            git commit -m 'docs: sync kmeshctl docs from kmesh-net/kmesh'
+            echo "✅ Commit created."
           fi
+
+      - name: 🤝 Create Pull Request
+        if: ${{ success() }}
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.WEBSITE_PAT }} 
+          path: website
+          branch: automated/sync-kmeshctl-docs-${{ github.run_id }}
+          base: main
+          title: "docs: sync latest kmeshctl documentation"
+          body: |
+            This PR syncs the latest changes from [kmesh/docs/ctl](https://github.com/kmesh-net/kmesh/tree/main/docs/ctl).
+
+            🔍 **Please review before merging.**
+
+            _Automated by GitHub Actions._
+          commit-message: "docs: sync kmeshctl docs"
+          delete-branch: true

--- a/.github/workflows/sync-kmeshctl-docs.yml
+++ b/.github/workflows/sync-kmeshctl-docs.yml
@@ -1,0 +1,124 @@
+name: Sync kmeshctl Docs to Website
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/ctl/**
+      - .github/workflows/sync-kmeshctl-docs.yml
+
+jobs:
+  sync-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🧭 Checkout website repository
+        uses: actions/checkout@v4
+        with:
+          repository: kmesh-net/website
+          token: ${{ secrets.WEBSITE_PAT }}
+          path: website
+          fetch-depth: 1
+
+      - name: 🧭 Checkout kmesh repository
+        uses: actions/checkout@v4
+        with:
+          repository: kmesh-net/kmesh
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: kmesh
+          fetch-depth: 1
+
+      - name: 🔁 Sync kmeshctl Docs Using rsync
+        run: |
+          set -e
+
+          KMESH_CTL_DIR="/github/workspace/kmesh/docs/ctl"
+          WEBSITE_KMESHCTL_DIR="/github/workspace/website/docs/kmeshctl"
+
+          echo "🔍 Source directory: $KMESH_CTL_DIR"
+          echo "🎯 Target directory: $WEBSITE_KMESHCTL_DIR"
+
+          # ✅ Check if source directory exists
+          if [ ! -d "$KMESH_CTL_DIR" ]; then
+            echo "❌ ERROR: Source directory $KMESH_CTL_DIR does not exist!"
+            ls -la /github/workspace/kmesh/docs/
+            exit 1
+          fi
+
+          # 📁 Create target directory if not exists
+          if [ ! -d "$WEBSITE_KMESHCTL_DIR" ]; then
+            echo "📁 Creating $WEBSITE_KMESHCTL_DIR..."
+            mkdir -p "$WEBSITE_KMESHCTL_DIR"
+          fi
+
+          # 🔍 LOG SOURCE FILES before sync
+          echo "📄 Files in SOURCE ($KMESH_CTL_DIR) before sync:"
+          if [ -d "$KMESH_CTL_DIR" ]; then
+            find "$KMESH_CTL_DIR" -type f | sort || echo "No files found"
+          else
+            echo "❌ Source directory missing!"
+            exit 1
+          fi
+
+          # 🔍 LOG TARGET FILES before sync
+          echo "📄 Files in TARGET ($WEBSITE_KMESHCTL_DIR) before sync:"
+          if [ -d "$WEBSITE_KMESHCTL_DIR" ]; then
+            find "$WEBSITE_KMESHCTL_DIR" -type f | sort || echo "No files found"
+          else
+            echo "⚠️ Target directory empty or missing"
+          fi
+
+          # 🔄 Run rsync to sync files with checksum for content changes
+          echo "🔄 Syncing files with rsync (using checksum for content comparison)..."
+          rsync -avc --delete --exclude='.git' --exclude='.*' "$KMESH_CTL_DIR/" "$WEBSITE_KMESHCTL_DIR/" || {
+            echo "❌ ERROR: rsync synchronization failed!"
+            exit 1
+          }
+
+          # 🔍 LOG TARGET FILES after sync
+          echo "📄 Files in TARGET ($WEBSITE_KMESHCTL_DIR) after sync:"
+          if [ -d "$WEBSITE_KMESHCTL_DIR" ]; then
+            find "$WEBSITE_KMESHCTL_DIR" -type f | sort || echo "No files copied"
+          else
+            echo "❌ ERROR: Target directory not created!"
+            exit 1
+          fi
+
+          # 🔀 Go into website repo
+          cd /github/workspace/website
+
+          # 📥 Refresh Git index and stage all changes
+          echo "🔍 Refreshing Git index and staging changes in docs/kmeshctl/..."
+          git reset --hard
+          git add -A docs/kmeshctl/
+
+          # 🔍 Show what was staged
+          echo "📌 Staged changes:"
+          git diff --cached --name-only || echo "No changes staged"
+
+          # ✅ Check if there are any changes
+          if git diff --cached --quiet; then
+            echo "✅ No changes detected. All docs are up to date."
+            exit 0
+          else
+            echo "✨ Changes detected. Creating commit..."
+
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+
+            git commit -m 'docs: sync kmeshctl docs from kmesh-net/kmesh' || {
+              echo "❌ ERROR: Commit failed!"
+              git status
+              exit 1
+            }
+
+            echo "📤 Pushing changes to kmesh-net/website..."
+            git push origin main || {
+              echo "❌ ERROR: Push failed!"
+              git status
+              exit 1
+            }
+
+            echo "🎉 Sync completed successfully!"
+          fi


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement
/kind documentation
/kind feature


**What this PR does / why we need it**:
- This PR updates the Sync kmeshctl Docs to Website GitHub Actions workflow to improve the synchronization of documentation between the kmesh-net/kmesh and kmesh-net/website repositories. 
- It ensures that the website/docs/kmeshctl directory is created if missing and populated with all files from kmesh/docs/ctl. Additionally, it enhances the workflow to detect and sync new changes (content modifications, added files, and deleted files) using rsync with checksum comparison, addressing previous issues where changes were not recognized. 
- This is necessary to maintain consistent and up-to-date documentation across repositories.
- Emojis are used for better readability and visual scanning of logs

**Which issue(s) this PR fixes**:
Fixes #1412

**Setup Instructions**:
Step 1: Create a Fine-Grained Personal Access Token (PAT)

1. Go to: [GitHub Settings → Tokens (Fine-grained)](https://github.com/settings/tokens)
2. Click "Generate new token"
3. Configure:
     - Name: kmesh-to-website-sync
     - Repository access: Select kmesh-net/website
     - Permissions:
        - Contents → Read and write
        - Pull Request → Read and write
4. Copy the token (you can't see it again)
 
Step 2: Add Secret to kmesh Repository

1. Go to: https://github.com/kmesh-net/kmesh/settings/secrets/actions
2. Click "New repository secret"
     - Name: WEBSITE_PAT
     - Value: Paste your PAT

**Special notes for your reviewer**:
- Please verify that the WEBSITE_PAT secret is correctly configured in the kmesh-net/kmesh repository with write access to kmesh-net/website.
- Note that the workflow uses absolute paths (/github/workspace/) and a git reset --hard step to ensure the Git index reflects rsynced changes; this may overwrite local uncommitted changes in the website repo during execution.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
