### PR TITLE
bpf/restart: use Update instead of Restart when versions match

### DIFF
--- a/pkg/bpf/bpf_test.go
+++ b/pkg/bpf/bpf_test.go
@@ -167,7 +167,7 @@ func KmeshRestart(t *testing.T, config options.BpfConfig) {
 	if err := bpfLoader.Start(); err != nil {
 		assert.ErrorIsf(t, err, nil, "bpfLoader start failed %v", err)
 	}
-	assert.Equal(t, restart.Restart, restart.GetStartType(), "set kmesh start status:Restart failed")
+	assert.Equal(t, restart.Update, restart.GetStartType(), "set kmesh start status:Update failed")
 	restart.SetExitType(restart.Normal)
 	bpfLoader.Stop()
 }

--- a/pkg/bpf/restart/bpf_restart.go
+++ b/pkg/bpf/restart/bpf_restart.go
@@ -100,8 +100,8 @@ func SetStartStatus(versionMap *ebpf.Map) {
 	oldGitVersion := getOldVersionFromMap(versionMap, 0)
 	log.Infof("oldGitVersion: %v newGitVersion: %v", oldGitVersion, GitVersion)
 	if GitVersion == oldGitVersion {
-		log.Infof("kmesh start with Restart, load bpf maps and prog from last")
-		SetStartType(Restart)
+		log.Infof("kmesh start with Update")
+		SetStartType(Update)
 	} else if oldGitVersion == 0 {
 		// version not found, it is a fresh start
 		log.Infof("kmesh start with Normal")

--- a/pkg/bpf/restart/bpf_update.go
+++ b/pkg/bpf/restart/bpf_update.go
@@ -106,12 +106,16 @@ func UpdateMapHandler(versionMap *ebpf.Map, kmBpfPath string, config *options.Bp
 
 			switch {
 			case !hasNew && hasOld: // clean up
-				oldMap, _ := ebpf.LoadPinnedMap(pinPath, &ebpf.LoadPinOptions{})
-				if err := oldMap.Unpin(); err != nil && !os.IsNotExist(err) {
-					log.Warnf("failed to unpin old map: %v (continuing)", err)
-				}
-				if err := oldMap.Close(); err != nil {
-					log.Warnf("failed to close old map FD: %v (continuing)", err)
+				oldMap, err := ebpf.LoadPinnedMap(pinPath, &ebpf.LoadPinOptions{})
+				if err != nil {
+					log.Warnf("failed to load pinned map %s: %v (continuing)", pinPath, err)
+				} else {
+					if err := oldMap.Unpin(); err != nil && !os.IsNotExist(err) {
+						log.Warnf("failed to unpin old map: %v (continuing)", err)
+					}
+					if err := oldMap.Close(); err != nil {
+						log.Warnf("failed to close old map FD: %v (continuing)", err)
+					}
 				}
 				if err := os.Remove(pinPath); err != nil && !os.IsNotExist(err) {
 					log.Warnf("failed to remove old map pinpath: %v (continuing)", err)

--- a/pkg/bpf/workload/sendmsg.go
+++ b/pkg/bpf/workload/sendmsg.go
@@ -95,7 +95,7 @@ func (sm *BpfSendMsgWorkload) loadKmeshSendmsgObjects() (*ebpf.CollectionSpec, e
 	// 2) unpin old sk_msg prog: If sockmap is deleted, sk_msg will also be cleaned up
 	// 3) pin new sk_msg prog
 	// 4) attach new sk_msg prog(in SendMsg.Attach): Replace the old sk_msg prog
-	if restart.GetStartType() == restart.Restart {
+	if restart.GetStartType() == restart.Restart || restart.GetStartType() == restart.Update {
 		pinPath := filepath.Join(sm.Info.BpfFsPath, "sendmsg_prog")
 		oldSkMsg, err := ebpf.LoadPinnedProgram(pinPath, nil)
 		if err != nil {


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:
`SetStartStatus` incorrectly sets the start type to `Restart` when `GitVersion == oldGitVersion`. The version hash only tracks the binary version, not BPF map state — maps can change independently at runtime. Equal versions don't prove maps are unchanged.

Changed to `Update` which reconciles partial state via `UpdateMapHandler`, rather than `Restart` which blindly reuses everything.

```diff
-SetStartType(Restart)
+SetStartType(Update)
```

## Which issue(s) this PR fixes:
Fixes #794