### PR TITLE
fix(ipsec): resolve golint warnings and remove name stuttering

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -60,7 +60,7 @@ type Controller struct {
 	bpfAdsObj           *bpfads.BpfAds
 	bpfWorkloadObj      *bpfwl.BpfWorkload
 	client              *XdsClient
-	ipsecController     *ipsec.IPSecController
+	ipsecController     *ipsec.Controller
 	enableByPass        bool
 	enableSecretManager bool
 	bpfConfig           *options.BpfConfig
@@ -102,7 +102,7 @@ func (c *Controller) Start(stopCh <-chan struct{}) error {
 			tcFd = c.bpfWorkloadObj.Tc.TcMarkEncrypt.FD()
 			decryptProg = c.bpfWorkloadObj.Tc.KmeshTcMarkDecryptObjects.TcMarkDecrypt
 		}
-		c.ipsecController, err = ipsec.NewIPsecController(clientset, kniMap, decryptProg)
+		c.ipsecController, err = ipsec.NewController(clientset, kniMap, decryptProg)
 		if err != nil {
 			return fmt.Errorf("failed to new IPsec controller, %v", err)
 		}


### PR DESCRIPTION
This PR resolves golint warnings in `pkg/controller/encryption/ipsec/ipsec_controller.go` to improve code quality and comply with Go best practices.

**Changes:**
1. **Removed Stuttering:** Renamed `IPSecController` to `Controller` and `NewIPsecController` to `NewController`. Since this resides in the `ipsec` package, usage becomes `ipsec.Controller` instead of the repetitive `ipsec.IPSecController`.
2. **Standardization:** Updated `ClusterId` -> `ClusterID` and `PodIp` -> `PodIP` to match Go naming conventions.
3. **Documentation:** Added missing GoDoc comments for exported functions (`NewController`, `Run`, `Stop`, `CleanAllIPsec`).
4. **Refactoring:** Updated `ipsec_controller_test.go` and `pkg/controller/controller.go` to reflect the renaming changes.

**Verification:**
Ran `golangci-lint run --build-tags=linux pkg/controller/encryption/ipsec/...` locally. Verified that all linting errors (typecheck and style) related to this controller are resolved.

Fixes #1475