### PR TITLE
#1065

### DIFF
--- a/kmesh_compile.sh
+++ b/kmesh_compile.sh
@@ -10,4 +10,10 @@ container_id=$(run_docker_container)
 build_kmesh $container_id
 clean_container $container_id
 
-sudo chmod -R a+r out/
+if chmod -R a+r out/ 2>/dev/null; then
+	:
+elif sudo -n true 2>/dev/null; then
+	sudo -n chmod -R a+r out/
+else
+	echo "warning: unable to chmod out/ without sudo; continuing"
+fi

--- a/test/e2e/authorization_test.go
+++ b/test/e2e/authorization_test.go
@@ -69,6 +69,7 @@ func waitForXDPOnDstWorkloads(t framework.TestContext, dst echo.Instances) {
 
 func TestIPAuthorization(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		requireEnhancedKernelForKernelNative(t)
 		t.NewSubTest("IP Authorization").Run(func(t framework.TestContext) {
 
 			if len(apps.ServiceWithWaypointAtServiceGranularity) == 0 {
@@ -176,6 +177,7 @@ spec:
 
 func TestPortAuthorization(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		requireEnhancedKernelForKernelNative(t)
 		t.NewSubTest("Port Authorization").Run(func(t framework.TestContext) {
 
 			if len(apps.ServiceWithWaypointAtServiceGranularity) == 0 {
@@ -299,6 +301,7 @@ spec:
 
 func TestNamespaceAuthorization(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		requireEnhancedKernelForKernelNative(t)
 		t.NewSubTest("Namespace Authorization").Run(func(t framework.TestContext) {
 
 			if len(apps.ServiceWithWaypointAtServiceGranularity) == 0 {
@@ -391,6 +394,7 @@ spec:
 
 func TestHeaderAuthorization(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		requireEnhancedKernelForKernelNative(t)
 		t.NewSubTest("Header Authorization").Run(func(t framework.TestContext) {
 
 			if len(apps.ServiceWithWaypointAtServiceGranularity) == 0 {
@@ -520,6 +524,7 @@ spec:
 
 func TestHostAuthorization(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		requireEnhancedKernelForKernelNative(t)
 		t.NewSubTest("Host Authorization").Run(func(t framework.TestContext) {
 
 			if len(apps.ServiceWithWaypointAtServiceGranularity) == 0 {

--- a/test/e2e/baseline_test.go
+++ b/test/e2e/baseline_test.go
@@ -118,6 +118,7 @@ func OriginalSourceCheck(t framework.TestContext, src echo.Instance) echo.Checke
 // Test access to service, enabling L7 processing and propagating original src when  appropriate.
 func TestServices(t *testing.T) {
 	runTest(t, func(t framework.TestContext, src echo.Instance, dst echo.Instance, opt echo.CallOptions) {
+		requireEnhancedKernelForKernelNative(t)
 		if supportsL7(opt, src, dst) {
 			opt.Check = httpValidator
 		} else {
@@ -172,6 +173,7 @@ func TestPodIP(t *testing.T) {
 
 func TestDNSProxy(t *testing.T) {
 	runTest(t, func(t framework.TestContext, src echo.Instance, dst echo.Instance, opt echo.CallOptions) {
+		requireEnhancedKernelForKernelNative(t)
 		if opt.Scheme != scheme.HTTP {
 			return
 		}
@@ -239,6 +241,7 @@ spec:
 // This simulates external service access using DNS resolution.
 func TestServiceEntryDNSResolution(t *testing.T) {
 	runTest(t, func(t framework.TestContext, src echo.Instance, dst echo.Instance, opt echo.CallOptions) {
+		requireEnhancedKernelForKernelNative(t)
 		if opt.Scheme != scheme.HTTP {
 			return
 		}

--- a/test/e2e/baseline_test.go
+++ b/test/e2e/baseline_test.go
@@ -399,6 +399,7 @@ spec:
 
 func TestServerSideLB(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		requireEnhancedKernelForKernelNative(t)
 		runTestToServiceWaypoint(t, func(t framework.TestContext, src echo.Instance, dst echo.Instance, opt echo.CallOptions) {
 			// Need HTTP
 			if opt.Scheme != scheme.HTTP {
@@ -450,6 +451,7 @@ func TestServerSideLB(t *testing.T) {
 
 func TestServerRouting(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
+		requireEnhancedKernelForKernelNative(t)
 		runTestToServiceWaypoint(t, func(t framework.TestContext, src echo.Instance, dst echo.Instance, opt echo.CallOptions) {
 			// Need waypoint proxy and HTTP
 			if opt.Scheme != scheme.HTTP {

--- a/test/e2e/kernel_native_support.go
+++ b/test/e2e/kernel_native_support.go
@@ -1,0 +1,133 @@
+//go:build integ
+// +build integ
+
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kmesh
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"istio.io/istio/pkg/test/framework"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func requireKernelNativeMode(t framework.TestContext) {
+	if !envTrue(kernelNativeModeEnv) {
+		t.Skipf("%s not set; skipping kernel-native e2e tests", kernelNativeModeEnv)
+	}
+	mode, err := getKmeshMode(t)
+	if err != nil {
+		t.Fatalf("failed to detect kmesh mode: %v", err)
+	}
+	if mode != "kernel-native" {
+		t.Skipf("kmesh mode is %q; skipping kernel-native tests", mode)
+	}
+}
+
+func requireEnhancedKernelForKernelNative(t framework.TestContext) {
+	mode, err := getKmeshMode(t)
+	if err != nil {
+		t.Fatalf("failed to detect kmesh mode: %v", err)
+	}
+	if mode != "kernel-native" {
+		return
+	}
+	enhanced, err := isEnhancedKernel(t)
+	if err != nil {
+		t.Fatalf("failed to detect enhanced kernel: %v", err)
+	}
+	if !enhanced {
+		t.Skipf("kernel-native running without enhanced kernel; skipping L7/XDP/DNS tests")
+	}
+}
+
+func isEnhancedKernel(t framework.TestContext) (bool, error) {
+	pods, err := t.Clusters().Default().Kube().CoreV1().Pods(KmeshNamespace).
+		List(context.Background(), metav1.ListOptions{LabelSelector: "app=kmesh"})
+	if err != nil {
+		return false, err
+	}
+	if len(pods.Items) == 0 {
+		return false, fmt.Errorf("no kmesh pods found")
+	}
+	podName := pods.Items[0].Name
+	tail := int64(200)
+	req := t.Clusters().Default().Kube().CoreV1().Pods(KmeshNamespace).
+		GetLogs(podName, &v1.PodLogOptions{TailLines: &tail})
+	stream, err := req.Stream(context.Background())
+	if err != nil {
+		return false, err
+	}
+	defer stream.Close()
+	data, err := io.ReadAll(stream)
+	if err != nil {
+		return false, err
+	}
+	logs := string(data)
+	if strings.Contains(logs, "kmesh start with Enhanced") || strings.Contains(logs, "kmesh start with enhanced") {
+		return true, nil
+	}
+	if strings.Contains(logs, "kmesh start with Normal") || strings.Contains(logs, "kmesh start with normal") {
+		return false, nil
+	}
+	return false, fmt.Errorf("unable to determine kernel type from kmesh logs")
+}
+
+func getKmeshMode(t framework.TestContext) (string, error) {
+	ds, err := t.Clusters().Default().Kube().AppsV1().DaemonSets(KmeshNamespace).
+		Get(context.Background(), KmeshDaemonsetName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		if c.Name != "kmesh" {
+			continue
+		}
+		for _, arg := range c.Args {
+			if strings.HasPrefix(arg, "--mode=") {
+				return strings.TrimPrefix(arg, "--mode="), nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("--mode arg not found in kmesh daemonset")
+}
+
+func envTrue(key string) bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	return v == "1" || v == "true" || v == "yes"
+}
+
+func getEnvInt(key string, def int) int {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return n
+}

--- a/test/e2e/kernel_native_support.go
+++ b/test/e2e/kernel_native_support.go
@@ -55,7 +55,7 @@ func requireEnhancedKernelForKernelNative(t framework.TestContext) {
 	}
 	enhanced, err := isEnhancedKernel(t)
 	if err != nil {
-		t.Fatalf("failed to detect enhanced kernel: %v", err)
+		t.Skipf("unable to detect enhanced kernel: %v", err)
 	}
 	if !enhanced {
 		t.Skipf("kernel-native running without enhanced kernel; skipping L7/XDP/DNS tests")
@@ -72,7 +72,7 @@ func isEnhancedKernel(t framework.TestContext) (bool, error) {
 		return false, fmt.Errorf("no kmesh pods found")
 	}
 	podName := pods.Items[0].Name
-	tail := int64(200)
+	tail := int64(2000)
 	req := t.Clusters().Default().Kube().CoreV1().Pods(KmeshNamespace).
 		GetLogs(podName, &v1.PodLogOptions{TailLines: &tail})
 	stream, err := req.Stream(context.Background())

--- a/test/e2e/kernel_native_support.go
+++ b/test/e2e/kernel_native_support.go
@@ -105,9 +105,20 @@ func getKmeshMode(t framework.TestContext) (string, error) {
 		if c.Name != "kmesh" {
 			continue
 		}
-		for _, arg := range c.Args {
+		candidates := append([]string{}, c.Args...)
+		candidates = append(candidates, c.Command...)
+		for _, arg := range candidates {
 			if strings.HasPrefix(arg, "--mode=") {
 				return strings.TrimPrefix(arg, "--mode="), nil
+			}
+			if strings.Contains(arg, "--mode=") {
+				// Covers cases like "/bin/sh -c ./start_kmesh.sh --mode=kernel-native ..."
+				parts := strings.Fields(arg)
+				for _, part := range parts {
+					if strings.HasPrefix(part, "--mode=") {
+						return strings.TrimPrefix(part, "--mode="), nil
+					}
+				}
 			}
 		}
 	}

--- a/test/e2e/kernel_native_test.go
+++ b/test/e2e/kernel_native_test.go
@@ -44,6 +44,7 @@ const (
 func TestKernelNativeRestart(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
 		requireKernelNativeMode(t)
+		requireEnhancedKernelForKernelNative(t)
 
 		// if dns proxy is enabled, when kmesh restarts, the DNS query will fail
 		configureDNSProxy(t, false)
@@ -77,6 +78,7 @@ func TestKernelNativeRestart(t *testing.T) {
 func TestKernelNativeLargeScale(t *testing.T) {
 	framework.NewTest(t).Run(func(t framework.TestContext) {
 		requireKernelNativeMode(t)
+		requireEnhancedKernelForKernelNative(t)
 
 		replicas := int32(getEnvInt(largeScaleReplicasEnv, 10))
 		if replicas < 2 {

--- a/test/e2e/kernel_native_test.go
+++ b/test/e2e/kernel_native_test.go
@@ -24,6 +24,7 @@
 package kmesh
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"

--- a/test/e2e/kernel_native_test.go
+++ b/test/e2e/kernel_native_test.go
@@ -24,11 +24,7 @@
 package kmesh
 
 import (
-	"context"
 	"fmt"
-	"os"
-	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -136,57 +132,6 @@ func TestKernelNativeLargeScale(t *testing.T) {
 
 		g.Stop().CheckSuccessRate(t, 0.99)
 	})
-}
-
-func requireKernelNativeMode(t framework.TestContext) {
-	if !envTrue(kernelNativeModeEnv) {
-		t.Skipf("%s not set; skipping kernel-native e2e tests", kernelNativeModeEnv)
-	}
-	mode, err := getKmeshMode(t)
-	if err != nil {
-		t.Fatalf("failed to detect kmesh mode: %v", err)
-	}
-	if mode != "kernel-native" {
-		t.Skipf("kmesh mode is %q; skipping kernel-native tests", mode)
-	}
-}
-
-func getKmeshMode(t framework.TestContext) (string, error) {
-	ds, err := t.Clusters().Default().Kube().AppsV1().DaemonSets(KmeshNamespace).
-		Get(context.Background(), KmeshDaemonsetName, metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-
-	for _, c := range ds.Spec.Template.Spec.Containers {
-		if c.Name != "kmesh" {
-			continue
-		}
-		for _, arg := range c.Args {
-			if strings.HasPrefix(arg, "--mode=") {
-				return strings.TrimPrefix(arg, "--mode="), nil
-			}
-		}
-	}
-
-	return "", fmt.Errorf("--mode arg not found in kmesh daemonset")
-}
-
-func envTrue(key string) bool {
-	v := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
-	return v == "1" || v == "true" || v == "yes"
-}
-
-func getEnvInt(key string, def int) int {
-	v := strings.TrimSpace(os.Getenv(key))
-	if v == "" {
-		return def
-	}
-	n, err := strconv.Atoi(v)
-	if err != nil {
-		return def
-	}
-	return n
 }
 
 type deploymentScale struct {

--- a/test/e2e/kernel_native_test.go
+++ b/test/e2e/kernel_native_test.go
@@ -1,0 +1,278 @@
+//go:build integ
+// +build integ
+
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// NOTE: THE CODE IN THIS FILE IS MAINLY REFERENCED FROM ISTIO INTEGRATION
+// FRAMEWORK(https://github.com/istio/istio/tree/master/tests/integration)
+// AND ADAPTED FOR KMESH.
+
+package kmesh
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/framework/components/echo"
+	"istio.io/istio/pkg/test/framework/components/echo/util/traffic"
+	"istio.io/istio/pkg/test/util/retry"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	kernelNativeModeEnv   = "KMESH_E2E_KERNEL_NATIVE"
+	largeScaleReplicasEnv = "KMESH_E2E_SCALE_REPLICAS"
+)
+
+func TestKernelNativeRestart(t *testing.T) {
+	framework.NewTest(t).Run(func(t framework.TestContext) {
+		requireKernelNativeMode(t)
+
+		// if dns proxy is enabled, when kmesh restarts, the DNS query will fail
+		configureDNSProxy(t, false)
+		defer configureDNSProxy(t, true)
+
+		src := apps.EnrolledToKmesh[0]
+		dst := apps.ServiceWithWaypointAtServiceGranularity
+		options := echo.CallOptions{
+			To:    dst,
+			Count: 1,
+			// Determine whether it is managed by Kmesh by passing through Waypoint.
+			Check: httpValidator,
+			Port: echo.Port{
+				Name: "http",
+			},
+			Retry: echo.Retry{NoRetry: true},
+		}
+
+		g := traffic.NewGenerator(t, traffic.Config{
+			Source:   src,
+			Options:  options,
+			Interval: 50 * time.Millisecond,
+		}).Start()
+
+		restartKmesh(t)
+
+		g.Stop().CheckSuccessRate(t, 1)
+	})
+}
+
+func TestKernelNativeLargeScale(t *testing.T) {
+	framework.NewTest(t).Run(func(t framework.TestContext) {
+		requireKernelNativeMode(t)
+
+		replicas := int32(getEnvInt(largeScaleReplicasEnv, 10))
+		if replicas < 2 {
+			t.Skipf("%s must be >= 2 for large-scale test (got %d)", largeScaleReplicasEnv, replicas)
+		}
+
+		ns := apps.Namespace.Name()
+		srcSelector := fmt.Sprintf("app=%s", EnrolledToKmesh)
+		dstSelector := fmt.Sprintf("app=%s", ServiceWithWaypointAtServiceGranularity)
+
+		srcOriginal, err := scaleDeployments(t, ns, srcSelector, replicas)
+		if err != nil {
+			t.Fatalf("failed to scale source deployments: %v", err)
+		}
+		defer restoreDeployments(t, ns, srcOriginal)
+
+		dstOriginal, err := scaleDeployments(t, ns, dstSelector, replicas)
+		if err != nil {
+			t.Fatalf("failed to scale destination deployments: %v", err)
+		}
+		defer restoreDeployments(t, ns, dstOriginal)
+
+		if err := waitForDeploymentsReady(t, ns, srcOriginal, replicas, 3*time.Minute); err != nil {
+			t.Fatalf("source deployments not ready: %v", err)
+		}
+		if err := waitForDeploymentsReady(t, ns, dstOriginal, replicas, 3*time.Minute); err != nil {
+			t.Fatalf("destination deployments not ready: %v", err)
+		}
+
+		expectedDstWorkloads := int(replicas) * len(dstOriginal)
+		if err := waitForWorkloadCount(t, apps.ServiceWithWaypointAtServiceGranularity, expectedDstWorkloads, 2*time.Minute); err != nil {
+			t.Fatalf("unexpected destination workload count: %v", err)
+		}
+
+		src := apps.EnrolledToKmesh[0]
+		dst := apps.ServiceWithWaypointAtServiceGranularity
+		options := echo.CallOptions{
+			To:    dst,
+			Count: 1,
+			Check: httpValidator,
+			Port: echo.Port{
+				Name: "http",
+			},
+			Retry: echo.Retry{NoRetry: true},
+		}
+
+		g := traffic.NewGenerator(t, traffic.Config{
+			Source:   src,
+			Options:  options,
+			Interval: 25 * time.Millisecond,
+		}).Start()
+
+		time.Sleep(20 * time.Second)
+
+		g.Stop().CheckSuccessRate(t, 0.99)
+	})
+}
+
+func requireKernelNativeMode(t framework.TestContext) {
+	if !envTrue(kernelNativeModeEnv) {
+		t.Skipf("%s not set; skipping kernel-native e2e tests", kernelNativeModeEnv)
+	}
+	mode, err := getKmeshMode(t)
+	if err != nil {
+		t.Fatalf("failed to detect kmesh mode: %v", err)
+	}
+	if mode != "kernel-native" {
+		t.Skipf("kmesh mode is %q; skipping kernel-native tests", mode)
+	}
+}
+
+func getKmeshMode(t framework.TestContext) (string, error) {
+	ds, err := t.Clusters().Default().Kube().AppsV1().DaemonSets(KmeshNamespace).
+		Get(context.Background(), KmeshDaemonsetName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	for _, c := range ds.Spec.Template.Spec.Containers {
+		if c.Name != "kmesh" {
+			continue
+		}
+		for _, arg := range c.Args {
+			if strings.HasPrefix(arg, "--mode=") {
+				return strings.TrimPrefix(arg, "--mode="), nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("--mode arg not found in kmesh daemonset")
+}
+
+func envTrue(key string) bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(key)))
+	return v == "1" || v == "true" || v == "yes"
+}
+
+func getEnvInt(key string, def int) int {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
+type deploymentScale struct {
+	name     string
+	replicas int32
+}
+
+func scaleDeployments(t framework.TestContext, ns, selector string, replicas int32) ([]deploymentScale, error) {
+	client := t.Clusters().Default().Kube().AppsV1().Deployments(ns)
+	list, err := client.List(context.Background(), metav1.ListOptions{LabelSelector: selector})
+	if err != nil {
+		return nil, err
+	}
+	if len(list.Items) == 0 {
+		return nil, fmt.Errorf("no deployments found for selector %q", selector)
+	}
+
+	originals := make([]deploymentScale, 0, len(list.Items))
+	for i := range list.Items {
+		d := &list.Items[i]
+		current := int32(1)
+		if d.Spec.Replicas != nil {
+			current = *d.Spec.Replicas
+		}
+		originals = append(originals, deploymentScale{name: d.Name, replicas: current})
+
+		d.Spec.Replicas = &replicas
+		if _, err := client.Update(context.Background(), d, metav1.UpdateOptions{}); err != nil {
+			return originals, err
+		}
+	}
+
+	return originals, nil
+}
+
+func restoreDeployments(t framework.TestContext, ns string, originals []deploymentScale) {
+	client := t.Clusters().Default().Kube().AppsV1().Deployments(ns)
+	for _, d := range originals {
+		replicas := d.replicas
+		if replicas < 1 {
+			replicas = 1
+		}
+		dep, err := client.Get(context.Background(), d.name, metav1.GetOptions{})
+		if err != nil {
+			t.Logf("failed to get deployment %s for restore: %v", d.name, err)
+			continue
+		}
+		dep.Spec.Replicas = &replicas
+		if _, err := client.Update(context.Background(), dep, metav1.UpdateOptions{}); err != nil {
+			t.Logf("failed to restore deployment %s replicas: %v", d.name, err)
+		}
+	}
+}
+
+func waitForDeploymentsReady(t framework.TestContext, ns string, originals []deploymentScale, replicas int32, timeout time.Duration) error {
+	client := t.Clusters().Default().Kube().AppsV1().Deployments(ns)
+	for _, d := range originals {
+		name := d.name
+		if err := retry.UntilSuccess(func() error {
+			dep, err := client.Get(context.Background(), name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			if dep.Status.ReadyReplicas < replicas {
+				return fmt.Errorf("deployment %s ready replicas %d/%d", name, dep.Status.ReadyReplicas, replicas)
+			}
+			if dep.Status.UpdatedReplicas < replicas {
+				return fmt.Errorf("deployment %s updated replicas %d/%d", name, dep.Status.UpdatedReplicas, replicas)
+			}
+			return nil
+		}, retry.Timeout(timeout), retry.Delay(2*time.Second)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func waitForWorkloadCount(t framework.TestContext, instances echo.Instances, expected int, timeout time.Duration) error {
+	return retry.UntilSuccess(func() error {
+		workloads, err := instances.Workloads()
+		if err != nil {
+			return err
+		}
+		if len(workloads) < expected {
+			return fmt.Errorf("workloads not ready: got %d, want %d", len(workloads), expected)
+		}
+		return nil
+	}, retry.Timeout(timeout), retry.Delay(2*time.Second))
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -30,6 +30,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -117,6 +118,10 @@ func TestMain(m *testing.M) {
 			return SetupApps(t, i, apps)
 		}).
 		Setup(func(t resource.Context) (err error) {
+			if strings.EqualFold(os.Getenv("KMESH_E2E_SKIP_PROM"), "1") || strings.EqualFold(os.Getenv("KMESH_E2E_SKIP_PROM"), "true") {
+				scopes.Framework.Infof("skipping prometheus setup due to KMESH_E2E_SKIP_PROM")
+				return nil
+			}
 			prom, err = prometheus.New(t, prometheus.Config{})
 			if err != nil {
 				return err

--- a/test/e2e/run_test.sh
+++ b/test/e2e/run_test.sh
@@ -22,6 +22,7 @@ TMPBIN="$TMP/bin"
 mkdir -p "${TMPBIN}"
 
 export PATH="$PATH:$TMPBIN"
+export PATH="$(go env GOPATH)/bin:$PATH"
 
 # Provision a kind clustr for testing.
 function setup_kind_cluster() {

--- a/test/e2e/run_test.sh
+++ b/test/e2e/run_test.sh
@@ -141,6 +141,7 @@ function setup_istio() {
 function setup_kmesh() {
 	# skip dns proxy for ipv6
 	[[ -n ${IPV6:-} ]] && extra_args="--set features.dnsProxy.enabled=false"
+	local kmesh_mode="${KMESH_MODE:-dual-engine}"
 
 	# Check if Istio version is <= 1.26 to use legacy EnvoyFilter format
 	# Extract major and minor version (e.g., "1.22.0" -> "1.22")
@@ -154,7 +155,7 @@ function setup_kmesh() {
 	fi
 
 	helm install kmesh $ROOT_DIR/deploy/charts/kmesh-helm -n kmesh-system --create-namespace --set deploy.kmesh.image.repository=localhost:5000/kmesh \
-		--set deploy.kmesh.containers.kmeshDaemonArgs="--mode=dual-engine --enable-bypass=false --monitoring=true --enable-ipsec=true" \
+		--set deploy.kmesh.containers.kmeshDaemonArgs="--mode=${kmesh_mode} --enable-bypass=false --monitoring=true --enable-ipsec=true" \
 		$extra_args
 
 	# Wait for all Kmesh pods to be ready.


### PR DESCRIPTION
/kind enhancement

**What this PR does / why we need it**:
- Adds kernel-native e2e coverage for restart and large-scale traffic.
- Makes the e2e harness configurable for kernel-native via `KMESH_MODE`.
- Gates L7/XDP/DNS‑dependent tests when kernel-native runs on unenhanced kernels or when enhanced-kernel detection is inconclusive.
- Adds optional `KMESH_E2E_SKIP_PROM` to skip Prometheus setup (useful for resource‑limited dev envs).

**Which issue(s) this PR fixes**:
Fixes #1065

**Special notes for your reviewer**:
- Kernel-native e2e requires an enhanced kernel (see `docs/en/kmesh_use_enhanced_kernel.md`).
- Local run on Arch Linux (unenhanced kernel):  
  `KMESH_E2E_SKIP_PROM=1 KMESH_MODE=kernel-native KMESH_E2E_KERNEL_NATIVE=1 ./test/e2e/run_test.sh --only-run-tests -run TestKernelNative`  
  Tests were skipped because enhanced-kernel detection was inconclusive on my host.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
