### PR TITLE
fix: add IPv6 address check to service_manager for waypoint routing

### DIFF
--- a/bpf/kmesh/workload/include/service.h
+++ b/bpf/kmesh/workload/include/service.h
@@ -107,7 +107,8 @@ static inline int service_manager(struct kmesh_context *kmesh_ctx, __u32 service
 {
     int ret = 0;
 
-    if (service_v->wp_addr.ip4 != 0 && service_v->waypoint_port != 0) {
+    if ((((__u64 *)service_v->wp_addr.ip6)[0] != 0 || ((__u64 *)service_v->wp_addr.ip6)[1] != 0)
+        && service_v->waypoint_port != 0) {
         BPF_LOG(
             DEBUG,
             SERVICE,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR updates the `service_manager` function in the eBPF data plane to support IPv6 waypoint routing.

Previously, the `service_manager` logic only checked if `service_v->wp_addr.ip4 != 0`. This caused services with valid IPv6 waypoint addresses to be ignored and bypass the proxy.

This fix introduces a check for the `ip6` array to ensure that if either an IPv4 or IPv6 address is present, the traffic is correctly routed to the waypoint manager.

**Which issue this PR fixes**:
Fixes #1460

**Special notes for the reviewer**:
The change is located in `bpf/kmesh/workload/include/service.h`. 
I modified the conditional check to verify if any of the 4 segments of the IPv6 address are non-zero.