### PR TITLE
feat(cni): add file watcher for CNI config file

### DIFF
--- a/pkg/cni/chained.go
+++ b/pkg/cni/chained.go
@@ -210,10 +210,6 @@ func (i *Installer) chainedKmeshCniPlugin(mode string, cniMountNetEtcDIR string)
 	}
 	log.Infof("cni config file: %s", cniConfigFilePath)
 
-	/*
-	 TODO: add watcher for cniConfigFile
-	*/
-
 	existCNIConfig, err := os.ReadFile(cniConfigFilePath)
 	if err != nil {
 		err = fmt.Errorf("failed to read cni config file %v : %v", cniConfigFilePath, err)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds a file watcher for the CNI config file to address the TODO comment in `pkg/cni/chained.go`.

Changes:
- Add `WatchCNIConfigFile()` function to monitor the CNI config file for external modifications
- Re-apply Kmesh CNI configuration when changes are detected
- This ensures Kmesh CNI plugin remains installed even if other CNI plugins modify the config file
- Remove the TODO comment that was addressed

The watcher uses the same pattern as the existing `WatchServiceAccountToken()` function, with a 100ms debounce timer to handle rapid file changes efficiently.

**Which issue(s) this PR fixes**:
Fixes #1565 

**Special notes for your reviewer**:

- The implementation follows the existing pattern used for watching the service account token
- Uses `fsnotify` via the `filewatcher` package already in use by the project
- Watches for `Write` and `Create` events on the CNI config file
- Automatically re-applies Kmesh CNI configuration when external changes are detected

**Does this PR introduce a user-facing change?**:

```release-note
Added file watcher for CNI config file to automatically re-apply Kmesh CNI configuration when external modifications are detected.