### PR TITLE
Resolving communication issue between pods after enabling IPsec

### DIFF
--- a/bpf/kmesh/general/include/tc.h
+++ b/bpf/kmesh/general/include/tc.h
@@ -24,8 +24,9 @@ struct tc_info {
     };
 };
 
-#define PARSER_FAILED 1
-#define PARSER_SUCC   0
+#define PARSER_FAILED        1
+#define PARSER_SUCC          0
+#define IPSEC_DECRYPTED_MARK 0x00d0
 
 static inline bool is_ipv4(struct tc_info *info)
 {

--- a/bpf/kmesh/general/tc_mark_decrypt.c
+++ b/bpf/kmesh/general/tc_mark_decrypt.c
@@ -32,10 +32,9 @@ int tc_mark_decrypt(struct __sk_buff *ctx)
     }
 
     mark = ctx->mark;
-    decrypted = (mark == 0x00d0); // if managed by kmesh, true managed by kmesh
+    decrypted = (mark == 0x00d0); //0x00d0 is same with xfmr state output-mark, which means packet was decrypted and back to ingress
 
     if(decrypted) {
-        ctx->mark = 0x00d0;
         return TC_ACT_OK;
     }
 

--- a/bpf/kmesh/general/tc_mark_decrypt.c
+++ b/bpf/kmesh/general/tc_mark_decrypt.c
@@ -32,8 +32,8 @@ int tc_mark_decrypt(struct __sk_buff *ctx)
     }
 
     mark = ctx->mark;
-    decrypted = (mark == 0x00d0); // 0x00d0 is same with xfmr state output-mark, which means packet was decrypted and
-                                  // then back to ingress
+    decrypted = (mark == IPSEC_DECRYPTED_MARK); // IPSEC_DECRYPTED_MARK is same with xfmr state output-mark, which means
+                                                // packet was decrypted and then back to ingress
 
     if (decrypted) {
         return TC_ACT_OK;

--- a/bpf/kmesh/general/tc_mark_decrypt.c
+++ b/bpf/kmesh/general/tc_mark_decrypt.c
@@ -32,9 +32,10 @@ int tc_mark_decrypt(struct __sk_buff *ctx)
     }
 
     mark = ctx->mark;
-    decrypted = (mark == 0x00d0); //0x00d0 is same with xfmr state output-mark, which means packet was decrypted and then back to ingress
+    decrypted = (mark == 0x00d0); // 0x00d0 is same with xfmr state output-mark, which means packet was decrypted and
+                                  // then back to ingress
 
-    if(decrypted) {
+    if (decrypted) {
         return TC_ACT_OK;
     }
 

--- a/bpf/kmesh/general/tc_mark_decrypt.c
+++ b/bpf/kmesh/general/tc_mark_decrypt.c
@@ -32,17 +32,12 @@ int tc_mark_decrypt(struct __sk_buff *ctx)
     }
 
     mark = ctx->mark;
-    decrypted = (mark == 0x00d0); //0x00d0 is same with xfmr state output-mark, which means packet was decrypted and back to ingress
+    decrypted = (mark == 0x00d0); //0x00d0 is same with xfmr state output-mark, which means packet was decrypted and then back to ingress
 
     if(decrypted) {
         return TC_ACT_OK;
     }
 
-    // nodeinfo = check_remote_manage_by_kmesh(ctx, &info, info.iph->saddr, info.ip6h->saddr.s6_addr32);
-    // if (!nodeinfo) {
-    //     return TC_ACT_OK;
-    // }
-    // 0x00d0 mean need decryption in ipsec
     ctx->mark = 0;
     return TC_ACT_OK;
 }

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -31,8 +31,11 @@ const (
 	ENABLED       = uint32(1)
 	DISABLED      = uint32(0)
 
-	TC_MARK_DECRYPT = "tc_mark_decrypt"
-	TC_MARK_ENCRYPT = "tc_mark_encrypt"
+	TC_MARK_DECRYPT   = "tc_mark_decrypt"
+	TC_MARK_ENCRYPT   = "tc_mark_encrypt"
+	XfrmDecryptedMark = 0x00d0
+	XfrmEncryptMark   = 0x00e0
+	XfrmMarkMask      = 0xffffffff
 
 	TC_ATTACH = 0
 	TC_DETACH = 1

--- a/pkg/controller/encryption/ipsec/ipsec_handler.go
+++ b/pkg/controller/encryption/ipsec/ipsec_handler.go
@@ -280,6 +280,10 @@ func (is *IpSecHandler) createStateRule(src net.IP, dst net.IP, key []byte, ipse
 			Key:    key,
 			ICVLen: ipsecKey.Length,
 		},
+		OutputMark: &netlink.XfrmMark{
+			Value: 0x00d0,
+			Mask:  0xffffffff,
+		},
 	}
 	err := netlink.XfrmStateAdd(state)
 	if err != nil && !os.IsExist(err) {

--- a/pkg/controller/encryption/ipsec/ipsec_handler.go
+++ b/pkg/controller/encryption/ipsec/ipsec_handler.go
@@ -281,8 +281,8 @@ func (is *IpSecHandler) createStateRule(src net.IP, dst net.IP, key []byte, ipse
 			ICVLen: ipsecKey.Length,
 		},
 		OutputMark: &netlink.XfrmMark{
-			Value: 0x00d0,
-			Mask:  0xffffffff,
+			Value: constants.XfrmDecryptedMark,
+			Mask:  constants.XfrmMarkMask,
 		},
 	}
 	err := netlink.XfrmStateAdd(state)
@@ -306,12 +306,12 @@ func (is *IpSecHandler) createPolicyRule(srcCIDR, dstCIDR *net.IPNet, src, dst n
 			},
 		},
 		Mark: &netlink.XfrmMark{
-			Mask: 0xffffffff,
+			Mask: constants.XfrmMarkMask,
 		},
 	}
 	if out {
 		// ingress
-		mark := uint32(0xd0)
+		mark := uint32(constants.XfrmDecryptedMark)
 		policy.Mark.Value = mark
 
 		policy.Dir = netlink.XFRM_DIR_IN
@@ -325,7 +325,7 @@ func (is *IpSecHandler) createPolicyRule(srcCIDR, dstCIDR *net.IPNet, src, dst n
 		}
 	} else {
 		// egress, update SPI
-		mark := uint32(0xe0)
+		mark := uint32(constants.XfrmEncryptMark)
 
 		policy.Mark.Value = uint32(mark)
 		policy.Tmpls[0].Spi = int(spi)

--- a/test/bpf_ut/bpftest/general_test.go
+++ b/test/bpf_ut/bpftest/general_test.go
@@ -46,7 +46,23 @@ func testGeneralTC(t *testing.T) {
 			objFilename: "tc_mark_decrypt_test.o",
 			uts: []unitTest_BPF_PROG_TEST_RUN{
 				{
-					name: "tc_mark_decrypt",
+					name: "tc_mark_decrypt_case1",
+					setupInUserSpace: func(t *testing.T, coll *ebpf.Collection) {
+						setBpfConfig(t, coll, &factory.GlobalBpfConfig{
+							BpfLogLevel: constants.BPF_LOG_DEBUG,
+						})
+					},
+				},
+				{
+					name: "tc_mark_decrypt_case2",
+					setupInUserSpace: func(t *testing.T, coll *ebpf.Collection) {
+						setBpfConfig(t, coll, &factory.GlobalBpfConfig{
+							BpfLogLevel: constants.BPF_LOG_DEBUG,
+						})
+					},
+				},
+				{
+					name: "tc_mark_decrypt_case3",
 					setupInUserSpace: func(t *testing.T, coll *ebpf.Collection) {
 						setBpfConfig(t, coll, &factory.GlobalBpfConfig{
 							BpfLogLevel: constants.BPF_LOG_DEBUG,

--- a/test/bpf_ut/tc_mark_decrypt_test.c
+++ b/test/bpf_ut/tc_mark_decrypt_test.c
@@ -64,7 +64,7 @@ int test1_jump(struct __sk_buff *ctx)
 {
     // Set initial mark to 0x00a0
     ctx->mark = 0x00a0;
-    
+
     bpf_tail_call(ctx, &entry_call_map, 0);
     return TEST_ERROR;
 }
@@ -130,7 +130,7 @@ int test3_pktgen(struct __sk_buff *ctx)
         .saddr = SRC_IP,
         .daddr = DEST_IP,
     };
-    
+
     return build_tc_packet(ctx, &l2, &l3_esp, &l4, body, (uint)sizeof(body));
 }
 
@@ -139,7 +139,7 @@ int test3_jump(struct __sk_buff *ctx)
 {
     // Set initial mark to 0x00d0
     ctx->mark = 0x00d0;
-    
+
     // build context - no need for nodeinfo map for ESP packets
     bpf_tail_call(ctx, &entry_call_map, 0);
     return TEST_ERROR;


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Refactored traffic decrypt marking logic.
Added OutputMark configuration in ipsec_handler.go

If the protocol is ESP, it directly enters the decryption phase to match the xfrm state and then re-enters ingress. If the packet is successfully decrypted, it will be marked as 0xd0. If the packet is not ESP protocol  and has not been decrypted(mark != 0xd0), its mark will be set to 0x0, ensuring it does not match any policy and avoiding the issue described previously.
**Which issue(s) this PR fixes**:
Fixes #1481 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
