### PR TITLE
Refactor kmeshctl ut v2

### DIFF
--- a/ctl/authz/authz.go
+++ b/ctl/authz/authz.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -59,10 +58,13 @@ func NewEnableCmd() *cobra.Command {
 		Short:   "Enable xdp authz eBPF program for Kmesh's authz offloading",
 		Example: "kmeshctl authz enable\nkmeshctl authz enable pod1 pod2",
 		Args:    cobra.ArbitraryArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			// If no pod names are given, apply to all kmesh daemon pods.
-			SetAuthzForPods(args, "true")
-			log.Info("Authorization has been enabled.")
+			if err := SetAuthzForPods(args, "true"); err != nil {
+				return err
+			}
+			cmd.Println("Authorization has been enabled.")
+			return nil
 		},
 	}
 	return cmd
@@ -75,9 +77,12 @@ func NewDisableCmd() *cobra.Command {
 		Short:   "Disable xdp authz eBPF program for Kmesh's authz offloading",
 		Example: "kmeshctl authz disable\nkmeshctl authz disable pod1 pod2",
 		Args:    cobra.ArbitraryArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			SetAuthzForPods(args, "false")
-			log.Info("Authorization has been disabled.")
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := SetAuthzForPods(args, "false"); err != nil {
+				return err
+			}
+			cmd.Println("Authorization has been disabled.")
+			return nil
 		},
 	}
 	return cmd
@@ -90,11 +95,10 @@ func NewStatusCmd() *cobra.Command {
 		Short:   "Display the current authorization status",
 		Example: "kmeshctl authz status\nkmeshctl authz status pod1 pod2",
 		Args:    cobra.ArbitraryArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cli, err := utils.CreateKubeClient()
 			if err != nil {
-				log.Errorf("failed to create cli client: %v", err)
-				os.Exit(1)
+				return fmt.Errorf("failed to create cli client: %v", err)
 			}
 
 			// Determine which pods to query.
@@ -102,8 +106,7 @@ func NewStatusCmd() *cobra.Command {
 			if len(args) == 0 {
 				podList, err := cli.PodsForSelector(context.TODO(), utils.KmeshNamespace, utils.KmeshLabel)
 				if err != nil {
-					log.Errorf("failed to get kmesh podList: %v", err)
-					os.Exit(1)
+					return fmt.Errorf("failed to get kmesh podList: %v", err)
 				}
 				for _, pod := range podList.Items {
 					podNames = append(podNames, pod.GetName())
@@ -137,7 +140,8 @@ func NewStatusCmd() *cobra.Command {
 				fmt.Fprintf(tw, "%s\t%s\n", s.Pod, s.Status)
 			}
 			tw.Flush()
-			fmt.Print(buf.String())
+			cmd.Print(buf.String())
+			return nil
 		},
 	}
 	return cmd
@@ -145,66 +149,69 @@ func NewStatusCmd() *cobra.Command {
 
 // SetAuthzForPods applies the authz setting (enable/disable) for the given pod(s).
 // If no pod names are specified, it applies the setting to all kmesh daemon pods.
-func SetAuthzForPods(podNames []string, info string) {
+func SetAuthzForPods(podNames []string, info string) error {
 	cli, err := utils.CreateKubeClient()
 	if err != nil {
-		log.Errorf("failed to create cli client: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create cli client: %v", err)
 	}
 
 	if len(podNames) == 0 {
 		// Apply to all kmesh daemon pods.
 		podList, err := cli.PodsForSelector(context.TODO(), utils.KmeshNamespace, utils.KmeshLabel)
 		if err != nil {
-			log.Errorf("failed to get kmesh podList: %v", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to get kmesh podList: %v", err)
 		}
 		for _, pod := range podList.Items {
-			SetAuthzPerKmeshDaemon(cli, pod.GetName(), info)
+			if err := SetAuthzPerKmeshDaemon(cli, pod.GetName(), info); err != nil {
+				return err
+			}
 		}
 	} else {
 		// Process for specified pods.
 		for _, podName := range podNames {
-			SetAuthzPerKmeshDaemon(cli, podName, info)
+			if err := SetAuthzPerKmeshDaemon(cli, podName, info); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
 // SetAuthzPerKmeshDaemon sends a POST request to a specific kmesh daemon pod
 // to set the authz flag based on the info parameter ("true" or "false").
-func SetAuthzPerKmeshDaemon(cli kube.CLIClient, podName, info string) {
+func SetAuthzPerKmeshDaemon(cli kube.CLIClient, podName, info string) error {
 	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
 	if err != nil {
-		log.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
 	}
 	if err := fw.Start(); err != nil {
-		log.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		os.Exit(1)
+		return fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
 	}
 	defer fw.Close()
 
 	url := fmt.Sprintf("http://%s%s?enable=%s", fw.Address(), patternAuthz, info)
+	return SetAuthz(url)
+}
 
+// SetAuthz sends a POST request to the specified URL to set the authz flag.
+func SetAuthz(url string) error {
 	req, err := http.NewRequest(http.MethodPost, url, nil)
 	if err != nil {
-		log.Errorf("Error creating request: %v", err)
-		return
+		return fmt.Errorf("error creating request: %v", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Errorf("failed to make HTTP request: %v", err)
-		return
+		return fmt.Errorf("failed to make HTTP request: %v", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		log.Errorf("Error: received status code %d", resp.StatusCode)
-		return
+		return fmt.Errorf("received status code %d", resp.StatusCode)
 	}
+	return nil
 }
 
 // fetchAuthzStatus sends a GET request to a specific kmesh daemon pod
@@ -220,7 +227,11 @@ func fetchAuthzStatus(cli kube.CLIClient, podName string) (string, error) {
 	defer fw.Close()
 
 	url := fmt.Sprintf("http://%s%s", fw.Address(), patternAuthz)
+	return GetAuthzStatus(url)
+}
 
+// GetAuthzStatus sends a GET request to the specified URL to retrieve the current authz status.
+func GetAuthzStatus(url string) (string, error) {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return "", fmt.Errorf("error creating request: %v", err)
@@ -243,6 +254,5 @@ func fetchAuthzStatus(cli kube.CLIClient, podName string) (string, error) {
 		return "", fmt.Errorf("failed to read response body: %v", err)
 	}
 
-	status := string(bodyBytes)
-	return status, nil
+	return string(bodyBytes), nil
 }

--- a/ctl/authz/authz_test.go
+++ b/ctl/authz/authz_test.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package authz
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewCmd(t *testing.T) {
+	cmd := NewCmd()
+	if cmd.Use != "authz" {
+		t.Fatalf("Use = %q, want %q", cmd.Use, "authz")
+	}
+
+	got := map[string]bool{}
+	for _, sub := range cmd.Commands() {
+		got[sub.Name()] = true
+	}
+	for _, want := range []string{"enable", "disable", "status"} {
+		if !got[want] {
+			t.Errorf("subcommand %q not registered", want)
+		}
+	}
+}
+
+func TestNewEnableCmd(t *testing.T) {
+	cmd := NewEnableCmd()
+	if cmd.Use != "enable [podNames...]" {
+		t.Fatalf("Use = %q, want %q", cmd.Use, "enable [podNames...]")
+	}
+}
+
+func TestNewDisableCmd(t *testing.T) {
+	cmd := NewDisableCmd()
+	if cmd.Use != "disable [podNames...]" {
+		t.Fatalf("Use = %q, want %q", cmd.Use, "disable [podNames...]")
+	}
+}
+
+func TestNewStatusCmd(t *testing.T) {
+	cmd := NewStatusCmd()
+	if cmd.Use != "status [podNames...]" {
+		t.Fatalf("Use = %q, want %q", cmd.Use, "status [podNames...]")
+	}
+}
+
+func TestSetAuthz(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Method = %q, want %q", r.Method, http.MethodPost)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	if err := SetAuthz(ts.URL); err != nil {
+		t.Errorf("SetAuthz() failed: %v", err)
+	}
+}
+
+func TestGetAuthzStatus(t *testing.T) {
+	want := "enabled"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("Method = %q, want %q", r.Method, http.MethodGet)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(want))
+	}))
+	defer ts.Close()
+
+	got, err := GetAuthzStatus(ts.URL)
+	if err != nil {
+		t.Errorf("GetAuthzStatus() failed: %v", err)
+	}
+	if got != want {
+		t.Errorf("GetAuthzStatus() = %q, want %q", got, want)
+	}
+}

--- a/ctl/common/common_test.go
+++ b/ctl/common/common_test.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"testing"
+)
+
+func TestGetRootCommand(t *testing.T) {
+	root := GetRootCommand()
+	if root.Use != "kmeshctl" {
+		t.Fatalf("Use = %q, want %q", root.Use, "kmeshctl")
+	}
+
+	want := map[string]bool{
+		"log": false, "dump": false, "waypoint": false, "version": false,
+		"monitoring": false, "authz": false, "secret": false,
+	}
+
+	for _, cmd := range root.Commands() {
+		if _, ok := want[cmd.Name()]; ok {
+			want[cmd.Name()] = true
+		}
+	}
+
+	for name, found := range want {
+		if !found {
+			t.Errorf("subcommand %q not registered", name)
+		}
+	}
+}

--- a/ctl/dump/dump.go
+++ b/ctl/dump/dump.go
@@ -57,8 +57,8 @@ kmeshctl dump <kmesh-daemon-pod> dual-engine
 # Output as raw JSON:
 kmeshctl dump <kmesh-daemon-pod> kernel-native -o json`,
 		Args: cobra.ExactArgs(2),
-		Run: func(cmd *cobra.Command, args []string) {
-			_ = RunDump(cmd, args, outputFormat)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunDump(cmd, args, outputFormat)
 		},
 	}
 
@@ -70,41 +70,31 @@ func RunDump(cmd *cobra.Command, args []string, outputFormat string) error {
 	podName := args[0]
 	mode := args[1]
 	if mode != constants.KernelNativeMode && mode != constants.DualEngineMode {
-		log.Errorf("Error: Argument must be 'kernel-native' or 'dual-engine'")
-		os.Exit(1)
+		return fmt.Errorf("error: argument must be 'kernel-native' or 'dual-engine'")
 	}
 
 	cli, err := utils.CreateKubeClient()
 	if err != nil {
-		log.Errorf("failed to create cli client: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create cli client: %v", err)
 	}
 
 	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
 	if err != nil {
-		log.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
 	}
 	if err := fw.Start(); err != nil {
-		log.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
+		return fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
 	}
+	defer fw.Close()
 
 	url := fmt.Sprintf("http://%s%s/%s", fw.Address(), configDumpPrefix, mode)
-	resp, err := http.Get(url)
+	body, err := GetConfigDump(url)
 	if err != nil {
-		log.Errorf("failed to make HTTP request: %v", err)
-		os.Exit(1)
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		log.Errorf("failed to read HTTP response body: %v", err)
-		os.Exit(1)
+		return err
 	}
 
 	if outputFormat == "json" {
-		fmt.Println(string(body))
+		cmd.Println(string(body))
 		return nil
 	}
 
@@ -116,6 +106,26 @@ func RunDump(cmd *cobra.Command, args []string, outputFormat string) error {
 	}
 
 	return nil
+}
+
+// GetConfigDump sends a GET request to the specified URL to retrieve the config dump.
+func GetConfigDump(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to make HTTP request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("received status code %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read HTTP response body: %v", err)
+	}
+
+	return body, nil
 }
 
 // printKernelNativeTable parses and displays kernel-native config dump as tables.

--- a/ctl/dump/dump_test.go
+++ b/ctl/dump/dump_test.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dump
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewCmd(t *testing.T) {
+	cmd := NewCmd()
+	if cmd.Use != "dump" {
+		t.Fatalf("Use = %q, want %q", cmd.Use, "dump")
+	}
+
+	if flag := cmd.Flags().Lookup("output"); flag == nil {
+		t.Error("output flag not registered")
+	}
+}
+
+func TestUint32ToIPStr(t *testing.T) {
+	tests := []struct {
+		ip   uint32
+		want string
+	}{
+		{0x0100007f, "127.0.0.1"},
+		{0x08080808, "8.8.8.8"},
+		{0x00000000, "0.0.0.0"},
+	}
+	for _, tt := range tests {
+		if got := uint32ToIPStr(tt.ip); got != tt.want {
+			t.Errorf("uint32ToIPStr(%d) = %q, want %q", tt.ip, got, tt.want)
+		}
+	}
+}
+
+func TestGetConfigDump(t *testing.T) {
+	want := `{"workloads": []}`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(want))
+	}))
+	defer ts.Close()
+
+	got, err := GetConfigDump(ts.URL)
+	if err != nil {
+		t.Errorf("GetConfigDump() failed: %v", err)
+	}
+	if string(got) != want {
+		t.Errorf("GetConfigDump() = %q, want %q", string(got), want)
+	}
+}

--- a/ctl/log/log.go
+++ b/ctl/log/log.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -55,8 +54,8 @@ kmeshctl log <kmesh-daemon-pod>
 # Get default logger's level:
 kmeshctl log <kmesh-daemon-pod> default`,
 		Args: cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			RunGetOrSetLoggerLevel(cmd, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunGetOrSetLoggerLevel(cmd, args)
 		},
 	}
 	cmd.Flags().String("set", "", "Set the logger level (e.g., default:debug)")
@@ -87,34 +86,25 @@ func GetJson(url string, val any) error {
 	return nil
 }
 
-func GetLoggerNames(url string) {
+func GetLoggerNames(url string) ([]string, error) {
 	var loggerNames []string
 	if err := GetJson(url, &loggerNames); err != nil {
-		log.Errorf("failed to get logger names: %v", err)
-		return
+		return nil, err
 	}
-
-	fmt.Printf("Existing Loggers:\n")
-	for _, logger := range loggerNames {
-		fmt.Printf("\t%s\n", logger)
-	}
+	return loggerNames, nil
 }
 
-func GetLoggerLevel(url string) {
+func GetLoggerLevel(url string) (*LoggerInfo, error) {
 	var loggerInfo LoggerInfo
 	if err := GetJson(url, &loggerInfo); err != nil {
-		log.Errorf("failed to get logger level: %v", err)
-		return
+		return nil, err
 	}
-
-	fmt.Printf("Logger Name: %s\n", loggerInfo.Name)
-	fmt.Printf("Logger Level: %s\n", loggerInfo.Level)
+	return &loggerInfo, nil
 }
 
-func SetLoggerLevel(url string, setFlag string) {
+func SetLoggerLevel(url string, setFlag string) (string, error) {
 	if !strings.Contains(setFlag, ":") {
-		log.Errorf("Invalid set flag, which should be loggerName:loggerLevel (e.g. default:debug)")
-		os.Exit(1)
+		return "", fmt.Errorf("invalid set flag, which should be loggerName:loggerLevel (e.g. default:debug)")
 	}
 	splits := strings.Split(setFlag, ":")
 	loggerName := splits[0]
@@ -126,53 +116,47 @@ func SetLoggerLevel(url string, setFlag string) {
 	}
 	data, err := json.Marshal(loggerInfo)
 	if err != nil {
-		log.Errorf("Error marshaling logger info: %v", err)
-		return
+		return "", fmt.Errorf("error marshaling logger info: %v", err)
 	}
 
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(data))
 	if err != nil {
-		log.Errorf("Error creating request: %v", err)
-		return
+		return "", fmt.Errorf("error creating request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Errorf("failed to make HTTP request: %v", err)
-		return
+		return "", fmt.Errorf("failed to make HTTP request: %v", err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		log.Errorf("Error: received status code %d", resp.StatusCode)
-	}
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Errorf("failed to read HTTP response body: %v", err)
-		return
+		return "", fmt.Errorf("failed to read HTTP response body: %v", err)
 	}
-	fmt.Println(string(body))
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("received status code %d, Response body: %s", resp.StatusCode, body)
+	}
+
+	return string(body), nil
 }
 
-func RunGetOrSetLoggerLevel(cmd *cobra.Command, args []string) {
+func RunGetOrSetLoggerLevel(cmd *cobra.Command, args []string) error {
 	podName := args[0]
 
 	cli, err := utils.CreateKubeClient()
 	if err != nil {
-		log.Errorf("failed to create cli client: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create cli client: %v", err)
 	}
 
 	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
 	if err != nil {
-		log.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
 	}
 	if err := fw.Start(); err != nil {
-		log.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		os.Exit(1)
+		return fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
 	}
 	defer fw.Close()
 
@@ -182,11 +166,28 @@ func RunGetOrSetLoggerLevel(cmd *cobra.Command, args []string) {
 	if setFlag == "" {
 		if len(args) >= 2 {
 			url += fmt.Sprintf("?name=%s", args[1])
-			GetLoggerLevel(url)
+			info, err := GetLoggerLevel(url)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Logger Name: %s\n", info.Name)
+			fmt.Fprintf(cmd.OutOrStdout(), "Logger Level: %s\n", info.Level)
 		} else {
-			GetLoggerNames(url)
+			names, err := GetLoggerNames(url)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Existing Loggers:\n")
+			for _, n := range names {
+				fmt.Fprintf(cmd.OutOrStdout(), "\t%s\n", n)
+			}
 		}
 	} else {
-		SetLoggerLevel(url, setFlag)
+		resp, err := SetLoggerLevel(url, setFlag)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(cmd.OutOrStdout(), resp)
 	}
+	return nil
 }

--- a/ctl/log/log_test.go
+++ b/ctl/log/log_test.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestNewCmd(t *testing.T) {
+	cmd := NewCmd()
+	if cmd.Use != "log" {
+		t.Fatalf("Use = %q, want %q", cmd.Use, "log")
+	}
+
+	if flag := cmd.Flags().Lookup("set"); flag == nil {
+		t.Error("set flag not registered")
+	}
+}
+
+func TestGetJson(t *testing.T) {
+	want := LoggerInfo{Name: "default", Level: "debug"}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(want)
+	}))
+	defer ts.Close()
+
+	var got LoggerInfo
+	if err := GetJson(ts.URL, &got); err != nil {
+		t.Errorf("GetJson() failed: %v", err)
+	}
+	if got != want {
+		t.Errorf("GetJson() = %+v, want %+v", got, want)
+	}
+}
+
+func TestSetLoggerLevel(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Method = %q, want %q", r.Method, http.MethodPost)
+		}
+		var info LoggerInfo
+		if err := json.NewDecoder(r.Body).Decode(&info); err != nil {
+			t.Errorf("failed to decode body: %v", err)
+		}
+		if info.Name != "default" || info.Level != "debug" {
+			t.Errorf("received info %+v, want {default debug}", info)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("success"))
+	}))
+	defer ts.Close()
+
+	resp, err := SetLoggerLevel(ts.URL, "default:debug")
+	if err != nil {
+		t.Errorf("SetLoggerLevel() failed: %v", err)
+	}
+	if resp != "success" {
+		t.Errorf("SetLoggerLevel() = %q, want %q", resp, "success")
+	}
+}

--- a/ctl/monitoring/monitoring.go
+++ b/ctl/monitoring/monitoring.go
@@ -17,12 +17,10 @@
 package monitoring
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -78,8 +76,8 @@ kmeshctl monitoring --connectionMetrics enable/disable
 #Enable/Disable services', workloads' and 'connections' metrics and accesslog generated from bpf in each node:
 kmeshctl monitoring --all enable/disable`,
 		Args: cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			ControlMonitoring(cmd, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ControlMonitoring(cmd, args)
 		},
 	}
 	cmd.Flags().String("accesslog", "", "Control accesslog enable or disable")
@@ -89,58 +87,73 @@ kmeshctl monitoring --all enable/disable`,
 	return cmd
 }
 
-func ControlMonitoring(cmd *cobra.Command, args []string) {
+func ControlMonitoring(cmd *cobra.Command, args []string) error {
 	client, err := utils.CreateKubeClient()
 	if err != nil {
-		log.Errorf("failed to create cli client: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create cli client: %v", err)
 	}
 	accesslogFlag, _ := cmd.Flags().GetString("accesslog")
 	allFlag, _ := cmd.Flags().GetString("all")
 	workloadMetricsFlag, _ := cmd.Flags().GetString("workloadMetrics")
 	connectionMetricsFlag, _ := cmd.Flags().GetString("connectionMetrics")
 	if accesslogFlag == "" && allFlag == "" && workloadMetricsFlag == "" && connectionMetricsFlag == "" {
-		log.Print("no parameters. Need --accesslog, --workloadMetrics, --connectionMetrics or --all")
-		return
+		cmd.Println("no parameters. Need --accesslog, --workloadMetrics, --connectionMetrics or --all")
+		return nil
 	}
 
 	podName, hasKmeshPod := getKmeshDaemonPod(args)
 	if hasKmeshPod {
 		// Processes triggers for specified kmesh daemon.
 		if allFlag != "" {
-			SetObservabilityPerKmeshDaemon(client, podName, allFlag, MONITORING, patternMonitoring)
+			if err := SetObservabilityPerKmeshDaemon(client, podName, allFlag, MONITORING, patternMonitoring); err != nil {
+				return err
+			}
 		}
 		if accesslogFlag != "" {
-			SetObservabilityPerKmeshDaemon(client, podName, accesslogFlag, ACCESSLOG, patternAccesslog)
+			if err := SetObservabilityPerKmeshDaemon(client, podName, accesslogFlag, ACCESSLOG, patternAccesslog); err != nil {
+				return err
+			}
 		}
 		if workloadMetricsFlag != "" {
-			SetObservabilityPerKmeshDaemon(client, podName, workloadMetricsFlag, WORKLOAD, patternWorkloadMetrics)
+			if err := SetObservabilityPerKmeshDaemon(client, podName, workloadMetricsFlag, WORKLOAD, patternWorkloadMetrics); err != nil {
+				return err
+			}
 		}
 		if connectionMetricsFlag != "" {
-			SetObservabilityPerKmeshDaemon(client, podName, connectionMetricsFlag, CONNECTION, patternConnectionMetrics)
+			if err := SetObservabilityPerKmeshDaemon(client, podName, connectionMetricsFlag, CONNECTION, patternConnectionMetrics); err != nil {
+				return err
+			}
 		}
 	} else {
 		// Perform operations on all kmesh daemons.
 		podList, err := client.PodsForSelector(context.TODO(), utils.KmeshNamespace, utils.KmeshLabel)
 		if err != nil {
-			log.Errorf("failed to get kmesh podList: %v", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to get kmesh podList: %v", err)
 		}
 		for _, pod := range podList.Items {
 			if allFlag != "" {
-				SetObservabilityPerKmeshDaemon(client, pod.GetName(), allFlag, MONITORING, patternMonitoring)
+				if err := SetObservabilityPerKmeshDaemon(client, pod.GetName(), allFlag, MONITORING, patternMonitoring); err != nil {
+					return err
+				}
 			}
 			if accesslogFlag != "" {
-				SetObservabilityPerKmeshDaemon(client, pod.GetName(), accesslogFlag, ACCESSLOG, patternAccesslog)
+				if err := SetObservabilityPerKmeshDaemon(client, pod.GetName(), accesslogFlag, ACCESSLOG, patternAccesslog); err != nil {
+					return err
+				}
 			}
 			if workloadMetricsFlag != "" {
-				SetObservabilityPerKmeshDaemon(client, pod.GetName(), workloadMetricsFlag, WORKLOAD, patternWorkloadMetrics)
+				if err := SetObservabilityPerKmeshDaemon(client, pod.GetName(), workloadMetricsFlag, WORKLOAD, patternWorkloadMetrics); err != nil {
+					return err
+				}
 			}
 			if connectionMetricsFlag != "" {
-				SetObservabilityPerKmeshDaemon(client, pod.GetName(), connectionMetricsFlag, CONNECTION, patternConnectionMetrics)
+				if err := SetObservabilityPerKmeshDaemon(client, pod.GetName(), connectionMetricsFlag, CONNECTION, patternConnectionMetrics); err != nil {
+					return err
+				}
 			}
 		}
 	}
+	return nil
 }
 
 func getKmeshDaemonPod(args []string) (string, bool) {
@@ -153,58 +166,57 @@ func getKmeshDaemonPod(args []string) (string, bool) {
 	return args[0], true
 }
 
-func SetObservabilityPerKmeshDaemon(cli kube.CLIClient, podName, info string, observablityType string, pattern string) {
+func SetObservabilityPerKmeshDaemon(cli kube.CLIClient, podName, info string, observabilityType string, pattern string) error {
 	var status string
 	if info == "enable" {
 		status = "true"
 	} else if info == "disable" {
 		status = "false"
 	} else {
-		log.Errorf("Error: Argument must be 'enable' or 'disable'")
-		os.Exit(1)
+		return fmt.Errorf("error: argument must be 'enable' or 'disable'")
 	}
 
 	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
 	if err != nil {
-		log.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
 	}
 	if err := fw.Start(); err != nil {
-		log.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		os.Exit(1)
+		return fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
 	}
 	defer fw.Close()
 
 	url := fmt.Sprintf("http://%s%s?enable=%s", fw.Address(), pattern, status)
+	return SetObservability(url, observabilityType)
+}
 
+// SetObservability sends a POST request to the specified URL to set the observability flag.
+func SetObservability(url string, observabilityType string) error {
 	req, err := http.NewRequest(http.MethodPost, url, nil)
 	if err != nil {
-		log.Errorf("Error creating request: %v", err)
-		return
+		return fmt.Errorf("error creating request: %v", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Errorf("failed to make HTTP request: %v", err)
-		return
+		return fmt.Errorf("failed to make HTTP request: %v", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		log.Errorf("Error: received status code %d", resp.StatusCode)
-		if observablityType == MONITORING {
-			return
+		if observabilityType == MONITORING {
+			return fmt.Errorf("received status code %d", resp.StatusCode)
 		}
 		bodyBytes, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
-			log.Errorf("Error reading response body: %v", readErr)
-			return
+			return fmt.Errorf("received status code %d, and error reading response body: %v", resp.StatusCode, readErr)
 		}
 		bodyString := string(bodyBytes)
-		if resp.StatusCode == http.StatusBadRequest && bytes.Contains(bodyBytes, []byte(fmt.Sprintf("Kmesh monitoring is disable, cannot enable %s.", observablityType))) {
-			log.Errorf("failed to enable %s: %v. Need to start Kmesh's Monitoring. Please run `kmeshctl monitoring -h` for more help.", observablityType, bodyString)
+		if resp.StatusCode == http.StatusBadRequest && strings.Contains(bodyString, fmt.Sprintf("Kmesh monitoring is disabled, cannot enable %s.", observabilityType)) {
+			return fmt.Errorf("failed to enable %s: %v. Need to start Kmesh's Monitoring. Please run `kmeshctl monitoring -h` for more help", observabilityType, bodyString)
 		}
+		return fmt.Errorf("received status code %d, Response body: %s", resp.StatusCode, bodyString)
 	}
+	return nil
 }

--- a/ctl/monitoring/monitoring_test.go
+++ b/ctl/monitoring/monitoring_test.go
@@ -17,39 +17,65 @@
 package monitoring
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
-
-func TestGetKmeshDaemonPod(t *testing.T) {
-	tests := []struct {
-		args     []string
-		wantPod  string
-		wantBool bool
-	}{
-		{nil, "", false},
-		{[]string{}, "", false},
-		{[]string{"kmesh-daemon-abc"}, "kmesh-daemon-abc", true},
-		{[]string{"--accesslog"}, "", false},
-		{[]string{"some--thing"}, "some--thing", true},
-		{[]string{"mypod"}, "mypod", true},
-	}
-	for _, tt := range tests {
-		pod, ok := getKmeshDaemonPod(tt.args)
-		if pod != tt.wantPod || ok != tt.wantBool {
-			t.Errorf("getKmeshDaemonPod(%v) = (%q, %v), want (%q, %v)",
-				tt.args, pod, ok, tt.wantPod, tt.wantBool)
-		}
-	}
-}
 
 func TestNewCmd(t *testing.T) {
 	cmd := NewCmd()
 	if cmd.Use != "monitoring" {
 		t.Fatalf("Use = %q, want %q", cmd.Use, "monitoring")
 	}
-	for _, name := range []string{"accesslog", "all", "workloadMetrics", "connectionMetrics"} {
-		if cmd.Flags().Lookup(name) == nil {
-			t.Errorf("--%s flag not defined", name)
+
+	for _, flagName := range []string{"accesslog", "all", "workloadMetrics", "connectionMetrics"} {
+		if flag := cmd.Flags().Lookup(flagName); flag == nil {
+			t.Errorf("%s flag not registered", flagName)
 		}
+	}
+}
+
+func TestGetKmeshDaemonPod(t *testing.T) {
+	tests := []struct {
+		args    []string
+		wantPod string
+		wantHas bool
+	}{
+		{[]string{"pod1"}, "pod1", true},
+		{[]string{"--accesslog", "enable"}, "", false},
+		{[]string{}, "", false},
+	}
+	for _, tt := range tests {
+		gotPod, gotHas := getKmeshDaemonPod(tt.args)
+		if gotPod != tt.wantPod || gotHas != tt.wantHas {
+			t.Errorf("getKmeshDaemonPod(%v) = (%q, %v), want (%q, %v)", tt.args, gotPod, gotHas, tt.wantPod, tt.wantHas)
+		}
+	}
+}
+
+func TestSetObservability(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("Method = %q, want %q", r.Method, http.MethodPost)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	if err := SetObservability(ts.URL, ACCESSLOG); err != nil {
+		t.Errorf("SetObservability() failed: %v", err)
+	}
+}
+
+func TestSetObservabilityError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("Kmesh monitoring is disable, cannot enable accesslog."))
+	}))
+	defer ts.Close()
+
+	err := SetObservability(ts.URL, ACCESSLOG)
+	if err == nil {
+		t.Error("SetObservability() expected error, got nil")
 	}
 }

--- a/ctl/secret/secret.go
+++ b/ctl/secret/secret.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -46,7 +45,6 @@ const (
 )
 
 func NewCmd() *cobra.Command {
-	clientset = createKubeClientOrExit()
 
 	cmd := &cobra.Command{
 		Use:   "secret",
@@ -57,7 +55,8 @@ kmeshctl secret get
 kmeshctl secret delete
 `,
 		Args: cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
 		},
 	}
 
@@ -70,8 +69,8 @@ kmeshctl secret create
 # Generate IPsec configuration with user-defined key:
 kmeshctl secret create --key=$(echo -n "{36-character user-defined key here}" | xxd -p -c 64)`,
 		Args: cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			CreateOrUpdateSecret(cmd, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return CreateOrUpdateSecret(cmd, args)
 		},
 	}
 
@@ -84,8 +83,8 @@ kmeshctl secret create --key=$(echo -n "{36-character user-defined key here}" | 
 		Example: `# Get IPsec key and configuration by kmeshctl. The results will be displayed in JSON format.
 kmeshctl secret get`,
 		Args: cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			GetSecret()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return GetSecret(cmd)
 		},
 	}
 
@@ -95,8 +94,8 @@ kmeshctl secret get`,
 		Short:   "Delete IPsec key and configuration by kmeshctl",
 		Example: `kmeshctl secret delete`,
 		Args:    cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			DeleteSecret()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return DeleteSecret()
 		},
 	}
 
@@ -108,18 +107,21 @@ kmeshctl secret get`,
 	return cmd
 }
 
-func createKubeClientOrExit() kube.CLIClient {
+func createKubeClient() (kube.CLIClient, error) {
 	clientset, err := utils.CreateKubeClient()
 	if err != nil {
-		log.Errorf("failed to connect k8s client, %v", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to connect k8s client, %v", err)
 	}
-	return clientset
+	return clientset, nil
 }
 
-func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
-	var ipSecKey, ipSecKeyOld encryption.IpSecKey
+func CreateOrUpdateSecret(cmd *cobra.Command, args []string) error {
 	var err error
+	clientset, err = createKubeClient()
+	if err != nil {
+		return err
+	}
+	var ipSecKey, ipSecKeyOld encryption.IpSecKey
 
 	ipSecKey.AeadKeyName = AeadAlgoName
 
@@ -131,20 +133,17 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 		aeadKey = make([]byte, AeadKeyLength)
 		_, err := rand.Read(aeadKey)
 		if err != nil {
-			log.Errorf("failed to generate random key: %v", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to generate random key: %v", err)
 		}
 	} else {
 		aeadKey, err = hex.DecodeString(aeadKeyArg)
 		if err != nil {
-			log.Errorf("failed to decode hex string: %v, input: %v", err, aeadKeyArg)
-			os.Exit(1)
+			return fmt.Errorf("failed to decode hex string: %v, input: %v", err, aeadKeyArg)
 		}
 	}
 
 	if len(aeadKey) != AeadKeyLength {
-		log.Errorf("invalid key length: expected %d bytes, got %d bytes (key must be 256-bit + 32-bit salt)", AeadKeyLength, len(aeadKey))
-		os.Exit(1)
+		return fmt.Errorf("invalid key length: expected %d bytes, got %d bytes (key must be 256-bit + 32-bit salt)", AeadKeyLength, len(aeadKey))
 	}
 
 	ipSecKey.AeadKey = aeadKey
@@ -154,23 +153,20 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 	secretOld, err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Get(context.TODO(), SecretName, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			log.Errorf("failed to get secret: %v, %v", SecretName, err)
-			os.Exit(1)
+			return fmt.Errorf("failed to get secret: %v, %v", SecretName, err)
 		}
 		ipSecKey.Spi = 1
 	} else {
 		err = json.Unmarshal(secretOld.Data["ipSec"], &ipSecKeyOld)
 		if err != nil {
-			log.Errorf("failed to unmarshal secret: %v, %v", secretOld, err)
-			os.Exit(1)
+			return fmt.Errorf("failed to unmarshal secret: %v, %v", secretOld, err)
 		}
 		ipSecKey.Spi = ipSecKeyOld.Spi + 1
 	}
 
 	secretData, err := json.Marshal(ipSecKey)
 	if err != nil {
-		log.Errorf("failed to convert ipsec key to secret data, %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to convert ipsec key to secret data, %v", err)
 	}
 
 	secret := &corev1.Secret{
@@ -186,39 +182,39 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 	if ipSecKey.Spi == 1 {
 		_, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Create(context.TODO(), secret, metav1.CreateOptions{})
 		if err != nil {
-			log.Errorf("failed to create %v secret, %v", SecretName, err)
-			os.Exit(1)
+			return fmt.Errorf("failed to create %v secret, %v", SecretName, err)
 		}
 	} else {
 		_, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
 		if err != nil {
-			log.Errorf("failed to update %v secret, %v", SecretName, err)
-			os.Exit(1)
+			return fmt.Errorf("failed to update %v secret, %v", SecretName, err)
 		}
 	}
+	return nil
 }
 
-func GetSecret() {
+func GetSecret(cmd *cobra.Command) error {
+	var err error
+	clientset, err = createKubeClient()
+	if err != nil {
+		return err
+	}
 	secret, err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Get(context.TODO(), SecretName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Errorf("secret %s not found", SecretName)
-			os.Exit(1)
+			return fmt.Errorf("secret %s not found", SecretName)
 		}
-		log.Errorf("failed to get secret: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to get secret: %v", err)
 	}
 
 	if secret.Data == nil || secret.Data["ipSec"] == nil {
-		log.Errorf("invalid secret data: missing ipSec field")
-		os.Exit(1)
+		return fmt.Errorf("invalid secret data: missing ipSec field")
 	}
 
 	// Parse the IPsec data
 	var ipSecKey encryption.IpSecKey
 	if err := json.Unmarshal(secret.Data["ipSec"], &ipSecKey); err != nil {
-		log.Errorf("failed to unmarshal secret data: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to unmarshal secret data: %v", err)
 	}
 
 	// Create a display structure with hex string key
@@ -236,25 +232,29 @@ func GetSecret() {
 
 	displayData, err := json.MarshalIndent(displayKey, "", "  ")
 	if err != nil {
-		log.Errorf("failed to marshal display data: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to marshal display data: %v", err)
 	}
 
-	fmt.Printf("Secret name: %s\n", SecretName)
-	fmt.Printf("Namespace: %s\n", utils.KmeshNamespace)
-	fmt.Printf("Created: %s\n", secret.CreationTimestamp.Format("2006-01-02 15:04:05"))
-	fmt.Println("IPsec Configuration:")
-	fmt.Println(string(displayData))
+	cmd.Printf("Secret name: %s\n", SecretName)
+	cmd.Printf("Namespace: %s\n", utils.KmeshNamespace)
+	cmd.Printf("Created: %s\n", secret.CreationTimestamp.Format("2006-01-02 15:04:05"))
+	cmd.Println("IPsec Configuration:")
+	cmd.Println(string(displayData))
+	return nil
 }
 
-func DeleteSecret() {
-	err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Delete(context.TODO(), SecretName, metav1.DeleteOptions{})
+func DeleteSecret() error {
+	var err error
+	clientset, err = createKubeClient()
+	if err != nil {
+		return err
+	}
+	err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Delete(context.TODO(), SecretName, metav1.DeleteOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Errorf("secret %s not found", SecretName)
-			os.Exit(1)
+			return fmt.Errorf("secret %s not found", SecretName)
 		}
-		log.Errorf("failed to delete secret: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to delete secret: %v", err)
 	}
+	return nil
 }

--- a/ctl/secret/secret_test.go
+++ b/ctl/secret/secret_test.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package secret
+
+import (
+	"testing"
+)
+
+func TestNewCmd(t *testing.T) {
+	cmd := NewCmd()
+	if cmd.Use != "secret" {
+		t.Fatalf("Use = %q, want %q", cmd.Use, "secret")
+	}
+
+	got := map[string]bool{}
+	for _, sub := range cmd.Commands() {
+		got[sub.Name()] = true
+	}
+	for _, want := range []string{"create", "get", "delete"} {
+		if !got[want] {
+			t.Errorf("subcommand %q not registered", want)
+		}
+	}
+}

--- a/ctl/version/version.go
+++ b/ctl/version/version.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"regexp"
 	"strings"
 
@@ -45,19 +44,18 @@ kmeshctl version
 
 # Show version info of a specific kmesh daemon
 kmeshctl version <kmesh-daemon-pod>`,
-		Run: func(cmd *cobra.Command, args []string) {
-			runVersion(cmd, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVersion(cmd, args)
 		},
 	}
 	return cmd
 }
 
 // runVersion output the version info of kmeshctl or kmesh-daemon.
-func runVersion(cmd *cobra.Command, args []string) {
+func runVersion(cmd *cobra.Command, args []string) error {
 	cli, err := utils.CreateKubeClient()
 	if err != nil {
-		log.Errorf("failed to create kube client: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create kube client: %v", err)
 	}
 
 	if len(args) == 0 {
@@ -70,13 +68,16 @@ func runVersion(cmd *cobra.Command, args []string) {
 
 		podList, err := cli.PodsForSelector(context.TODO(), utils.KmeshNamespace, utils.KmeshLabel)
 		if err != nil {
-			log.Errorf("failed to get kmesh daemon pods: %v", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to get kmesh daemon pods: %v", err)
 		}
 
 		daemonVersions := map[string]int{}
 		for _, pod := range podList.Items {
-			v := getVersion(cli, pod.Name)
+			v, err := getVersion(cli, pod.Name)
+			if err != nil {
+				log.Errorf("failed to get version for pod %s: %v", pod.Name, err)
+				continue
+			}
 			if v.GitVersion != "" {
 				if stringMatch(v.GitVersion) {
 					daemonVersions[v.GitVersion] = daemonVersions[v.GitVersion] + 1
@@ -91,53 +92,50 @@ func runVersion(cmd *cobra.Command, args []string) {
 			counts = append(counts, fmt.Sprintf("%s (%d daemons)", k, v))
 		}
 		cmd.Printf("%s\n", strings.Join(counts, ", "))
-		return
+		return nil
 	}
 
 	podName := args[0]
-	v := getVersion(cli, podName)
-	if v.GitVersion != "" {
-		data, err := json.MarshalIndent(&v, "", "  ")
-		if err != nil {
-			log.Errorf("Failed to marshal version info: %v", err)
-			os.Exit(1)
-		}
-		cmd.Printf("%s\n", string(data))
+	v, err := getVersion(cli, podName)
+	if err != nil {
+		return err
 	}
+	data, err := json.MarshalIndent(&v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal version info: %v", err)
+	}
+	cmd.Printf("%s\n", string(data))
+	return nil
 }
 
-func getVersion(client kube.CLIClient, podName string) (version version.Info) {
+func getVersion(client kube.CLIClient, podName string) (version.Info, error) {
+	v := version.Info{}
 	fw, err := utils.CreateKmeshPortForwarder(client, podName)
 	if err != nil {
-		log.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		return
+		return v, fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
 	}
 	if err := fw.Start(); err != nil {
-		log.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		return
+		return v, fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
 	}
 	defer fw.Close()
 
 	url := fmt.Sprintf("http://%s/version", fw.Address())
 	resp, err := http.Get(url)
 	if err != nil {
-		log.Errorf("failed to make HTTP request: %v", err)
-		return
+		return v, fmt.Errorf("failed to make HTTP request: %v", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Errorf("failed to read HTTP response body: %v", err)
-		return
+		return v, fmt.Errorf("failed to read HTTP response body: %v", err)
 	}
 
-	if err := json.Unmarshal(body, &version); err != nil {
-		log.Errorf("failed to unmarshal version info: %v", err)
-		return
+	if err := json.Unmarshal(body, &v); err != nil {
+		return v, fmt.Errorf("failed to unmarshal version info: %v", err)
 	}
 
-	return
+	return v, nil
 }
 
 // match release version vx.y.z-(alpha)

--- a/ctl/waypoint/waypoint_test.go
+++ b/ctl/waypoint/waypoint_test.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package waypoint
+
+import (
+	"testing"
+)
+
+func TestNewCmd(t *testing.T) {
+	cmd := NewCmd()
+	if cmd.Use != "waypoint" {
+		t.Fatalf("Use = %q, want %q", cmd.Use, "waypoint")
+	}
+
+	got := map[string]bool{}
+	for _, sub := range cmd.Commands() {
+		got[sub.Name()] = true
+	}
+	for _, want := range []string{"apply", "generate", "list", "delete", "status"} {
+		if !got[want] {
+			t.Errorf("subcommand %q not registered", want)
+		}
+	}
+}
+
+func TestNamespaceOrDefault(t *testing.T) {
+	tests := []struct {
+		ns   string
+		want string
+	}{
+		{"", "default"},
+		{"foo", "foo"},
+	}
+	for _, tt := range tests {
+		if got := namespaceOrDefault(tt.ns); got != tt.want {
+			t.Errorf("namespaceOrDefault(%q) = %q, want %q", tt.ns, got, tt.want)
+		}
+	}
+}

--- a/pkg/controller/security/manager.go
+++ b/pkg/controller/security/manager.go
@@ -257,3 +257,4 @@ func (s *SecretManager) retryFetchCert(identity string) {
 
 	go s.fetchCert(identity)
 }
+

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -17,15 +17,11 @@
 package logger
 
 import (
-	"context"
-	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/ringbuf"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
@@ -121,44 +117,4 @@ func NewLoggerScope(scope string) *logrus.Entry {
 // NewFileLogger don't output log to stdout
 func NewFileLogger(pkgSubsys string) *logrus.Entry {
 	return fileOnlyLogger.WithField(logSubsys, pkgSubsys)
-}
-
-// print bpf log in kmesh-daemon
-func StartLogReader(ctx context.Context, logMapFd *ebpf.Map) {
-	go handleLogEvents(ctx, logMapFd)
-}
-
-func handleLogEvents(ctx context.Context, rbMap *ebpf.Map) {
-	log := NewLoggerScope("ebpf")
-	events, err := ringbuf.NewReader(rbMap)
-	if err != nil {
-		log.Errorf("ringbuf new reader from rb map failed:%v", err)
-		return
-	}
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-			record, err := events.Read()
-			if err != nil {
-				return
-			}
-			le, err := decodeRecord(record.RawSample)
-			if err != nil {
-				log.Errorf("ringbuf decode data failed:%v", err)
-			}
-			log.Infof("%v", le.Msg)
-		}
-	}
-}
-
-// 4 is the msg length, -1 is the '\0' terminate character
-func decodeRecord(data []byte) (*LogEvent, error) {
-	le := LogEvent{}
-	lenOfMsg := binary.NativeEndian.Uint32(data[0:4])
-	le.len = uint32(lenOfMsg)
-	le.Msg = string(data[4 : 4+lenOfMsg-1])
-	return &le, nil
 }

--- a/pkg/logger/logger_linux.go
+++ b/pkg/logger/logger_linux.go
@@ -1,0 +1,82 @@
+//go:build linux
+
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logger
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/ringbuf"
+)
+
+// print bpf log in kmesh-daemon
+func StartLogReader(ctx context.Context, logMapFd *ebpf.Map) {
+	go handleLogEvents(ctx, logMapFd)
+}
+
+func handleLogEvents(ctx context.Context, rbMap *ebpf.Map) {
+	log := NewLoggerScope("ebpf")
+	events, err := ringbuf.NewReader(rbMap)
+	if err != nil {
+		log.Errorf("ringbuf new reader from rb map failed:%v", err)
+		return
+	}
+	defer events.Close()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			record, err := events.Read()
+			if err != nil {
+				return
+			}
+			le, err := decodeRecord(record.RawSample)
+			if err != nil {
+				log.Errorf("ringbuf decode data failed: %v", err)
+				continue
+			}
+			log.Infof("%v", le.Msg)
+		}
+	}
+}
+
+// 4 is the msg length, -1 is the '\0' terminate character
+func decodeRecord(data []byte) (*LogEvent, error) {
+	if len(data) < 4 {
+		return nil, fmt.Errorf("data length too short: %d", len(data))
+	}
+
+	le := LogEvent{}
+	lenOfMsg := binary.NativeEndian.Uint32(data[0:4])
+	if lenOfMsg < 1 {
+		return nil, fmt.Errorf("invalid message length: %d", lenOfMsg)
+	}
+
+	if uint32(len(data)) < 4+lenOfMsg {
+		return nil, fmt.Errorf("data length %d less than expected %d", len(data), 4+lenOfMsg)
+	}
+
+	le.len = uint32(lenOfMsg)
+	le.Msg = string(data[4 : 4+lenOfMsg-1])
+	return &le, nil
+}

--- a/pkg/logger/logger_stub.go
+++ b/pkg/logger/logger_stub.go
@@ -1,0 +1,30 @@
+//go:build !linux
+
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logger
+
+import (
+	"context"
+)
+
+// Dummy types to satisfy compilation on non-linux platforms where ebpf is not used.
+type ebpfMap struct{}
+
+// StartLogReader is a stub on non-linux platforms.
+func StartLogReader(ctx context.Context, logMapFd any) {
+}

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -53,6 +53,8 @@ const (
 	configDumpPrefix          = "/debug/config_dump"
 	patternConfigDumpAds      = configDumpPrefix + "/kernel-native"
 	patternConfigDumpWorkload = configDumpPrefix + "/dual-engine"
+	patternConfigDumpServices = configDumpPrefix + "/services"
+	patternConfigDumpPolicies = configDumpPrefix + "/policies"
 	patternReadyProbe         = "/debug/ready"
 	patternLoggers            = "/debug/loggers"
 	patternAccesslog          = "/accesslog"
@@ -95,6 +97,8 @@ func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs, loade
 	s.mux.HandleFunc(patternBpfWorkloadMaps, s.bpfWorkloadMaps)
 	s.mux.HandleFunc(patternConfigDumpAds, s.configDumpAds)
 	s.mux.HandleFunc(patternConfigDumpWorkload, s.configDumpWorkload)
+	s.mux.HandleFunc(patternConfigDumpServices, s.configDumpServices)
+	s.mux.HandleFunc(patternConfigDumpPolicies, s.configDumpPolicies)
 	s.mux.HandleFunc(patternLoggers, s.loggersHandler)
 	s.mux.HandleFunc(patternAccesslog, s.accesslogHandler)
 	s.mux.HandleFunc(patternMonitoring, s.monitoringHandler)
@@ -102,7 +106,6 @@ func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs, loade
 	s.mux.HandleFunc(patternConnectionMetrics, s.connectionMetricHandler)
 	s.mux.HandleFunc(patternAuthz, s.authzHandler)
 
-	// TODO: add dump certificate, authorizationPolicies and services
 	s.mux.HandleFunc(patternReadyProbe, s.readyProbe)
 
 	// support pprof
@@ -364,6 +367,7 @@ func (s *Server) getLoggerNames(w http.ResponseWriter) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(data)
 }
 
@@ -494,6 +498,43 @@ func (s *Server) configDumpWorkload(w http.ResponseWriter, r *http.Request) {
 		workloadDump.Policies = append(workloadDump.Policies, ConvertAuthorizationPolicy(p))
 	}
 	printWorkloadDump(w, workloadDump)
+}
+
+// configDumpServices dumps all K8s services known to Kmesh
+func (s *Server) configDumpServices(w http.ResponseWriter, r *http.Request) {
+	if !s.checkWorkloadMode(w) {
+		return
+	}
+
+	services := s.xdsClient.WorkloadController.Processor.ServiceCache.List()
+	dumpJSON(w, services, ConvertService, "services")
+}
+
+// configDumpPolicies dumps all security (RBAC) policies
+func (s *Server) configDumpPolicies(w http.ResponseWriter, r *http.Request) {
+	if !s.checkWorkloadMode(w) {
+		return
+	}
+
+	policies := s.xdsClient.WorkloadController.Rbac.PoliciesList()
+	dumpJSON(w, policies, ConvertAuthorizationPolicy, "policies")
+}
+
+// dumpJSON is a generic helper to marshal and write a slice of items as JSON.
+func dumpJSON[T any, U any](w http.ResponseWriter, items []T, converter func(T) U, subject string) {
+	dump := make([]U, 0, len(items))
+	for _, item := range items {
+		dump = append(dump, converter(item))
+	}
+
+	data, err := json.MarshalIndent(dump, "", "    ")
+	if err != nil {
+		log.Errorf("Failed to marshal %s: %v", subject, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
 }
 
 func (s *Server) readyProbe(w http.ResponseWriter, r *http.Request) {

--- a/pkg/status/status_server_test.go
+++ b/pkg/status/status_server_test.go
@@ -662,3 +662,92 @@ func TestServerMonitoringHandler(t *testing.T) {
 		assert.Equal(t, constants.ENABLED, enableMonitoring)
 	})
 }
+
+func TestServer_configDumpServices(t *testing.T) {
+	t.Run("invalid mode returns 400", func(t *testing.T) {
+		server := &Server{}
+		req := httptest.NewRequest(http.MethodGet, patternConfigDumpServices, nil)
+		w := httptest.NewRecorder()
+		server.configDumpServices(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns 200 with JSON-encoded services", func(t *testing.T) {
+		fakeServiceCache := cache.NewServiceCache()
+		fakeServiceCache.AddOrUpdateService(buildService("svc-a", "hostname-a"))
+		fakeServiceCache.AddOrUpdateService(buildService("svc-b", "hostname-b"))
+
+		server := &Server{
+			xdsClient: &controller.XdsClient{
+				WorkloadController: &workload.Controller{
+					Processor: &workload.Processor{
+						WorkloadCache: cache.NewWorkloadCache(),
+						ServiceCache:  fakeServiceCache,
+					},
+					Rbac: auth.NewRbac(cache.NewWorkloadCache()),
+				},
+			},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, patternConfigDumpServices, nil)
+		w := httptest.NewRecorder()
+		server.configDumpServices(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var services []*Service
+		err := json.Unmarshal(w.Body.Bytes(), &services)
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(services))
+	})
+}
+
+func TestServer_configDumpPolicies(t *testing.T) {
+	t.Run("invalid mode returns 400", func(t *testing.T) {
+		server := &Server{}
+		req := httptest.NewRequest(http.MethodGet, patternConfigDumpPolicies, nil)
+		w := httptest.NewRecorder()
+		server.configDumpPolicies(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns 200 with JSON-encoded policies", func(t *testing.T) {
+		fakeWorkloadCache := cache.NewWorkloadCache()
+		fakeAuth := auth.NewRbac(fakeWorkloadCache)
+		fakeAuth.UpdatePolicy(&security.Authorization{
+			Name:      "policy-1",
+			Namespace: "ns",
+			Scope:     security.Scope_GLOBAL,
+			Action:    security.Action_ALLOW,
+		})
+		fakeAuth.UpdatePolicy(&security.Authorization{
+			Name:      "policy-2",
+			Namespace: "ns",
+			Scope:     security.Scope_WORKLOAD,
+			Action:    security.Action_DENY,
+		})
+
+		server := &Server{
+			xdsClient: &controller.XdsClient{
+				WorkloadController: &workload.Controller{
+					Processor: &workload.Processor{
+						WorkloadCache: fakeWorkloadCache,
+						ServiceCache:  cache.NewServiceCache(),
+					},
+					Rbac: fakeAuth,
+				},
+			},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, patternConfigDumpPolicies, nil)
+		w := httptest.NewRecorder()
+		server.configDumpPolicies(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var policies []*AuthorizationPolicy
+		err := json.Unmarshal(w.Body.Bytes(), &policies)
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(policies))
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind feature

**What this PR does / why we need it**:
This PR focuses on refactoring `kmeshctl` for better testability and fixing cross-platform build issues. Key changes include:

1. **CLI Refactoring & Unit Testing**:
    a. Extracted core logic and HTTP/Kube logic into testable functions for [authz](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/kmesh/pkg/status/status_server.go:334:0-359:1), [dump](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/kmesh/pkg/status/status_server.go:522:0-537:1), [monitoring](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/kmesh/pkg/status/status_server.go:246:0-277:1), `secret`, and [log](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/kmesh/pkg/status/status_server.go:213:0-221:1).
    b. Added comprehensive unit tests using `httptest` to mock the daemon's response.
    c. Added root command checks in [common_test.go](cci:7://file:///c:/Users/dhara/Documents/Aashish/vscode/kmesh/ctl/common/common_test.go:0:0-0:0) to verify subcommand registration.

2. **Cross-Platform Compatibility**:
    a. Split `pkg/logger` into platform-specific files to fix Windows build errors.
    b. Moved eBPF-specific ringbuffer logic to `logger_linux.go` with build tags.
    c. Added `logger_stub.go` for non-Linux platforms to ensure `kmeshctl` builds everywhere.

3. **Status Server Improvements**:
    a. Fixed HTTP header ordering to ensure `WriteHeader(http.StatusOK)` is called before writing the payload.
    b. Introduced a `dumpJSON` helper to reduce code duplication in debug handlers.
    c. Added new endpoints for `/debug/config_dump/services` and `/debug/config_dump/policies`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The main goal was to make the ctl package more robust and local-build friendly. Deferred kube-client creation in the `secret` command also prevents crashes in testing environments.

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
