### PR TITLE
test:Refactor DNS upstream resolver to use interface-based client and improve test coverage

### DIFF
--- a/pkg/dns/upstream.go
+++ b/pkg/dns/upstream.go
@@ -22,8 +22,12 @@ import (
 	"github.com/miekg/dns"
 )
 
+type dnsClient interface {
+	Exchange(m *dns.Msg, addr string) (*dns.Msg, time.Duration, error)
+}
+
 type upstreamResolver struct {
-	*dns.Client
+	Client    dnsClient
 	upstreams []string
 }
 
@@ -47,7 +51,7 @@ func (r *upstreamResolver) Resolve(req *dns.Msg) (*dns.Msg, error) {
 	var response *dns.Msg
 
 	for _, upstream := range r.upstreams {
-		resp, _, err := r.Exchange(req, upstream)
+		resp, _, err := r.Client.Exchange(req, upstream)
 		if err != nil || resp == nil {
 			continue
 		}

--- a/pkg/dns/upstream_test.go
+++ b/pkg/dns/upstream_test.go
@@ -1,0 +1,119 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dns
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeDNSClient struct {
+	responses map[string]*dns.Msg
+	errors    map[string]error
+	calls     int
+}
+
+func (f *fakeDNSClient) Exchange(m *dns.Msg, addr string) (*dns.Msg, time.Duration, error) {
+	f.calls++
+
+	if err, ok := f.errors[addr]; ok {
+		return nil, 0, err
+	}
+	if resp, ok := f.responses[addr]; ok {
+		return resp, 0, nil
+	}
+	return nil, 0, errors.New("no response")
+}
+
+func TestResolve_SingleUpstreamSuccess(t *testing.T) {
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	resp.Rcode = dns.RcodeSuccess
+
+	r := NewUpstreamResolver("1.1.1.1:53")
+	r.Client = &fakeDNSClient{
+		responses: map[string]*dns.Msg{
+			"1.1.1.1:53": resp,
+		},
+		errors: map[string]error{},
+	}
+
+	out, err := r.Resolve(req)
+	assert.NoError(t, err)
+	assert.Equal(t, dns.RcodeSuccess, out.Rcode)
+}
+
+func TestResolve_FallbackToSecondUpstream(t *testing.T) {
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+
+	failResp := new(dns.Msg)
+	failResp.SetReply(req)
+	failResp.Rcode = dns.RcodeServerFailure
+
+	okResp := new(dns.Msg)
+	okResp.SetReply(req)
+	okResp.Rcode = dns.RcodeSuccess
+
+	fake := &fakeDNSClient{
+		responses: map[string]*dns.Msg{
+			"1.1.1.1:53": failResp,
+			"8.8.8.8:53": okResp,
+		},
+		errors: map[string]error{},
+	}
+
+	r := NewUpstreamResolver("1.1.1.1:53", "8.8.8.8:53")
+	r.Client = fake
+
+	out, err := r.Resolve(req)
+	assert.NoError(t, err)
+	assert.Equal(t, dns.RcodeSuccess, out.Rcode)
+	assert.Equal(t, 2, fake.calls)
+}
+
+func TestResolve_AllUpstreamsFail(t *testing.T) {
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+
+	fake := &fakeDNSClient{
+		responses: map[string]*dns.Msg{},
+		errors: map[string]error{
+			"1.1.1.1:53": errors.New("fail"),
+			"8.8.8.8:53": errors.New("fail"),
+		},
+	}
+
+	r := NewUpstreamResolver("1.1.1.1:53", "8.8.8.8:53")
+	r.Client = fake
+
+	out, err := r.Resolve(req)
+	assert.NoError(t, err)
+	assert.Equal(t, dns.RcodeServerFailure, out.Rcode)
+}
+
+func TestWithUpstreams(t *testing.T) {
+	r := NewUpstreamResolver("1.1.1.1:53")
+	r.WithUpstreams("8.8.8.8:53", "9.9.9.9:53")
+	assert.Len(t, r.upstreams, 3)
+}


### PR DESCRIPTION

**What type of PR is this?**

/kind enhancement
/kind security
/kind feature


**What this PR does / why we need it**:
This PR refactors the DNS upstream resolver to improve testability and code quality by introducing an interface-based DNS client. It removes direct dependency on *dns.Client, enabling clean mocking in unit tests without method overriding.

- Introduced a DNSExchanger interface to abstract DNS client behavior.
- Updated UpstreamResolver to depend on the interface instead of *dns.Client.
- Added a fake DNS client for deterministic and isolated unit testing.
- Fixed test failures and typecheck issues reported by golangci-lint.
- Improved unit test coverage for upstream resolution logic, including:


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
