### PR TITLE
bypass: do not insert iptables when sidecar not injected

### DIFF
--- a/pkg/controller/bypass/bypass_controller.go
+++ b/pkg/controller/bypass/bypass_controller.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	"kmesh.net/kmesh/pkg/constants"
 	ns "kmesh.net/kmesh/pkg/controller/netns"
 	"kmesh.net/kmesh/pkg/kube"
 	"kmesh.net/kmesh/pkg/logger"
@@ -59,8 +60,8 @@ func NewByPassController(client kubernetes.Interface) *Controller {
 				log.Errorf("expected *corev1.Pod but got %T", obj)
 				return
 			}
-			if !istio.PodHasSidecar(pod) {
-				log.Infof("pod %s/%s does not have sidecar injected, skip", pod.GetNamespace(), pod.GetName())
+			if !istio.PodHasSidecar(pod) && !isKmeshManaged(pod) {
+				log.Infof("pod %s/%s does not need process, skip", pod.GetNamespace(), pod.GetName())
 				return
 			}
 
@@ -89,8 +90,8 @@ func NewByPassController(client kubernetes.Interface) *Controller {
 				return
 			}
 
-			if !istio.PodHasSidecar(newPod) {
-				log.Debugf("pod %s/%s does not have a sidecar", newPod.GetNamespace(), newPod.GetName())
+			if !istio.PodHasSidecar(newPod) && !isKmeshManaged(newPod) {
+				log.Debugf("pod %s/%s does not have a sidecar and not managed by kmesh", newPod.GetNamespace(), newPod.GetName())
 				return
 			}
 
@@ -133,6 +134,10 @@ func (c *Controller) Run(stop <-chan struct{}) {
 // checks whether there is a bypass label
 func shouldBypass(pod *corev1.Pod) bool {
 	return pod.Labels[ByPassLabel] == ByPassValue
+}
+
+func isKmeshManaged(pod *corev1.Pod) bool {
+	return utils.AnnotationEnabled(pod.Annotations[constants.KmeshRedirectionAnnotation])
 }
 
 func isPodBeingDeleted(pod *corev1.Pod) bool {

--- a/pkg/utils/istio/sidecar.go
+++ b/pkg/utils/istio/sidecar.go
@@ -26,5 +26,12 @@ func PodHasSidecar(pod *corev1.Pod) bool {
 		return true
 	}
 
+	for _, container := range pod.Spec.Containers {
+		if container.Name == "istio-proxy" {
+			return true
+		}
+	}
+
 	return false
 }
+

--- a/pkg/utils/istio/sidecar_test.go
+++ b/pkg/utils/istio/sidecar_test.go
@@ -47,7 +47,26 @@ func TestPodHasSidecar(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "pod without annotation",
+			name: "pod with sidecar container but no annotation",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-pod-no-annotation",
+					Namespace:   "default",
+					Annotations: map[string]string{},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "test-node",
+					Containers: []corev1.Container{
+						{
+							Name: "istio-proxy",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pod without sidecar annotation and container",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "test-pod",


### PR DESCRIPTION
What this PR does / why we need it:
This PR improves the sidecar detection logic in the bypass controller. Previously, it only checked the pod annotation for sidecar status, which could be inaccurate if a pod was started before sidecar injection was enabled in its namespace. We've enhanced the detection to also check for the actual presence of the istio-proxy container and properly account for Kmesh management states.

Which issue(s) this PR fixes:
Fixes #474

Special notes for your reviewer:
NONE

Does this PR introduce a user-facing change?:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
release-note
NONE
