### PR TITLE
ctl/monitoring: fix getKmeshDaemonPod rejecting pod names with double hyphens

### DIFF
--- a/ctl/monitoring/monitoring.go
+++ b/ctl/monitoring/monitoring.go
@@ -147,7 +147,7 @@ func getKmeshDaemonPod(args []string) (string, bool) {
 	if len(args) == 0 {
 		return "", false
 	}
-	if strings.Contains(args[0], "--") {
+	if strings.HasPrefix(args[0], "--") {
 		return "", false
 	}
 	return args[0], true

--- a/ctl/monitoring/monitoring_test.go
+++ b/ctl/monitoring/monitoring_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monitoring
+
+import (
+	"testing"
+)
+
+func TestGetKmeshDaemonPod(t *testing.T) {
+	tests := []struct {
+		args     []string
+		wantPod  string
+		wantBool bool
+	}{
+		{nil, "", false},
+		{[]string{}, "", false},
+		{[]string{"kmesh-daemon-abc"}, "kmesh-daemon-abc", true},
+		{[]string{"--accesslog"}, "", false},
+		{[]string{"some--thing"}, "some--thing", true},
+		{[]string{"mypod"}, "mypod", true},
+	}
+	for _, tt := range tests {
+		pod, ok := getKmeshDaemonPod(tt.args)
+		if pod != tt.wantPod || ok != tt.wantBool {
+			t.Errorf("getKmeshDaemonPod(%v) = (%q, %v), want (%q, %v)",
+				tt.args, pod, ok, tt.wantPod, tt.wantBool)
+		}
+	}
+}
+
+func TestNewCmd(t *testing.T) {
+	cmd := NewCmd()
+	if cmd.Use != "monitoring" {
+		t.Fatalf("Use = %q, want %q", cmd.Use, "monitoring")
+	}
+	for _, name := range []string{"accesslog", "all", "workloadMetrics", "connectionMetrics"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Errorf("--%s flag not defined", name)
+		}
+	}
+}


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
Fixes `getKmeshDaemonPod` using `strings.Contains(arg, "--")` which incorrectly rejects legitimate Kubernetes pod names containing consecutive hyphens (e.g. `some--thing`). Changed to `strings.HasPrefix(arg, "--")` so only flag-style arguments starting with `--` are skipped.

```diff
-if strings.Contains(args[0], "--") {
+if strings.HasPrefix(args[0], "--") {
```

Includes a unit test verifying the corrected behavior.

## Which issue(s) this PR fixes:
Fixes #1600