### PR TITLE
feat(kmeshctl):automatic key generation for ipsec secrets

### DIFF
--- a/ctl/secret/secret.go
+++ b/ctl/secret/secret.go
@@ -50,7 +50,7 @@ func NewCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newCreateCmd())
-	
+
 	return cmd
 }
 
@@ -102,7 +102,6 @@ func createSecretWithRandomKey() {
 		log.Errorf("failed to generate random key: %v", err)
 		os.Exit(1)
 	}
-
 
 	ipSecKey.AeadKey = aeadKey
 	ipSecKey.Length = AeadAlgoICVLength

--- a/ctl/secret/secret.go
+++ b/ctl/secret/secret.go
@@ -151,4 +151,5 @@ func createSecretWithRandomKey() {
 			os.Exit(1)
 		}
 	}
+	log.Infof("IPsec secret created successfully")
 }

--- a/docs/ctl/kmeshctl.md
+++ b/docs/ctl/kmeshctl.md
@@ -14,6 +14,6 @@ Kmesh command line tools to operate and debug Kmesh
 * [kmeshctl dump](kmeshctl_dump.md) - Dump config of kernel-native or dual-engine mode
 * [kmeshctl log](kmeshctl_log.md) - Get or set kmesh-daemon's logger level
 * [kmeshctl monitoring](kmeshctl_monitoring.md) - Control Kmesh's monitoring to be turned on as needed
-* [kmeshctl secret](kmeshctl_secret.md) - Use secrets to generate secret configuration data for IPsec
+* [kmeshctl secret](kmeshctl_secret.md) - Manage IPsec secrets for Kmesh
 * [kmeshctl version](kmeshctl_version.md) - Prints out build version info
 * [kmeshctl waypoint](kmeshctl_waypoint.md) - Manage waypoint configuration

--- a/docs/ctl/kmeshctl_secret.md
+++ b/docs/ctl/kmeshctl_secret.md
@@ -1,29 +1,18 @@
 ## kmeshctl secret
 
-Use secrets to generate secret configuration data for IPsec
+Manage IPsec secrets for Kmesh
 
-```bash
-kmeshctl secret [flags]
-```
+### Synopsis
 
-### Examples
-
-```bash
-# Use secrets to generate secret configuration data for IPsec:
- kmeshctl secret --key or -k, only support use aead algo: rfc4106(gcm(aes))
- key need 36 characters(use 32 characters as key, 4 characters as salt).
- Hexadecimal dump is required when the key is entered.
- e.g.:kmeshctl secret --key=$(dd if=/dev/urandom count=36 bs=1 2>/dev/null | xxd -p -c 64)
- e.g.:kmeshctl secret -k=$(echo -n "{36-character user-defined key here}" | xxd -p -c 64)
-```
+Generate and manage IPsec encryption secrets for secure communication between nodes
 
 ### Options
 
 ```bash
-  -h, --help         help for secret
-  -k, --key string   key of the encryption
+  -h, --help   help for secret
 ```
 
 ### SEE ALSO
 
 * [kmeshctl](kmeshctl.md) - Kmesh command line tools to operate and debug Kmesh
+* [kmeshctl secret create](kmeshctl_secret_create.md) - Create a new IPsec secret with automatically generated key

--- a/docs/ctl/kmeshctl_secret_create.md
+++ b/docs/ctl/kmeshctl_secret_create.md
@@ -1,0 +1,33 @@
+## kmeshctl secret create
+
+Create a new IPsec secret with automatically generated key
+
+### Synopsis
+
+Create a new IPsec secret with automatically generated encryption key.
+The key is generated using cryptographically secure random bytes and formatted
+for use with the rfc4106(gcm(aes)) AEAD algorithm.
+
+```bash
+kmeshctl secret create [flags]
+```
+
+### Examples
+
+```bash
+# Create a new IPsec secret with automatically generated key:
+kmeshctl secret create
+
+# This will generate a 36-byte key (32-byte key + 4-byte salt) and create
+# the 'kmesh-ipsec' secret in the kmesh-system namespace.
+```
+
+### Options
+
+```bash
+  -h, --help   help for create
+```
+
+### SEE ALSO
+
+* [kmeshctl secret](kmeshctl_secret.md) - Manage IPsec secrets for Kmesh


### PR DESCRIPTION
**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
This PR simplifies IPsec secret creation by implementing automatic key generation for the kmeshctl CLI tool.
Create the IPsec secret by `kmeshctl secret create`.
**Which issue(s) this PR fixes**:


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
