### PR TITLE
Remove unnecessary images in e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ docker.push: docker
 
 .PHONY: e2e
 e2e:
-	./test/e2e/run_test.sh
+	./test/e2e/run_test.sh --build-image-clean
 
 .PHONY: e2e-ipv6
 e2e-ipv6:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

During end-to-end testing, to free up more disk space, delete the kmesh build image after building kmesh.

Two identifiers were added in the run-e2e.sh script.

```sh
# default is false. When --build-image-clean is true, will clean up ghcr.io/kmesh-net/kmesh-build:latest 
--build-image-clean 

# defaule is false. Kmesh debug logs are only output when debug is set to true.
--debug
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
