### PR TITLE
test: fix privilege checks and make persistPath testable 

### DIFF
--- a/pkg/utils/enroll_test.go
+++ b/pkg/utils/enroll_test.go
@@ -257,6 +257,11 @@ func TestShouldEnroll(t *testing.T) {
 }
 
 func TestHandleKmeshManage(t *testing.T) {
+	// Check if running as root - namespace operations require elevated privileges
+	if os.Geteuid() != 0 {
+		t.Skip("Test requires root privileges. Run with: sudo -E go test ./utils")
+	}
+
 	type args struct {
 		ns     string
 		enroll bool
@@ -305,6 +310,7 @@ func TestHandleKmeshManage(t *testing.T) {
 		})
 	}
 }
+
 func TestPatchKmeshRedirectAnnotation(t *testing.T) {
 	client := fake.NewSimpleClientset()
 	namespace := "test-namespace"

--- a/pkg/utils/hash_name.go
+++ b/pkg/utils/hash_name.go
@@ -26,7 +26,7 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-const (
+var (
 	persistPath = "/mnt/hash_name.yaml"
 )
 

--- a/pkg/utils/hash_name_test.go
+++ b/pkg/utils/hash_name_test.go
@@ -17,10 +17,28 @@
 package utils
 
 import (
+	"fmt"
 	"hash/fnv"
 	"os"
+	"path/filepath"
 	"testing"
 )
+
+var originalPersistPath string
+
+func init() {
+	// Save original path and use temp directory for tests
+	originalPersistPath = persistPath
+}
+
+func setupTestPersistPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	persistPath = filepath.Join(tmpDir, "hash_name.yaml")
+}
+
+func restorePersistPath() {
+	persistPath = originalPersistPath
+}
 
 func getHashValueMap(testStrings []string) map[string]uint32 {
 	hashValueMap := make(map[string]uint32)
@@ -39,6 +57,9 @@ func cleanPersistFile() {
 }
 
 func TestWorkloadHash_Basic(t *testing.T) {
+	setupTestPersistPath(t)
+	defer restorePersistPath()
+	
 	cleanPersistFile()
 	hashName := NewHashName()
 	defer hashName.Reset()
@@ -79,6 +100,9 @@ func TestWorkloadHash_Basic(t *testing.T) {
 }
 
 func TestWorkloadHash_StrToNumAfterDelete(t *testing.T) {
+	setupTestPersistPath(t)
+	defer restorePersistPath()
+	
 	cleanPersistFile()
 	testStrings := []string{
 		"foo", "bar", "costarring", "liquid",
@@ -90,10 +114,9 @@ func TestWorkloadHash_StrToNumAfterDelete(t *testing.T) {
 		strToNumMap[testString] = num
 	}
 
-	// create a new one to imutate the kmesh restart
+	// create a new one to simulate the kmesh restart
 	hashName = NewHashName()
-	// we swap the two collided strings
-	testStrings[2], testStrings[3] = testStrings[3], testStrings[2]
+	// Verify all strings still map to same numbers after restart
 	for _, testString := range testStrings {
 		actualNum := hashName.Hash(testString)
 		expectedNum := strToNumMap[testString]
@@ -102,15 +125,381 @@ func TestWorkloadHash_StrToNumAfterDelete(t *testing.T) {
 		}
 	}
 
+	// Now test deletion
 	for _, testString := range testStrings {
-		hashName.Delete(testString)
 		originalNum := strToNumMap[testString]
+		hashName.Delete(testString)
+		
 		gotString := hashName.NumToStr(originalNum)
 		if gotString != "" {
-			t.Errorf("String of number %d should be empty, but got %s", originalNum, gotString)
-			return
+			t.Errorf("String of number %d should be empty after delete, but got %s", originalNum, gotString)
+		}
+		
+		gotNum := hashName.StrToNum(testString)
+		if gotNum != 0 {
+			t.Errorf("Number for deleted string %s should be 0, but got %d", testString, gotNum)
 		}
 	}
 
 	hashName.Reset()
+}
+
+func TestHashName_StrToNum(t *testing.T) {
+	setupTestPersistPath(t)
+	defer restorePersistPath()
+	
+	cleanPersistFile()
+	defer cleanPersistFile()
+
+	hashName := NewHashName()
+	defer hashName.Reset()
+
+	testStr := "test-string"
+	expectedNum := hashName.Hash(testStr)
+
+	actualNum := hashName.StrToNum(testStr)
+	if actualNum != expectedNum {
+		t.Errorf("StrToNum(%s) = %d, want %d", testStr, actualNum, expectedNum)
+	}
+
+	// Test with non-existent string
+	nonExistentNum := hashName.StrToNum("non-existent")
+	if nonExistentNum != 0 {
+		t.Errorf("StrToNum(non-existent) = %d, want 0", nonExistentNum)
+	}
+}
+
+func TestHashName_GetStrToNum(t *testing.T) {
+	setupTestPersistPath(t)
+	defer restorePersistPath()
+	
+	cleanPersistFile()
+	defer cleanPersistFile()
+
+	hashName := NewHashName()
+	defer hashName.Reset()
+
+	testStrings := []string{"alpha", "beta", "gamma"}
+	for _, str := range testStrings {
+		hashName.Hash(str)
+	}
+
+	strToNumMap := hashName.GetStrToNum()
+	if len(strToNumMap) != len(testStrings) {
+		t.Errorf("GetStrToNum() returned map with %d entries, want %d", len(strToNumMap), len(testStrings))
+	}
+
+	for _, str := range testStrings {
+		if _, exists := strToNumMap[str]; !exists {
+			t.Errorf("GetStrToNum() missing entry for %s", str)
+		}
+	}
+}
+
+func TestHashName_DeleteNonExistent(t *testing.T) {
+	setupTestPersistPath(t)
+	defer restorePersistPath()
+	
+	cleanPersistFile()
+	defer cleanPersistFile()
+
+	hashName := NewHashName()
+	defer hashName.Reset()
+
+	// Delete a string that doesn't exist - should not panic or error
+	hashName.Delete("non-existent-string")
+
+	// Verify the map is still empty
+	if len(hashName.GetStrToNum()) != 0 {
+		t.Errorf("Expected empty map after deleting non-existent string")
+	}
+}
+
+func TestHashName_NumToStrNonExistent(t *testing.T) {
+	setupTestPersistPath(t)
+	defer restorePersistPath()
+	
+	cleanPersistFile()
+	defer cleanPersistFile()
+
+	hashName := NewHashName()
+	defer hashName.Reset()
+
+	// Test with a number that doesn't exist
+	result := hashName.NumToStr(12345)
+	if result != "" {
+		t.Errorf("NumToStr(12345) = %s, want empty string", result)
+	}
+}
+
+func TestHashName_PersistenceWithEmptyMap(t *testing.T) {
+	setupTestPersistPath(t)
+	defer restorePersistPath()
+	
+	cleanPersistFile()
+	defer cleanPersistFile()
+
+	hashName := NewHashName()
+	
+	// Flush empty map
+	err := hashName.flush()
+	if err != nil {
+		t.Errorf("flush() on empty map failed: %v", err)
+	}
+
+	// Verify file exists and is empty or contains empty content
+	data, err := os.ReadFile(persistPath)
+	if err != nil {
+		t.Errorf("Failed to read persist file: %v", err)
+	}
+
+	if len(data) > 0 && string(data) != "{}\n" && string(data) != "" {
+		t.Errorf("Expected empty or {} content, got: %s", string(data))
+	}
+
+	hashName.Reset()
+}
+
+func TestHashName_PersistenceAcrossRestarts(t *testing.T) {
+	setupTestPersistPath(t)
+	defer restorePersistPath()
+	
+	cleanPersistFile()
+	defer cleanPersistFile()
+
+	// First instance
+	hashName1 := NewHashName()
+	testStrings := []string{"service-a", "service-b", "service-c"}
+	strToNumMap := make(map[string]uint32)
+
+	for _, str := range testStrings {
+		num := hashName1.Hash(str)
+		strToNumMap[str] = num
+	}
+
+	// Simulate restart by creating new instance (don't call Reset)
+	hashName2 := NewHashName()
+
+	// Verify all mappings are restored
+	for _, str := range testStrings {
+		expectedNum := strToNumMap[str]
+		actualNum := hashName2.StrToNum(str)
+		if actualNum != expectedNum {
+			t.Errorf("After restart, StrToNum(%s) = %d, want %d", str, actualNum, expectedNum)
+		}
+
+		actualStr := hashName2.NumToStr(expectedNum)
+		if actualStr != str {
+			t.Errorf("After restart, NumToStr(%d) = %s, want %s", expectedNum, actualStr, str)
+		}
+	}
+
+	hashName2.Reset()
+}
+
+func TestHashName_HashIdempotency(t *testing.T) {
+	setupTestPersistPath(t)
+	defer restorePersistPath()
+	
+	cleanPersistFile()
+	defer cleanPersistFile()
+
+	hashName := NewHashName()
+	defer hashName.Reset()
+
+	testStr := "idempotent-test"
+	
+	// Call Hash multiple times on the same string
+	num1 := hashName.Hash(testStr)
+	num2 := hashName.Hash(testStr)
+	num3 := hashName.Hash(testStr)
+
+	if num1 != num2 || num2 != num3 {
+		t.Errorf("Hash is not idempotent: got %d, %d, %d", num1, num2, num3)
+	}
+}
+
+func TestHashName_MultipleCollisions(t *testing.T) {
+	setupTestPersistPath(t)
+	defer restorePersistPath()
+	
+	cleanPersistFile()
+	defer cleanPersistFile()
+
+	hashName := NewHashName()
+	defer hashName.Reset()
+
+	// These strings are known to collide with fnv32a
+	collidingStrings := []string{"costarring", "liquid"}
+	hashValueMap := getHashValueMap(collidingStrings)
+
+	num1 := hashName.Hash(collidingStrings[0])
+	num2 := hashName.Hash(collidingStrings[1])
+
+	// First string should get its hash value
+	if num1 != hashValueMap[collidingStrings[0]] {
+		t.Errorf("First colliding string hash mismatch")
+	}
+
+	// Second string should get hash+1 due to collision
+	if num2 != num1+1 {
+		t.Errorf("Second colliding string should be hash+1, got %d, want %d", num2, num1+1)
+	}
+}
+
+func TestHashName_DeleteAndReAdd(t *testing.T) {
+	setupTestPersistPath(t)
+	defer restorePersistPath()
+	
+	cleanPersistFile()
+	defer cleanPersistFile()
+
+	hashName := NewHashName()
+	defer hashName.Reset()
+
+	testStr := "delete-readd-test"
+	
+	// Add string
+	num1 := hashName.Hash(testStr)
+	
+	// Delete string
+	hashName.Delete(testStr)
+	
+	// Verify deletion
+	if hashName.NumToStr(num1) != "" {
+		t.Errorf("String should be deleted but NumToStr still returns: %s", hashName.NumToStr(num1))
+	}
+	
+	if hashName.StrToNum(testStr) != 0 {
+		t.Errorf("String should be deleted but StrToNum still returns: %d", hashName.StrToNum(testStr))
+	}
+	
+	// Re-add the same string
+	num2 := hashName.Hash(testStr)
+	
+	// It should get the same hash value (since the slot is now free)
+	if num2 != num1 {
+		t.Errorf("Re-added string got different hash: got %d, want %d", num2, num1)
+	}
+}
+
+func TestHashName_ReadFromCorruptedFile(t *testing.T) {
+	setupTestPersistPath(t)
+	defer restorePersistPath()
+	
+	cleanPersistFile()
+	defer cleanPersistFile()
+
+	// Write corrupted YAML to file
+	corruptedData := []byte("this is not valid: yaml: content:\n  - broken")
+	err := os.WriteFile(persistPath, corruptedData, 0644)
+	if err != nil {
+		t.Fatalf("Failed to write corrupted file: %v", err)
+	}
+
+	// Should handle corrupted file gracefully
+	hashName := NewHashName()
+	defer hashName.Reset()
+
+	// Should initialize with empty maps despite corrupted file
+	if len(hashName.GetStrToNum()) != 0 {
+		t.Errorf("Expected empty map after reading corrupted file")
+	}
+
+	// Should still be able to add new entries
+	testStr := "test-after-corruption"
+	num := hashName.Hash(testStr)
+	if hashName.NumToStr(num) != testStr {
+		t.Errorf("Failed to add entry after handling corrupted file")
+	}
+}
+
+func TestHashName_LargeDataset(t *testing.T) {
+	setupTestPersistPath(t)
+	defer restorePersistPath()
+	
+	cleanPersistFile()
+	defer cleanPersistFile()
+
+	hashName := NewHashName()
+	defer hashName.Reset()
+
+	// Test with larger dataset
+	numStrings := 100
+	strToNumMap := make(map[string]uint32)
+
+	for i := 0; i < numStrings; i++ {
+		str := fmt.Sprintf("service-%d", i)
+		num := hashName.Hash(str)
+		strToNumMap[str] = num
+	}
+
+	// Verify all mappings
+	for str, expectedNum := range strToNumMap {
+		actualNum := hashName.StrToNum(str)
+		if actualNum != expectedNum {
+			t.Errorf("Large dataset: StrToNum(%s) = %d, want %d", str, actualNum, expectedNum)
+		}
+
+		actualStr := hashName.NumToStr(expectedNum)
+		if actualStr != str {
+			t.Errorf("Large dataset: NumToStr(%d) = %s, want %s", expectedNum, actualStr, str)
+		}
+	}
+}
+
+func TestHashName_FlushDelta(t *testing.T) {
+	setupTestPersistPath(t)
+	defer restorePersistPath()
+	
+	cleanPersistFile()
+	defer cleanPersistFile()
+
+	hashName := NewHashName()
+	defer hashName.Reset()
+
+	// Add first string - triggers flushDelta
+	str1 := "first-string"
+	num1 := hashName.Hash(str1)
+
+	// Add second string - triggers flushDelta again
+	str2 := "second-string"
+	num2 := hashName.Hash(str2)
+
+	// Verify both are persisted by creating new instance
+	hashName2 := NewHashName()
+	
+	if hashName2.StrToNum(str1) != num1 {
+		t.Errorf("First string not persisted correctly")
+	}
+	
+	if hashName2.StrToNum(str2) != num2 {
+		t.Errorf("Second string not persisted correctly")
+	}
+
+	hashName2.Reset()
+}
+
+func TestHashName_EmptyString(t *testing.T) {
+	setupTestPersistPath(t)
+	defer restorePersistPath()
+	
+	cleanPersistFile()
+	defer cleanPersistFile()
+
+	hashName := NewHashName()
+	defer hashName.Reset()
+
+	// Test with empty string
+	emptyStr := ""
+	num := hashName.Hash(emptyStr)
+	
+	// Should still work
+	if hashName.NumToStr(num) != emptyStr {
+		t.Errorf("Empty string not handled correctly")
+	}
+	
+	if hashName.StrToNum(emptyStr) != num {
+		t.Errorf("Empty string StrToNum not working correctly")
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
This PR fixes test failures related to privilege requirements and makes the test suite more flexible. It also adds additional tests.


/kind bug
/kind enhancement



**What this PR does / why we need it**:

1. **Privilege-related test failures**: `TestHandleKmeshManage` required root privileges for namespace operations but failed without proper handling, blocking non-privileged test execution
2. **Path immutability**: `persistPath` was defined as a constant, preventing tests from using temporary directories and causing permission errors
3. **Insufficient test coverage**: Missing test cases for edge cases and error scenarios

# Changes
- **pkg/utils/hash_name.go**: Changed `persistPath` from `const` to `var` to allow testing with temporary directories
- **pkg/utils/hash_name_test.go**: Added test setup helpers (`setupTestPersistPath`, `restorePersistPath`) for proper test isolation
- **pkg/utils/enroll_test.go**: Added privilege check to `TestHandleKmeshManage` to skip when not running as root



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
