### PR TITLE
run build before `make kmeshctl`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ all-binary:
 
 OUT ?= kmeshctl
 .PHONY: kmeshctl
-kmeshctl:
+kmeshctl: build
 	$(call printlog, BUILD, $(APPS4))
 	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
 		CGO_ENABLED=0 $(GO) build -gcflags $(GOGCFLAGS) -ldflags $(GOLDFLAGS) -o $(OUT) $(GOFLAGS) ./ctl/main.go)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

Fixed an error where `kmeshcgroupskb.o` files could not be found during the build of kmeshctl.

**Which issue(s) this PR fixes**:
Fixes #1541 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
