### PR TITLE
feature(workflow): added Kmeshctl doc syncing workflow

### DIFF
--- a/.github/workflows/sync-kmeshctl-docs.yml
+++ b/.github/workflows/sync-kmeshctl-docs.yml
@@ -84,7 +84,7 @@ jobs:
           base: main
           title: "docs: sync latest kmeshctl documentation"
           body: |
-            This PR syncs the latest changes from [kmesh/docs/ctl](https://github.com/yashisrani/kmesh/tree/main/docs/ctl).
+            This PR syncs the latest changes from [kmesh/docs/ctl](https://github.com/kmesh-net/kmesh/tree/main/docs/ctl).
 
             Please review and merge.
           commit-message: "docs: sync kmeshctl docs"

--- a/.github/workflows/sync-kmeshctl-docs.yml
+++ b/.github/workflows/sync-kmeshctl-docs.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kmesh-net/website
-          token: ${{ secrets.WEBSITE_PAT }}
+          token: ${{ secrets.GH_PAT }}
           path: website
           ref: main
           fetch-depth: 1
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: kmesh-net/kmesh
-          token: ${{ secrets.WEBSITE_PAT }}
+          token: ${{ secrets.GH_PAT }}
           path: kmesh
           fetch-depth: 1
 
@@ -77,14 +77,15 @@ jobs:
       - name: 🤝 Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.WEBSITE_PAT }}
+          token: ${{ secrets.GH_PAT }}
           path: website
-          # Use timestamp for a guaranteed unique branch name
           branch-suffix: timestamp
           base: main
-          title: "docs: sync latest kmeshctl documentation"
+          title: "docs: sync latest kmeshctl documentation (commit ${{ github.sha }})"
           body: |
             This PR syncs the latest changes from [kmesh/docs/ctl](https://github.com/kmesh-net/kmesh/tree/main/docs/ctl).
+
+            **Triggered by commit:** ${{ github.sha }}
 
             Please review and merge.
           commit-message: "docs: sync kmeshctl docs"

--- a/.github/workflows/sync-kmeshctl-docs.yml
+++ b/.github/workflows/sync-kmeshctl-docs.yml
@@ -1,0 +1,91 @@
+name: Sync kmeshctl Docs to Website (via PR)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/ctl/**
+      - .github/workflows/sync-kmeshctl-docs.yml
+
+jobs:
+  sync-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🧭 Checkout website repository
+        uses: actions/checkout@v4
+        with:
+          repository: kmesh-net/website
+          token: ${{ secrets.WEBSITE_PAT }}
+          path: website
+          ref: main
+          fetch-depth: 1
+
+      - name: 🧭 Checkout kmesh repository
+        uses: actions/checkout@v4
+        with:
+          repository: kmesh-net/kmesh
+          token: ${{ secrets.WEBSITE_PAT }}
+          path: kmesh
+          fetch-depth: 1
+
+      - name: 🔁 Sync kmeshctl Docs Using rsync
+        run: |
+          set -e
+
+          # Define source and target directories
+          KMESH_CTL_DIR="kmesh/docs/ctl"
+          WEBSITE_KMESHCTL_DIR="website/docs/kmeshctl"
+
+          echo "🔍 Source directory: $KMESH_CTL_DIR"
+          echo "🎯 Target directory: $WEBSITE_KMESHCTL_DIR"
+
+          # Check if source directory exists
+          if [ ! -d "$KMESH_CTL_DIR" ]; then
+            echo "❌ ERROR: Source directory does not exist!"
+            exit 1
+          fi
+
+          # Create target directory if it doesn't exist
+          if [ ! -d "$WEBSITE_KMESHCTL_DIR" ]; then
+            echo "📁 Creating $WEBSITE_KMESHCTL_DIR..."
+            mkdir -p "$WEBSITE_KMESHCTL_DIR"
+          fi
+
+          # Sync files using rsync
+          echo "🔄 Syncing files with rsync..."
+          rsync -avc --delete --exclude='.git' --exclude='.*' "$KMESH_CTL_DIR/" "$WEBSITE_KMESHCTL_DIR/"
+
+          # Navigate to the website repository
+          cd website
+
+          # Stage changes
+          git add -A docs/kmeshctl/
+
+          # Check if there are any changes
+          if git diff --cached --quiet; then
+            echo "✅ No changes detected."
+            exit 0
+          else
+            echo "✨ Changes detected. Creating commit..."
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git commit -m 'docs: sync kmeshctl docs from kmesh-net/kmesh'
+          fi
+
+      - name: 🤝 Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.WEBSITE_PAT }}
+          path: website
+          # Use timestamp for a guaranteed unique branch name
+          branch-suffix: timestamp
+          base: main
+          title: "docs: sync latest kmeshctl documentation"
+          body: |
+            This PR syncs the latest changes from [kmesh/docs/ctl](https://github.com/yashisrani/kmesh/tree/main/docs/ctl).
+
+            Please review and merge.
+          commit-message: "docs: sync kmeshctl docs"
+          delete-branch: true


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement
/kind documentation
/kind feature

**What this PR does / why we need it**:


- This PR updates the Sync kmeshctl Docs to Website GitHub Actions workflow to improve the synchronization of documentation between the kmesh-net/kmesh and kmesh-net/website repositories.
 - It ensures that the website/docs/kmeshctl directory is created if missing and populated with all files from kmesh/docs/ctl. Additionally, it enhances the workflow to detect and sync new changes (content modifications, added files, and deleted files) using rsync with checksum comparison, addressing previous issues where changes were not recognized.
 - This is necessary to maintain consistent and up-to-date documentation across repositories.
 - Workflow will create PR for any changes.
 - Emojis are used for better readability and visual scanning of logs


**Which issue(s) this PR fixes**:
Fixes #1412

Setup Instructions:
Step 1: Create a Fine-Grained Personal Access Token (PAT)

    Go to: [GitHub Settings → Tokens (Fine-grained)](https://github.com/settings/tokens)
    Click "Generate new token"
    Configure:
        Name: kmesh-to-website-sync
        Repository access: Select kmesh-net/website
        Permissions:
            Contents → Read and write
            Pull Request → Read and write
    Copy the token (you can't see it again)

Step 2: Add Secret to kmesh Repository

    Go to: https://github.com/kmesh-net/kmesh/settings/secrets/actions
    Click "New repository secret"
        Name: WEBSITE_PAT
        Value: Paste your PAT

**Special notes for your reviewer**:


 - Please verify that the WEBSITE_PAT secret is correctly configured in the kmesh-net/kmesh repository with write access to kmesh-net/website.
 - Note that the workflow uses absolute paths (/github/workspace/) and a git reset --hard step to ensure the Git index reflects rsynced changes; this may overwrite local uncommitted changes in the website repo during execution.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
