### PR TITLE
fix(bypass): clean up stale iptables rules on daemon restart

### DIFF
--- a/pkg/controller/bypass/bypass_controller.go
+++ b/pkg/controller/bypass/bypass_controller.go
@@ -65,7 +65,11 @@ func NewByPassController(client kubernetes.Interface) *Controller {
 			}
 
 			if !shouldBypass(pod) {
-				// TODO: add delete iptables in case we missed skip bypass during kmesh restart
+				nspath, _ := ns.GetPodNSpath(pod)
+				if nspath != "" {
+					// during daemon restart, reconcile to ensure stale bypass rules are cleared
+					_ = deleteIptables(nspath)
+				}
 				return
 			}
 
@@ -157,7 +161,7 @@ func addIptables(ns string) error {
 		}
 		for _, args := range iptArgs {
 			if err := utils.Execute("iptables", args); err != nil {
-				return fmt.Errorf("failed to exec command: iptables %v\", err: %v", args, err)
+				return fmt.Errorf("failed to exec command: iptables %v, err: %v", args, err)
 			}
 		}
 		return nil
@@ -178,7 +182,7 @@ func deleteIptables(ns string) error {
 		log.Infof("Running delete iptables rule in namespace:%s", ns)
 		for _, args := range iptArgs {
 			if err := utils.Execute("iptables", args); err != nil {
-				err = fmt.Errorf("failed to exec command: iptables %v\", err: %v", args, err)
+				err = fmt.Errorf("failed to exec command: iptables %v, err: %v", args, err)
 				log.Error(err)
 				return err
 			}

--- a/pkg/controller/bypass/bypass_test.go
+++ b/pkg/controller/bypass/bypass_test.go
@@ -150,4 +150,27 @@ func TestBypassController(t *testing.T) {
 	wg.Wait()
 	assert.Equal(t, true, enabled.Load(), "unexpected value for enabled flag")
 	assert.Equal(t, false, disabled.Load(), "unexpected value for disabled flag")
+
+	enabled.Store(false)
+	disabled.Store(false)
+	// case 5: Pod with sidecar but no bypass label at creation
+	podWithSidecarButNoBypass := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod-no-bypass",
+			Namespace: namespaceName,
+			Labels:    map[string]string{}, // no bypass label
+			Annotations: map[string]string{
+				"sidecar.istio.io/status": "placeholder",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+		},
+	}
+	wg.Add(1)
+	_, err = client.CoreV1().Pods(namespaceName).Create(context.TODO(), podWithSidecarButNoBypass, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	wg.Wait()
+	assert.Equal(t, false, enabled.Load(), "unexpected value for enabled flag")
+	assert.Equal(t, true, disabled.Load(), "unexpected value for disabled flag")
 }


### PR DESCRIPTION
### Purpose
While auditing the bypass controller, we found that Kmesh doesn't flush existing bypass iptables rules when the daemon restarts. This can lead to stale rules accumulating in pod network namespaces if the bypass state changed while Kmesh was down.

### Changes
- Implement iptables cleanup for non-bypassing pods in AddFunc to ensure reconciliation on restart.
- Fix minor formatting typo in iptables execution error messages.
- Add test case to verify cleanup on pod addition.

Fixes #1592