### PR TITLE
feat(cni): add file watcher for CNI config file

### DIFF
--- a/pkg/cni/chained.go
+++ b/pkg/cni/chained.go
@@ -25,8 +25,10 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"github.com/containernetworking/cni/libcni"
+	"github.com/fsnotify/fsnotify"
 
 	"kmesh.net/kmesh/pkg/utils"
 )
@@ -210,9 +212,55 @@ func (i *Installer) chainedKmeshCniPlugin(mode string, cniMountNetEtcDIR string)
 	}
 	log.Infof("cni config file: %s", cniConfigFilePath)
 
-	/*
-	 TODO: add watcher for cniConfigFile
-	*/
+	i.cniWatcherMu.Lock()
+	if !i.cniWatcherStarted {
+		i.cniWatcherStarted = true
+		go func() {
+			defer func() {
+				i.cniWatcherMu.Lock()
+				i.cniWatcherStarted = false
+				i.cniWatcherMu.Unlock()
+			}()
+
+			if err := i.Watcher.Add(cniConfigFilePath); err != nil {
+				log.Errorf("failed to add %s to file watcher: %v", cniConfigFilePath, err)
+				return
+			}
+			log.Infof("start watching file %s", cniConfigFilePath)
+
+			var timerC <-chan time.Time
+			for {
+				select {
+				case <-timerC:
+					timerC = nil
+					if err := i.addCniConfig(); err != nil {
+						log.Errorf("failed try to update Kmesh cni config: %v", err)
+					}
+				case event := <-i.Watcher.Events(cniConfigFilePath):
+					if event.Has(fsnotify.Write) || event.Has(fsnotify.Create) {
+						if timerC == nil {
+							timerC = time.After(100 * time.Millisecond)
+						}
+					} else if event.Has(fsnotify.Remove) {
+						log.Infof("cni config file %s removed, try to re-install", cniConfigFilePath)
+						if err := i.addCniConfig(); err != nil {
+							log.Errorf("failed try to update Kmesh cni config: %v", err)
+						}
+						// If the file was removed, the watch might be lost.
+						// We exit this goroutine, and the next call to chainedKmeshCniPlugin
+						// SHOULD re-initiate the watch because i.cniWatcherStarted will be false.
+						return
+					}
+				case err := <-i.Watcher.Errors(cniConfigFilePath):
+					if err != nil {
+						log.Errorf("error from errors channel of file watcher: %v", err)
+						return
+					}
+				}
+			}
+		}()
+	}
+	i.cniWatcherMu.Unlock()
 
 	existCNIConfig, err := os.ReadFile(cniConfigFilePath)
 	if err != nil {

--- a/pkg/cni/install.go
+++ b/pkg/cni/install.go
@@ -19,6 +19,7 @@ package cni
 import (
 	"fmt"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -61,7 +62,9 @@ type Installer struct {
 	CniConfigChained   bool
 	ServiceAccountPath string
 
-	Watcher filewatcher.FileWatcher
+	Watcher           filewatcher.FileWatcher
+	cniWatcherMu      sync.Mutex
+	cniWatcherStarted bool
 }
 
 func NewInstaller(mode string,


### PR DESCRIPTION
What type of PR is this? /kind feature

What this PR does / why we need it: This PR addresses the TODO in pkg/cni/chained.go by implementing a standard fsnotify file watcher for the CNI config file. It ensures that any changes to the CNI configuration are detected in real-time and trigger the necessary reload logic.

Which issue(s) this PR fixes: Fixes #1565

Special notes for your reviewer:
Implemented using fsnotify which is standard in the Kmesh codebase.
Added a mutex (cniWatcherMu) in the Installer struct to prevent multiple goroutines from watching the same file.
Handles file removal gracefully by resetting the watcher state.
Does this PR introduce a user-facing change?: NONE