### PR TITLE
refactor kmeshctl secret command

### DIFF
--- a/ctl/secret/secret.go
+++ b/ctl/secret/secret.go
@@ -30,7 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kmesh.net/kmesh/ctl/utils"
-	"kmesh.net/kmesh/pkg/controller/encryption/ipsec"
+	"kmesh.net/kmesh/pkg/controller/encryption"
 	"kmesh.net/kmesh/pkg/kube"
 	"kmesh.net/kmesh/pkg/logger"
 )
@@ -118,7 +118,7 @@ func createKubeClientOrExit() kube.CLIClient {
 }
 
 func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
-	var ipSecKey, ipSecKeyOld ipsec.IpSecKey
+	var ipSecKey, ipSecKeyOld encryption.IpSecKey
 	var err error
 
 	ipSecKey.AeadKeyName = AeadAlgoName
@@ -215,7 +215,7 @@ func GetSecret() {
 	}
 
 	// Parse the IPsec data
-	var ipSecKey ipsec.IpSecKey
+	var ipSecKey encryption.IpSecKey
 	if err := json.Unmarshal(secret.Data["ipSec"], &ipSecKey); err != nil {
 		log.Errorf("failed to unmarshal secret data: %v", err)
 		os.Exit(1)

--- a/pkg/controller/encryption/common.go
+++ b/pkg/controller/encryption/common.go
@@ -1,0 +1,24 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package encryption
+
+type IpSecKey struct {
+	Spi         int    `json:"spi"`
+	AeadKeyName string `json:"aeadKeyName"`
+	AeadKey     []byte `json:"aeadKey"`
+	Length      int    `json:"length"`
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

Previously, the implementation of the `kmeshctl secret` command resided within `kmeshctl` itself. This cause `kmeshctl` introducing excessive dependencies. #1541 
Therefore, this PR moved the location of the `IpsecKey` structure to avoid import BPF-related dependencies.

**Which issue(s) this PR fixes**:
Fixes #1541 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
