### PR TITLE
fix: replace improper error wrapping with %w in fmt.Errorf calls

### DIFF
--- a/pkg/bpf/ads/loader.go
+++ b/pkg/bpf/ads/loader.go
@@ -109,15 +109,15 @@ func (sc *BpfAds) Start() error {
 		if errors.As(err, &ve) {
 			return fmt.Errorf("bpf load failed: %+v", ve)
 		}
-		return fmt.Errorf("bpf load failed: %v", err)
+		return fmt.Errorf("bpf load failed: %w", err)
 	}
 
 	if err := sc.Attach(); err != nil {
-		return fmt.Errorf("bpf attach failed, %s", err)
+		return fmt.Errorf("bpf attach failed, %w", err)
 	}
 
 	if err := sc.ApiEnvCfg(); err != nil {
-		return fmt.Errorf("api env config failed, %s", err)
+		return fmt.Errorf("api env config failed, %w", err)
 	}
 
 	ret := C.deserial_init()
@@ -126,7 +126,7 @@ func (sc *BpfAds) Start() error {
 	}
 
 	if err := maglev.InitMaglevMap(); err != nil {
-		return fmt.Errorf("consistent hash lb maglev config init failed, %s", err)
+		return fmt.Errorf("consistent hash lb maglev config init failed, %w", err)
 	}
 
 	return nil

--- a/pkg/bpf/ads/loader_enhanced.go
+++ b/pkg/bpf/ads/loader_enhanced.go
@@ -109,15 +109,15 @@ func (sc *BpfAds) Start() error {
 		if errors.As(err, &ve) {
 			return fmt.Errorf("bpf Load failed: %+v", ve)
 		}
-		return fmt.Errorf("bpf Load failed: %v", err)
+		return fmt.Errorf("bpf Load failed: %w", err)
 	}
 
 	if err := sc.Attach(); err != nil {
-		return fmt.Errorf("bpf Attach failed, %s", err)
+		return fmt.Errorf("bpf Attach failed, %w", err)
 	}
 
 	if err := sc.ApiEnvCfg(); err != nil {
-		return fmt.Errorf("failed to set api env")
+		return fmt.Errorf("failed to set api env: %w", err)
 	}
 
 	ret := C.deserial_init()

--- a/pkg/bpf/utils/pin.go
+++ b/pkg/bpf/utils/pin.go
@@ -33,10 +33,10 @@ func PinPrograms(value *reflect.Value, path string) error {
 
 		info, err := tp.Info()
 		if err != nil {
-			return fmt.Errorf("get prog info failed, %s", err)
+			return fmt.Errorf("get prog info failed, %w", err)
 		}
 		if err := tp.Pin(path + info.Name); err != nil {
-			return fmt.Errorf("pin prog failed, %s", err)
+			return fmt.Errorf("pin prog failed, %w", err)
 		}
 	}
 
@@ -50,7 +50,7 @@ func UnpinPrograms(value *reflect.Value) error {
 			continue
 		}
 		if err := tp.Unpin(); err != nil {
-			return fmt.Errorf("unpin prog failed, %s", err)
+			return fmt.Errorf("unpin prog failed, %w", err)
 		}
 	}
 
@@ -64,7 +64,7 @@ func UnpinMaps(value *reflect.Value) error {
 			continue
 		}
 		if err := tp.Unpin(); err != nil {
-			return fmt.Errorf("unpin map failed, %s", err)
+			return fmt.Errorf("unpin map failed, %w", err)
 		}
 	}
 

--- a/pkg/bpf/workload/loader.go
+++ b/pkg/bpf/workload/loader.go
@@ -83,19 +83,19 @@ func (w *BpfWorkload) Start() error {
 		if errors.As(err, &ve) {
 			return fmt.Errorf("bpf Load failed: %+v", ve)
 		}
-		return fmt.Errorf("bpf Load failed: %v", err)
+		return fmt.Errorf("bpf Load failed: %w", err)
 	}
 
 	if err := w.Attach(); err != nil {
-		return fmt.Errorf("bpf Attach failed, %s", err)
+		return fmt.Errorf("bpf Attach failed, %w", err)
 	}
 
 	if err := w.ApiEnvCfg(); err != nil {
-		return fmt.Errorf("failed to set api env")
+		return fmt.Errorf("failed to set api env: %w", err)
 	}
 
 	if err := w.DeserialInit(); err != nil {
-		return fmt.Errorf("failed to init deserialization: %v", err)
+		return fmt.Errorf("failed to init deserialization: %w", err)
 	}
 	return nil
 }

--- a/pkg/cache/v2/maps/authz.go
+++ b/pkg/cache/v2/maps/authz.go
@@ -111,7 +111,7 @@ func AuthorizationUpdate(policyKey uint32, value *security_v2.Authorization) err
 	cKey := C.uint(policyKey)
 	cMsg, err := authorizationToClang(value)
 	if err != nil {
-		return fmt.Errorf("authorizationUpdate %s", err)
+		return fmt.Errorf("authorizationUpdate %w", err)
 	}
 	defer authorizationFreeClang(cMsg)
 

--- a/pkg/cache/v2/maps/cluster.go
+++ b/pkg/cache/v2/maps/cluster.go
@@ -116,7 +116,7 @@ func ClusterUpdate(key string, value *cluster_v2.Cluster) error {
 
 	cMsg, err := clusterToClang(value)
 	if err != nil {
-		return fmt.Errorf("ClusterUpdate %s", err)
+		return fmt.Errorf("ClusterUpdate %w", err)
 	}
 	if cMsg == nil {
 		return nil

--- a/pkg/cache/v2/maps/listener.go
+++ b/pkg/cache/v2/maps/listener.go
@@ -102,7 +102,7 @@ func ListenerLookup(key *core_v2.SocketAddress, value *listener_v2.Listener) err
 
 	cKey, err := socketAddressToClang(key)
 	if err != nil {
-		return fmt.Errorf("ListenerLookup %s", err)
+		return fmt.Errorf("ListenerLookup %w", err)
 	}
 	if cKey == nil {
 		return nil
@@ -129,7 +129,7 @@ func ListenerUpdate(key *core_v2.SocketAddress, value *listener_v2.Listener) err
 
 	cKey, err := socketAddressToClang(key)
 	if err != nil {
-		return fmt.Errorf("ListenerLookup %s", err)
+		return fmt.Errorf("ListenerLookup %w", err)
 	}
 	if cKey == nil {
 		return nil
@@ -138,7 +138,7 @@ func ListenerUpdate(key *core_v2.SocketAddress, value *listener_v2.Listener) err
 
 	cMsg, err := listenerToClang(value)
 	if err != nil {
-		return fmt.Errorf("ListenerUpdate %s", err)
+		return fmt.Errorf("ListenerUpdate %w", err)
 	}
 	if cMsg == nil {
 		return nil
@@ -164,7 +164,7 @@ func ListenerDelete(key *core_v2.SocketAddress) error {
 
 	cKey, err := socketAddressToClang(key)
 	if err != nil {
-		return fmt.Errorf("ListenerLookup %s", err)
+		return fmt.Errorf("ListenerLookup %w", err)
 	}
 	if cKey == nil {
 		return nil

--- a/pkg/cache/v2/maps/route.go
+++ b/pkg/cache/v2/maps/route.go
@@ -116,7 +116,7 @@ func RouteConfigUpdate(key string, value *route_v2.RouteConfiguration) error {
 
 	cMsg, err := routeConfigToClang(value)
 	if err != nil {
-		return fmt.Errorf("RouteConfigUpdate %s", err)
+		return fmt.Errorf("RouteConfigUpdate %w", err)
 	}
 	if cMsg == nil {
 		return nil

--- a/pkg/cni/chained.go
+++ b/pkg/cni/chained.go
@@ -43,7 +43,7 @@ func (i *Installer) getCniConfigPath() (string, error) {
 		confFile = filepath.Join(i.CniMountNetEtcDIR, i.CniConfigName)
 		confList, err := libcni.ConfListFromFile(confFile)
 		if err != nil {
-			err = fmt.Errorf("failed to read conflist %v : %v", confFile, err)
+			err = fmt.Errorf("failed to read conflist %v : %w", confFile, err)
 			log.Error(err)
 			return "", err
 		}
@@ -55,7 +55,7 @@ func (i *Installer) getCniConfigPath() (string, error) {
 	} else {
 		files, err := libcni.ConfFiles(i.CniMountNetEtcDIR, []string{".conflist"})
 		if err != nil {
-			err = fmt.Errorf("failed to load conflist from dir :%v, : %v", i.CniMountNetEtcDIR, err)
+			err = fmt.Errorf("failed to load conflist from dir :%v, : %w", i.CniMountNetEtcDIR, err)
 			log.Error(err)
 			return "", err
 		}
@@ -65,7 +65,7 @@ func (i *Installer) getCniConfigPath() (string, error) {
 		for _, file := range files {
 			confList, err = libcni.ConfListFromFile(file)
 			if err != nil {
-				err = fmt.Errorf("failed to read conflist: %v, %v", file, err)
+				err = fmt.Errorf("failed to read conflist: %v, %w", file, err)
 				log.Info(err)
 				continue
 			}
@@ -91,7 +91,7 @@ func (i *Installer) insertCNIConfig(oldconfig []byte, mode string) ([]byte, erro
 	var cniConfigMap map[string]interface{}
 	err := json.Unmarshal(oldconfig, &cniConfigMap)
 	if err != nil {
-		err = fmt.Errorf("failed to unmarshal json: %v", err)
+		err = fmt.Errorf("failed to unmarshal json: %w", err)
 		log.Error(err)
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (i *Installer) insertCNIConfig(oldconfig []byte, mode string) ([]byte, erro
 
 	byte, err := json.MarshalIndent(cniConfigMap, "", "  ")
 	if err != nil {
-		err = fmt.Errorf("failed to marshal json: %v", err)
+		err = fmt.Errorf("failed to marshal json: %w", err)
 		log.Error(err)
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func deleteCNIConfig(oldconfig []byte) ([]byte, error) {
 
 	err := json.Unmarshal(oldconfig, &cniConfigMap)
 	if err != nil {
-		err = fmt.Errorf("failed to unmarshal json: %v", err)
+		err = fmt.Errorf("failed to unmarshal json: %w", err)
 		log.Error(err)
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func deleteCNIConfig(oldconfig []byte) ([]byte, error) {
 
 	byte, err := json.MarshalIndent(cniConfigMap, "", "  ")
 	if err != nil {
-		err = fmt.Errorf("failed to marshal json: %v", err)
+		err = fmt.Errorf("failed to marshal json: %w", err)
 		log.Error(err)
 		return nil, err
 	}
@@ -193,7 +193,7 @@ func (i *Installer) chainedKmeshCniPlugin(mode string, cniMountNetEtcDIR string)
 	// and we harm no one by doing so.
 	err := copyBinary("/usr/bin/kmesh-cni", MountedCNIBinDir)
 	if err != nil {
-		return fmt.Errorf("copy binaries: %v", err)
+		return fmt.Errorf("copy binaries: %w", err)
 	}
 
 	// Install kubeconfig (if needed) - we write/update this in the shared node CNI bin dir,
@@ -201,7 +201,7 @@ func (i *Installer) chainedKmeshCniPlugin(mode string, cniMountNetEtcDIR string)
 	// unless it's missing or the contents are not what we expect.
 	kubeconfigFilepath := filepath.Join(cniMountNetEtcDIR, kmeshCniKubeConfig)
 	if err := maybeWriteKubeConfigFile(i.ServiceAccountPath, kubeconfigFilepath); err != nil {
-		return fmt.Errorf("write kubeconfig: %v", err)
+		return fmt.Errorf("write kubeconfig: %w", err)
 	}
 
 	cniConfigFilePath, err := i.getCniConfigPath()
@@ -216,7 +216,7 @@ func (i *Installer) chainedKmeshCniPlugin(mode string, cniMountNetEtcDIR string)
 
 	existCNIConfig, err := os.ReadFile(cniConfigFilePath)
 	if err != nil {
-		err = fmt.Errorf("failed to read cni config file %v : %v", cniConfigFilePath, err)
+		err = fmt.Errorf("failed to read cni config file %v : %w", cniConfigFilePath, err)
 		log.Error(err)
 		return err
 	}
@@ -256,7 +256,7 @@ func (i *Installer) removeChainedKmeshCniPlugin() error {
 	}
 	existCNIConfig, err := os.ReadFile(cniConfigFilePath)
 	if err != nil {
-		err = fmt.Errorf("failed to read cni config file %v : %v", cniConfigFilePath, err)
+		err = fmt.Errorf("failed to read cni config file %v : %w", cniConfigFilePath, err)
 		log.Error(err)
 		return err
 	}

--- a/pkg/cni/install.go
+++ b/pkg/cni/install.go
@@ -84,7 +84,7 @@ func NewInstaller(mode string,
 func (i *Installer) WatchServiceAccountToken() error {
 	tokenPath := i.ServiceAccountPath + "/token"
 	if err := i.Watcher.Add(tokenPath); err != nil {
-		return fmt.Errorf("failed to add %s to file watcher: %v", tokenPath, err)
+		return fmt.Errorf("failed to add %s to file watcher: %w", tokenPath, err)
 	}
 
 	// Start listening for events.

--- a/pkg/cni/plugin/plugin.go
+++ b/pkg/cni/plugin/plugin.go
@@ -141,7 +141,7 @@ func enableTcMarkEncrypt(args *skel.CmdArgs) error {
 	ifIndex = 0
 
 	if tc, err = utils.GetProgramByName(constants.TC_MARK_ENCRYPT); err != nil {
-		return fmt.Errorf("failed to get tc program: %v", err)
+		return fmt.Errorf("failed to get tc program: %w", err)
 	}
 
 	getVethPeerIndexFunc := func(netns.NetNS) error {
@@ -159,11 +159,11 @@ func enableTcMarkEncrypt(args *skel.CmdArgs) error {
 	}
 
 	if link, err = netlink.LinkByIndex(int(ifIndex)); err != nil {
-		return fmt.Errorf("failed to link valid interface, %v", err)
+		return fmt.Errorf("failed to link valid interface, %w", err)
 	}
 
 	if err = utils.ManageTCProgram(link, tc, constants.TC_ATTACH); err != nil {
-		return fmt.Errorf("failed to attach tc program, %v", err)
+		return fmt.Errorf("failed to attach tc program, %w", err)
 	}
 
 	return nil
@@ -190,14 +190,14 @@ func CmdAdd(args *skel.CmdArgs) error {
 
 	client, err := kube.CreateKubeClient(cniConf.KubeConfig)
 	if err != nil {
-		err = fmt.Errorf("failed to get k8s client: %v", err)
+		err = fmt.Errorf("failed to get k8s client: %w", err)
 		log.Error(err)
 		return err
 	}
 
 	pod, err := client.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
 	if err != nil {
-		err = fmt.Errorf("failed to get pod: %v", err)
+		err = fmt.Errorf("failed to get pod: %w", err)
 		return err
 	}
 

--- a/pkg/consistenthash/maglev/maglev.go
+++ b/pkg/consistenthash/maglev/maglev.go
@@ -62,7 +62,7 @@ func InitMaglevMap() error {
 
 	outer_map, err := ebpf.LoadPinnedMap("/sys/fs/bpf"+"/bpf_kmesh/map/"+MaglevOuterMapName, opt)
 	if err != nil {
-		return fmt.Errorf("load outer map of maglev failed err: %v", err)
+		return fmt.Errorf("load outer map of maglev failed err: %w", err)
 	}
 	outer = outer_map
 
@@ -96,7 +96,7 @@ func CreateLB(cluster *cluster_v2.Cluster) error {
 
 	err = updateMaglevTable(backendIDs, clusterName)
 	if err != nil {
-		return fmt.Errorf("updateMaglevTable fail err:%v", err)
+		return fmt.Errorf("updateMaglevTable fail err:%w", err)
 	}
 
 	return nil

--- a/pkg/controller/ads/ads_controller.go
+++ b/pkg/controller/ads/ads_controller.go
@@ -67,7 +67,7 @@ func (c *Controller) AdsStreamCreateAndSend(client service_discovery_v3.Aggregat
 
 	stream, err := client.StreamAggregatedResources(ctx)
 	if err != nil {
-		return fmt.Errorf("StreamAggregatedResources failed, %s", err)
+		return fmt.Errorf("StreamAggregatedResources failed, %w", err)
 	}
 
 	c.con = &connection{
@@ -78,7 +78,7 @@ func (c *Controller) AdsStreamCreateAndSend(client service_discovery_v3.Aggregat
 
 	c.Processor.Reset()
 	if err := stream.Send(newAdsRequest(resource_v3.ClusterType, nil, "")); err != nil {
-		return fmt.Errorf("send request failed, %s", err)
+		return fmt.Errorf("send request failed, %w", err)
 	}
 	go sendUpstream(c.con)
 
@@ -92,7 +92,7 @@ func (c *Controller) HandleAdsStream() error {
 	)
 	if rsp, err = c.con.Stream.Recv(); err != nil {
 		_ = c.con.Stream.CloseSend()
-		return fmt.Errorf("stream recv failed, %s", err)
+		return fmt.Errorf("stream recv failed, %w", err)
 	}
 
 	// Because Kernel-Native mode is full update.

--- a/pkg/controller/bypass/bypass_controller.go
+++ b/pkg/controller/bypass/bypass_controller.go
@@ -157,7 +157,7 @@ func addIptables(ns string) error {
 		}
 		for _, args := range iptArgs {
 			if err := utils.Execute("iptables", args); err != nil {
-				return fmt.Errorf("failed to exec command: iptables %v\", err: %w", args, err)
+				return fmt.Errorf("failed to exec command: iptables %v, err: %w", args, err)
 			}
 		}
 		return nil
@@ -178,7 +178,7 @@ func deleteIptables(ns string) error {
 		log.Infof("Running delete iptables rule in namespace:%s", ns)
 		for _, args := range iptArgs {
 			if err := utils.Execute("iptables", args); err != nil {
-				err = fmt.Errorf("failed to exec command: iptables %v\", err: %w", args, err)
+				err = fmt.Errorf("failed to exec command: iptables %v, err: %w", args, err)
 				log.Error(err)
 				return err
 			}

--- a/pkg/controller/bypass/bypass_controller.go
+++ b/pkg/controller/bypass/bypass_controller.go
@@ -157,13 +157,13 @@ func addIptables(ns string) error {
 		}
 		for _, args := range iptArgs {
 			if err := utils.Execute("iptables", args); err != nil {
-				return fmt.Errorf("failed to exec command: iptables %v\", err: %v", args, err)
+				return fmt.Errorf("failed to exec command: iptables %v\", err: %w", args, err)
 			}
 		}
 		return nil
 	}
 	if err := netns.WithNetNSPath(ns, execFunc); err != nil {
-		return fmt.Errorf("enter namespace path: %v, run command failed: %v", ns, err)
+		return fmt.Errorf("enter namespace path: %v, run command failed: %w", ns, err)
 	}
 	return nil
 }
@@ -178,7 +178,7 @@ func deleteIptables(ns string) error {
 		log.Infof("Running delete iptables rule in namespace:%s", ns)
 		for _, args := range iptArgs {
 			if err := utils.Execute("iptables", args); err != nil {
-				err = fmt.Errorf("failed to exec command: iptables %v\", err: %v", args, err)
+				err = fmt.Errorf("failed to exec command: iptables %v\", err: %w", args, err)
 				log.Error(err)
 				return err
 			}
@@ -187,7 +187,7 @@ func deleteIptables(ns string) error {
 	}
 
 	if err := netns.WithNetNSPath(ns, execFunc); err != nil {
-		return fmt.Errorf("enter namespace path: %v, run command failed: %v", ns, err)
+		return fmt.Errorf("enter namespace path: %v, run command failed: %w", ns, err)
 	}
 	return nil
 }

--- a/pkg/controller/client.go
+++ b/pkg/controller/client.go
@@ -76,7 +76,7 @@ func (c *XdsClient) createGrpcStreamClient() error {
 	var err error
 
 	if c.grpcConn, err = nets.GrpcConnect(c.xdsConfig.DiscoveryAddress); err != nil {
-		return fmt.Errorf("grpc connect failed: %s", err)
+		return fmt.Errorf("grpc connect failed: %w", err)
 	}
 
 	c.client = discoveryv3.NewAggregatedDiscoveryServiceClient(c.grpcConn)
@@ -84,12 +84,12 @@ func (c *XdsClient) createGrpcStreamClient() error {
 	if c.mode == constants.DualEngineMode {
 		if err = c.WorkloadController.WorkloadStreamCreateAndSend(c.client, c.ctx); err != nil {
 			_ = c.grpcConn.Close()
-			return fmt.Errorf("create workload stream failed, %s", err)
+			return fmt.Errorf("create workload stream failed, %w", err)
 		}
 	} else if c.mode == constants.KernelNativeMode {
 		if err = c.AdsController.AdsStreamCreateAndSend(c.client, c.ctx); err != nil {
 			_ = c.grpcConn.Close()
-			return fmt.Errorf("create ads stream failed, %s", err)
+			return fmt.Errorf("create ads stream failed, %w", err)
 		}
 	}
 
@@ -148,7 +148,7 @@ func (c *XdsClient) handleUpstream(ctx context.Context) {
 
 func (c *XdsClient) Run(stopCh <-chan struct{}) error {
 	if err := c.createGrpcStreamClient(); err != nil {
-		return fmt.Errorf("create client and stream failed, %s", err)
+		return fmt.Errorf("create client and stream failed, %w", err)
 	}
 
 	go c.handleUpstream(c.ctx)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -104,7 +104,7 @@ func (c *Controller) Start(stopCh <-chan struct{}) error {
 		}
 		c.ipsecController, err = ipsec.NewController(clientset, kniMap, decryptProg)
 		if err != nil {
-			return fmt.Errorf("failed to new IPsec controller, %v", err)
+			return fmt.Errorf("failed to new IPsec controller, %w", err)
 		}
 		go c.ipsecController.Run(stopCh)
 		log.Info("start IPsec controller successfully")
@@ -117,7 +117,7 @@ func (c *Controller) Start(stopCh <-chan struct{}) error {
 		if c.enableSecretManager {
 			secertManager, err = security.NewSecretManager()
 			if err != nil {
-				return fmt.Errorf("secretManager create failed: %v", err)
+				return fmt.Errorf("secretManager create failed: %w", err)
 			}
 			go secertManager.Run(stopCh)
 		}
@@ -127,7 +127,7 @@ func (c *Controller) Start(stopCh <-chan struct{}) error {
 		kmeshManageController, err = manage.NewKmeshManageController(clientset, nil, -1, tcFd, c.mode)
 	}
 	if err != nil {
-		return fmt.Errorf("failed to start kmesh manage controller: %v", err)
+		return fmt.Errorf("failed to start kmesh manage controller: %w", err)
 	}
 	go kmeshManageController.Run(stopCh)
 	log.Info("start kmesh manage controller successfully")
@@ -155,14 +155,14 @@ func (c *Controller) Start(stopCh <-chan struct{}) error {
 	// If the startup parameter is false, update the kmeshConfigMap.
 	if !c.bpfConfig.EnableMonitoring {
 		if err := c.loader.UpdateEnableMonitoring(constants.DISABLED); err != nil {
-			return fmt.Errorf("failed to update config in order to start metric: %v", err)
+			return fmt.Errorf("failed to update config in order to start metric: %w", err)
 		}
 	}
 	// kmeshConfigMap.PeriodicReport initialized to uint32(0).
 	// If the startup parameter is true, update the kmeshConfigMap.
 	if c.bpfConfig.EnablePeriodicReport && c.bpfConfig.EnableMonitoring {
 		if err := c.loader.UpdateEnablePeriodicReport(constants.ENABLED); err != nil {
-			return fmt.Errorf("failed to update config in order to start periodic report: %v", err)
+			return fmt.Errorf("failed to update config in order to start periodic report: %w", err)
 		}
 	}
 
@@ -212,7 +212,7 @@ func (c *Controller) setupDNSProxy() error {
 	if workload.EnableDNSProxy {
 		server, err := dnsclient.NewLocalDNSServer(kmeshNamespace, clusterDomain, ":53", dnsForwardParallel)
 		if err != nil {
-			return fmt.Errorf("failed to start local dns server: %v", err)
+			return fmt.Errorf("failed to start local dns server: %w", err)
 		}
 		ntb := dns.NewNameTableBuilder(c.client.WorkloadController.Processor.ServiceCache, c.client.WorkloadController.Processor.WorkloadCache)
 

--- a/pkg/controller/encryption/ipsec/ipsec_controller.go
+++ b/pkg/controller/encryption/ipsec/ipsec_controller.go
@@ -78,7 +78,7 @@ type Controller struct {
 func NewController(k8sClientSet kubernetes.Interface, kniMap *ebpf.Map, decryptProg *ebpf.Program) (*Controller, error) {
 	clientSet, err := kube.GetKmeshNodeInfoClient()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get kmesh node info client: %v", err)
+		return nil, fmt.Errorf("failed to get kmesh node info client: %w", err)
 	}
 	factroy := informer.NewSharedInformerFactory(clientSet, 0)
 	nodeinfoLister := factroy.Kmesh().V1alpha1().KmeshNodeInfos().Lister()
@@ -98,7 +98,7 @@ func NewController(k8sClientSet kubernetes.Interface, kniMap *ebpf.Map, decryptP
 	if _, err := os.Stat(IpSecKeyFile); err == nil {
 		err = ipsecController.ipsecHandler.LoadIPSecKeyFromFile(IpSecKeyFile)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load ipsec key from file %s: %v", IpSecKeyFile, err)
+			return nil, fmt.Errorf("failed to load ipsec key from file %s: %w", IpSecKeyFile, err)
 		}
 	} else if !os.IsNotExist(err) {
 		log.Errorf("failed to stat ipsec key file %s: %v", IpSecKeyFile, err)
@@ -108,7 +108,7 @@ func NewController(k8sClientSet kubernetes.Interface, kniMap *ebpf.Map, decryptP
 
 	localNode, err := k8sClientSet.CoreV1().Nodes().Get(context.TODO(), localNodeName, metav1.GetOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get kmesh node info from k8s: %v", err)
+		return nil, fmt.Errorf("failed to get kmesh node info from k8s: %w", err)
 	}
 
 	ipsecController.kmeshNodeInfo = v1alpha1.KmeshNodeInfo{
@@ -139,7 +139,7 @@ func NewController(k8sClientSet kubernetes.Interface, kniMap *ebpf.Map, decryptP
 			ipsecController.handleKNIDelete(obj)
 		},
 	}); err != nil {
-		return nil, fmt.Errorf("failed to add event handler to kmeshnodeinfoInformer: %v", err)
+		return nil, fmt.Errorf("failed to add event handler to kmeshnodeinfoInformer: %w", err)
 	}
 
 	return ipsecController, nil
@@ -198,7 +198,7 @@ func (c *Controller) Stop() {
 func (c *Controller) handleTc(mode int) error {
 	ifaces, err := net.Interfaces()
 	if err != nil {
-		return fmt.Errorf("failed to get interfaces: %v", err)
+		return fmt.Errorf("failed to get interfaces: %w", err)
 	}
 
 	for _, iface := range ifaces {
@@ -235,7 +235,7 @@ func (c *Controller) attachTcDecrypt() error {
 	}
 
 	if err := netns.WithNetNSPath(nodeNsPath, attachFunc); err != nil {
-		return fmt.Errorf("failed to exec tc program attach, %v", err)
+		return fmt.Errorf("failed to exec tc program attach, %w", err)
 	}
 	return nil
 }
@@ -333,7 +333,7 @@ func (c *Controller) handleOneNodeInfo(node *v1alpha1.KmeshNodeInfo) error {
 
 	for _, podCIDR := range node.Spec.PodCIDRs {
 		if err := c.updateKNIMapCIDR(podCIDR, c.kniMap); err != nil {
-			return fmt.Errorf("update kni map podCIDR failed, %v", err)
+			return fmt.Errorf("update kni map podCIDR failed, %w", err)
 		}
 	}
 
@@ -384,7 +384,7 @@ func (c *Controller) deleteKNIMapCIDR(remoteCIDR string, mapfd *ebpf.Map) {
 func (c *Controller) syncAllNodeInfo() error {
 	nodeList, err := c.lister.KmeshNodeInfos(kube.KmeshNamespace).List(labels.Everything())
 	if err != nil {
-		return fmt.Errorf("failed to get kmesh node info list: %v", err)
+		return fmt.Errorf("failed to get kmesh node info list: %w", err)
 	}
 	for _, node := range nodeList {
 		if node.Name == c.kmeshNodeInfo.Name {
@@ -402,7 +402,7 @@ func (c *Controller) updateLocalKmeshNodeInfo() error {
 	if node == nil {
 		_, err := c.knclient.Create(context.TODO(), &c.kmeshNodeInfo, metav1.CreateOptions{})
 		if err != nil {
-			return fmt.Errorf("failed to create kmesh node info: %v", err)
+			return fmt.Errorf("failed to create kmesh node info: %w", err)
 		}
 		return nil
 	}
@@ -414,7 +414,7 @@ func (c *Controller) updateLocalKmeshNodeInfo() error {
 	node.Spec = c.kmeshNodeInfo.Spec
 	_, err := c.knclient.Update(context.TODO(), node, metav1.UpdateOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to update kmeshinfo, %v", err)
+		return fmt.Errorf("failed to update kmeshinfo, %w", err)
 	}
 	return nil
 }

--- a/pkg/controller/encryption/ipsec/ipsec_handler.go
+++ b/pkg/controller/encryption/ipsec/ipsec_handler.go
@@ -56,7 +56,7 @@ func NewIpSecHandler() *IpSecHandler {
 func (is *IpSecHandler) LoadIPSecKeyFromFile(filePath string) error {
 	file, err := os.Open(filePath)
 	if err != nil {
-		return fmt.Errorf("load ipsec keys failed: %v", err)
+		return fmt.Errorf("load ipsec keys failed: %w", err)
 	}
 	defer file.Close()
 
@@ -72,7 +72,7 @@ func (is *IpSecHandler) loadIPSecKeyFromIO(file *os.File) error {
 	decoder := json.NewDecoder(reader)
 	var key encryption.IpSecKey
 	if err := decoder.Decode(&key); err != nil {
-		return fmt.Errorf("ipsec config file decoder error, %v, please use Kmesh tool generate ipsec secret key", err)
+		return fmt.Errorf("ipsec config file decoder error, %w, please use Kmesh tool generate ipsec secret key", err)
 	}
 	if !strings.HasPrefix(key.AeadKeyName, "rfc") {
 		return fmt.Errorf("ipsec config file error, invalid algo name, aead need begin with \"rfc\"")
@@ -86,7 +86,7 @@ func (is *IpSecHandler) loadIPSecKeyFromIO(file *os.File) error {
 func (h *IpSecHandler) StartWatch(f func()) error {
 	h.watcher = filewatcher.NewWatcher()
 	if err := h.watcher.Add(IpSecKeyFile); err != nil {
-		return fmt.Errorf("failed to add %s to file watcher: %v", IpSecKeyFile, err)
+		return fmt.Errorf("failed to add %s to file watcher: %w", IpSecKeyFile, err)
 	}
 	go func() {
 		log.Infof("start watching file %s", IpSecKeyFile)
@@ -168,7 +168,7 @@ func (is *IpSecHandler) CreateXfrmRule(localNode, remoteNode *v1alpha1.KmeshNode
 
 			if err := is.createXfrmRuleEgress(localNicIP, remoteNicIP, localNode.Spec.BootID, remoteNode.Spec.BootID,
 				ipsecKey, remoteNode.Spec.PodCIDRs); err != nil {
-				return fmt.Errorf("create xfrm out rule failed, %v", err)
+				return fmt.Errorf("create xfrm out rule failed, %w", err)
 			}
 		}
 	}
@@ -203,16 +203,16 @@ func (is *IpSecHandler) createXfrmRuleIngress(rawRemoteIP, rawLocalNicIP, remote
 
 	_, remoteCIDR, err := net.ParseCIDR(constants.ALL_CIDR)
 	if err != nil {
-		return fmt.Errorf("failed to parser podCIDR in inserting xfrm rule, %v", err)
+		return fmt.Errorf("failed to parser podCIDR in inserting xfrm rule, %w", err)
 	}
 
 	for _, pocCIDR := range podCIDRs {
 		_, localCIDR, err := net.ParseCIDR(pocCIDR)
 		if err != nil {
-			return fmt.Errorf("failed to parser podCIDR in inserting xfrm rule, %v", err)
+			return fmt.Errorf("failed to parser podCIDR in inserting xfrm rule, %w", err)
 		}
 		if err = is.createPolicyRule(remoteCIDR, localCIDR, src, dst, 0, true); err != nil {
-			return fmt.Errorf("failed to create policy rule, %v", err)
+			return fmt.Errorf("failed to create policy rule, %w", err)
 		}
 	}
 
@@ -245,16 +245,16 @@ func (is *IpSecHandler) createXfrmRuleEgress(rawLocalNicIP, rawRemoteIP, localBo
 
 	_, localCIDR, err := net.ParseCIDR(constants.ALL_CIDR)
 	if err != nil {
-		return fmt.Errorf("failed to parser podCIDR in inserting xfrm rule, %v", err)
+		return fmt.Errorf("failed to parser podCIDR in inserting xfrm rule, %w", err)
 	}
 
 	for _, podCIDR := range podCIDRs {
 		_, remoteCIDR, err := net.ParseCIDR(podCIDR)
 		if err != nil {
-			return fmt.Errorf("failed to parser podCIDR in inserting xfrm rule, %v", err)
+			return fmt.Errorf("failed to parser podCIDR in inserting xfrm rule, %w", err)
 		}
 		if err = is.createPolicyRule(localCIDR, remoteCIDR, src, dst, ipsecKey.Spi, false); err != nil {
-			return fmt.Errorf("failed to create policy rule, %v", err)
+			return fmt.Errorf("failed to create policy rule, %w", err)
 		}
 	}
 
@@ -285,7 +285,7 @@ func (is *IpSecHandler) createStateRule(src net.IP, dst net.IP, key []byte, ipse
 
 	err := netlink.XfrmStateAdd(state)
 	if err != nil && !os.IsExist(err) {
-		return fmt.Errorf("failed to add xfrm state to host in inserting xfrm out rule, %v", err)
+		return fmt.Errorf("failed to add xfrm state to host in inserting xfrm out rule, %w", err)
 	}
 	return nil
 }
@@ -342,7 +342,7 @@ func (*IpSecHandler) xfrmPolicyCreateOrUpdate(policy *netlink.XfrmPolicy) error 
 		err = netlink.XfrmPolicyUpdate(policy)
 	}
 	if err != nil {
-		return fmt.Errorf("failed to add xfrm policy to host in inserting xfrm fwd rule, %v", err)
+		return fmt.Errorf("failed to add xfrm policy to host in inserting xfrm fwd rule, %w", err)
 	}
 	return nil
 }

--- a/pkg/controller/manage/manage_controller.go
+++ b/pkg/controller/manage/manage_controller.go
@@ -117,7 +117,7 @@ func NewKmeshManageController(client kubernetes.Interface, sm *kmeshsecurity.Sec
 			c.handlePodDelete(obj)
 		},
 	}); err != nil {
-		return nil, fmt.Errorf("failed to add event handler to podInformer: %v", err)
+		return nil, fmt.Errorf("failed to add event handler to podInformer: %w", err)
 	}
 
 	if _, err := namespaceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -128,7 +128,7 @@ func NewKmeshManageController(client kubernetes.Interface, sm *kmeshsecurity.Sec
 			c.handleNamespaceUpdate(oldObj, newObj)
 		},
 	}); err != nil {
-		return nil, fmt.Errorf("failed to add event handler to namespaceInformer: %v", err)
+		return nil, fmt.Errorf("failed to add event handler to namespaceInformer: %w", err)
 	}
 
 	return c, nil
@@ -357,14 +357,14 @@ func (c *KmeshManageController) syncPod(key QueueItem) error {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to get pod %s/%s: %v", key.podNs, key.podName, err)
+		return fmt.Errorf("failed to get pod %s/%s: %w", key.podNs, key.podName, err)
 	}
 	namespace, err := c.namespaceLister.Get(pod.Namespace)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to get pod namespace %s: %v", pod.Namespace, err)
+		return fmt.Errorf("failed to get pod namespace %s: %w", pod.Namespace, err)
 	}
 
 	if key.action == ActionAddAnnotation && utils.ShouldEnroll(pod, namespace) {
@@ -507,7 +507,7 @@ func managleVethTc(ifIndex uint64, tcProgFd int, mode int) error {
 		link netlink.Link
 	)
 	if link, err = netlink.LinkByIndex(int(ifIndex)); err != nil {
-		return fmt.Errorf("failed to link valid interface, %v", err)
+		return fmt.Errorf("failed to link valid interface, %w", err)
 	}
 
 	return utils.ManageTCProgramByFd(link, tcProgFd, mode)
@@ -529,14 +529,14 @@ func linkTc(netNsPath string, tcProgFd int) error {
 	}
 
 	if err = netns.WithNetNSPath(netNsPath, warpGetVethPeerNum); err != nil {
-		err = fmt.Errorf("Run get veth peer num in netNsPath %v failed, err: %v", netNsPath, err)
+		err = fmt.Errorf("Run get veth peer num in netNsPath %v failed, err: %w", netNsPath, err)
 		return err
 	}
 	// set tc on node namespace veth peer
 	if err = netns.WithNetNSPath(kmesh_netns.GetNodeNSpath(), func(_ netns.NetNS) error {
 		return managleVethTc(ifIndex, tcProgFd, constants.TC_ATTACH)
 	}); err != nil {
-		err = fmt.Errorf("Run link tc in netNsPath %v failed, err: %v", netNsPath, err)
+		err = fmt.Errorf("Run link tc in netNsPath %v failed, err: %w", netNsPath, err)
 		return err
 	}
 
@@ -559,14 +559,14 @@ func unlinkTc(netNsPath string, tcProgFd int) error {
 	}
 
 	if err = netns.WithNetNSPath(netNsPath, warpGetVethPeerNum); err != nil {
-		err = fmt.Errorf("Run get veth peer num in netNsPath %v failed, err: %v", netNsPath, err)
+		err = fmt.Errorf("Run get veth peer num in netNsPath %v failed, err: %w", netNsPath, err)
 		return err
 	}
 	// set tc on node namespace veth peer
 	if err := netns.WithNetNSPath(kmesh_netns.GetNodeNSpath(), func(_ netns.NetNS) error {
 		return managleVethTc(ifIndex, tcProgFd, constants.TC_DETACH)
 	}); err != nil {
-		err = fmt.Errorf("Run link tc in netNsPath %v failed, err: %v", netNsPath, err)
+		err = fmt.Errorf("Run link tc in netNsPath %v failed, err: %w", netNsPath, err)
 		return err
 	}
 	return nil

--- a/pkg/controller/security/caclient.go
+++ b/pkg/controller/security/caclient.go
@@ -60,7 +60,7 @@ func newCaClient(opts *security.Options, tlsOpts *tlsOptions) (CaClient, error) 
 
 	conn, err := nets.GrpcConnect(caAddress)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create grpcconnect : %v", err)
+		return nil, fmt.Errorf("failed to create grpcconnect : %w", err)
 	}
 
 	c.conn = conn
@@ -91,7 +91,7 @@ func (c caClient) CsrSend(csrPEM []byte, certValidsec int64, identity string) ([
 	// when certificate acquisition fails. If it still fails, return an error.
 	resp, err := c.client.CreateCertificate(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("create certificate failed: %v", err)
+		return nil, fmt.Errorf("create certificate failed: %w", err)
 	}
 
 	if len(resp.CertChain) <= 1 {

--- a/pkg/controller/security/mock/mockcaclient.go
+++ b/pkg/controller/security/mock/mockcaclient.go
@@ -54,7 +54,7 @@ func NewMockCaClient(opts *security.Options, certLifetime time.Duration) (*CACli
 	}
 	bundle, err := util.NewVerifiedKeyCertBundleFromFile(caCertPath, caKeyPath, certChainPath, rootCertPath)
 	if err != nil {
-		return nil, fmt.Errorf("mock ca client creation error: %v", err)
+		return nil, fmt.Errorf("mock ca client creation error: %w", err)
 	}
 	cl.bundle = bundle
 	return &cl, nil
@@ -67,12 +67,12 @@ func (c *CAClient) CsrSend(csrPEM []byte, certValidsec int64, identity string) (
 	signingCert, signingKey, certChain, rootCert := c.bundle.GetAll()
 	csr, err := util.ParsePemEncodedCSR(csrPEM)
 	if err != nil {
-		return nil, fmt.Errorf("csr sign error: %v", err)
+		return nil, fmt.Errorf("csr sign error: %w", err)
 	}
 	subjectIDs := []string{"test"}
 	certBytes, err := util.GenCertFromCSR(csr, signingCert, csr.PublicKey, *signingKey, subjectIDs, c.certLifetime, false)
 	if err != nil {
-		return nil, fmt.Errorf("csr sign error: %v", err)
+		return nil, fmt.Errorf("csr sign error: %w", err)
 	}
 
 	block := &pem.Block{
@@ -110,7 +110,7 @@ func (c *CAClient) FetchCert(identity string) (*security.SecretItem, error) {
 	}
 	certChainPEM, err := c.CsrSend(csrPEM, int64(c.opts.SecretTTL.Seconds()), identity)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get certChainPEM due to %v", err)
+		return nil, fmt.Errorf("failed to get certChainPEM due to %w", err)
 	}
 
 	certChain := standardCerts(certChainPEM)

--- a/pkg/controller/telemetry/map_metric.go
+++ b/pkg/controller/telemetry/map_metric.go
@@ -149,7 +149,7 @@ func getMapEntryCountFallback(m *ebpf.Map) (uint32, error) {
 		entryCount++
 	}
 	if err := iterator.Err(); err != nil {
-		return 0, fmt.Errorf("failed during map iteration: %v", err)
+		return 0, fmt.Errorf("failed during map iteration: %w", err)
 	}
 	return entryCount, nil
 }

--- a/pkg/controller/workload/workload_controller.go
+++ b/pkg/controller/workload/workload_controller.go
@@ -126,7 +126,7 @@ func (c *Controller) WorkloadStreamCreateAndSend(client discoveryv3.AggregatedDi
 
 	c.Stream, err = client.DeltaAggregatedResources(ctx)
 	if err != nil {
-		return fmt.Errorf("DeltaAggregatedResources failed, %s", err)
+		return fmt.Errorf("DeltaAggregatedResources failed, %w", err)
 	}
 
 	if c.Processor != nil {
@@ -146,13 +146,13 @@ func (c *Controller) WorkloadStreamCreateAndSend(client discoveryv3.AggregatedDi
 
 	log.Debugf("send initial request with address resources: %v", initialResourceVersions)
 	if err := c.Stream.Send(newDeltaRequest(AddressType, nil, initialResourceVersions)); err != nil {
-		return fmt.Errorf("send request failed, %s", err)
+		return fmt.Errorf("send request failed, %w", err)
 	}
 
 	initialResourceVersions = c.Rbac.GetAllPolicies()
 	log.Debugf("send initial request with authorization resources: %v", initialResourceVersions)
 	if err = c.Stream.Send(newDeltaRequest(AuthorizationType, nil, initialResourceVersions)); err != nil {
-		return fmt.Errorf("authorization subscribe failed, %s", err)
+		return fmt.Errorf("authorization subscribe failed, %w", err)
 	}
 
 	return nil
@@ -166,18 +166,18 @@ func (c *Controller) HandleWorkloadStream() error {
 
 	if rspDelta, err = c.Stream.Recv(); err != nil {
 		_ = c.Stream.CloseSend()
-		return fmt.Errorf("stream recv failed, %s", err)
+		return fmt.Errorf("stream recv failed, %w", err)
 	}
 
 	c.Processor.processWorkloadResponse(rspDelta, c.Rbac)
 
 	if err = c.Stream.Send(c.Processor.ack); err != nil {
-		return fmt.Errorf("stream send ack failed, %s", err)
+		return fmt.Errorf("stream send ack failed, %w", err)
 	}
 
 	if c.Processor.req != nil {
 		if err = c.Stream.Send(c.Processor.req); err != nil {
-			return fmt.Errorf("stream send req failed, %s", err)
+			return fmt.Errorf("stream send req failed, %w", err)
 		}
 	}
 

--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -229,7 +229,7 @@ func (p *Processor) storePodFrontendData(uid uint32, ip []byte) error {
 	nets.CopyIpByteFromSlice(&fk.Ip, ip)
 	fv.UpstreamId = uid
 	if err := p.bpf.FrontendUpdate(&fk, &fv); err != nil {
-		return fmt.Errorf("update frontend map failed, err:%s", err)
+		return fmt.Errorf("update frontend map failed, err:%w", err)
 	}
 
 	return nil
@@ -272,7 +272,7 @@ func (p *Processor) handleUnhealthyWorkload(workload *workloadapi.Workload) erro
 	// 1. find all endpoint keys related to this workload and delete them
 	if eks := p.bpf.GetEndpointKeys(backendUid); len(eks) > 0 {
 		if err := p.deleteEndpointRecords(eks.UnsortedList()); err != nil {
-			return fmt.Errorf("handleUnhealthyWorkload: deleteEndpointRecords for %s failed: %v", workload.Uid, err)
+			return fmt.Errorf("handleUnhealthyWorkload: deleteEndpointRecords for %s failed: %w", workload.Uid, err)
 		}
 	}
 
@@ -534,7 +534,7 @@ func (p *Processor) updateWorkloadInFrontendMap(workload *workloadapi.Workload) 
 			continue
 		}
 		if err := p.storePodFrontendData(backendUid, ip); err != nil {
-			return fmt.Errorf("storePodFrontendData failed, err:%s", err)
+			return fmt.Errorf("storePodFrontendData failed, err:%w", err)
 		}
 	}
 	return nil
@@ -583,7 +583,7 @@ func (p *Processor) handleWorkload(workload *workloadapi.Workload) error {
 
 	// 1. update workload in backend map
 	if err := p.updateWorkloadInBackendMap(workload); err != nil {
-		return fmt.Errorf("updateWorkloadInBackendMap %s failed: %v", workload.Uid, err)
+		return fmt.Errorf("updateWorkloadInBackendMap %s failed: %w", workload.Uid, err)
 	}
 
 	// 2~3. update workload in endpoint map and service map
@@ -599,7 +599,7 @@ func (p *Processor) handleWorkload(workload *workloadapi.Workload) error {
 
 	// 4. update workload in frontend map
 	if err := p.updateWorkloadInFrontendMap(workload); err != nil {
-		return fmt.Errorf("updateWorkloadInFrontendMap %s failed: %v", workload.Uid, err)
+		return fmt.Errorf("updateWorkloadInFrontendMap %s failed: %w", workload.Uid, err)
 	}
 	if oldWorkload != nil {
 		// To be able to find a workload in the workloadCache,
@@ -613,7 +613,7 @@ func (p *Processor) handleWorkload(workload *workloadapi.Workload) error {
 		if len(newWorkloadAddresses) > 0 && len(oldWorkloadAddresses) > 0 && !slices.Equal(newWorkloadAddresses[0], oldWorkloadAddresses[0]) {
 			err := p.deleteFrontendByIp(oldWorkloadAddresses)
 			if err != nil {
-				return fmt.Errorf("frontend map delete failed: %v", err)
+				return fmt.Errorf("frontend map delete failed: %w", err)
 			}
 		}
 	}
@@ -684,7 +684,7 @@ func (p *Processor) updateEndpointOneByOne(serviceId uint32, epsUpdate []cache.E
 		}
 		ev := bpf.EndpointValue{}
 		if err := p.bpf.EndpointLookup(&ek, &ev); err != nil { // get backend Uid
-			return fmt.Errorf("lookup endpoint %#v failed: %v", ek, err)
+			return fmt.Errorf("lookup endpoint %#v failed: %w", ek, err)
 		}
 
 		// Calc Priority
@@ -703,17 +703,17 @@ func (p *Processor) updateEndpointOneByOne(serviceId uint32, epsUpdate []cache.E
 		sKey := bpf.ServiceKey{ServiceId: serviceId}
 		sValue := bpf.ServiceValue{}
 		if err := p.bpf.ServiceLookup(&sKey, &sValue); err != nil {
-			return fmt.Errorf("lookup service %v failed: %v", serviceId, err)
+			return fmt.Errorf("lookup service %v failed: %w", serviceId, err)
 		}
 
 		// add ek first to another priority group
 		if _, err := p.addWorkloadToService(&sKey, &sValue, ev.BackendUid, prio); err != nil {
-			return fmt.Errorf("update endpoint %d priority to %d failed: %v", ev.BackendUid, prio, err)
+			return fmt.Errorf("update endpoint %d priority to %d failed: %w", ev.BackendUid, prio, err)
 		}
 		epKeys := []bpf.EndpointKey{ek}
 		// delete ek from old priority group
 		if err := p.deleteEndpointRecords(epKeys); err != nil {
-			return fmt.Errorf("delete endpoint %d from old priority group %d failed: %v", ev.BackendUid, ek.Prio, err)
+			return fmt.Errorf("delete endpoint %d from old priority group %d failed: %w", ev.BackendUid, ek.Prio, err)
 		}
 	}
 	return nil
@@ -789,15 +789,15 @@ func (p *Processor) updateServiceMap(service, oldService *workloadapi.Service) e
 				// there might not be any workload with the highest priority, and directly switching the service's LB policy could
 				// lead to unexpected service disruptions.
 				if err = p.updateEndpointPriority(sk.ServiceId, false); err != nil { // this will change bpf map totally
-					return fmt.Errorf("update endpoint priority failed: %v", err)
+					return fmt.Errorf("update endpoint priority failed: %w", err)
 				}
 				updateServiceInfo := bpf.ServiceValue{}
 				if err = p.bpf.ServiceLookup(&sk, &updateServiceInfo); err != nil {
-					return fmt.Errorf("service map lookup %v failed: %v", sk.ServiceId, err)
+					return fmt.Errorf("service map lookup %v failed: %w", sk.ServiceId, err)
 				}
 				updateServiceInfo.LbPolicy = newServiceInfo.LbPolicy
 				if err = p.bpf.ServiceUpdate(&sk, &updateServiceInfo); err != nil {
-					return fmt.Errorf("service map update failed: %v", err)
+					return fmt.Errorf("service map update failed: %w", err)
 				}
 				return nil
 			} else if oldServiceInfo.LbPolicy == uint32(workloadapi.LoadBalancing_UNSPECIFIED_MODE) {
@@ -807,11 +807,11 @@ func (p *Processor) updateServiceMap(service, oldService *workloadapi.Service) e
 				// we update the endpoint map. During this update process, the load balancer may briefly exhibit abnormal random behavior,
 				// after which it will fully transition to the locality load balancing mode.
 				if err = p.bpf.ServiceUpdate(&sk, &newServiceInfo); err != nil {
-					return fmt.Errorf("service map update lb policy failed: %v", err)
+					return fmt.Errorf("service map update lb policy failed: %w", err)
 				}
 
 				if err = p.updateEndpointPriority(sk.ServiceId, true); err != nil {
-					return fmt.Errorf("update endpoint priority failed: %v", err)
+					return fmt.Errorf("update endpoint priority failed: %w", err)
 				}
 				return nil
 			}
@@ -823,17 +823,17 @@ func (p *Processor) updateServiceMap(service, oldService *workloadapi.Service) e
 		oldServiceAddress := oldService.GetIpAddresses()
 		removeServiceAddress := nets.CompareIpByte(newServiceAddress, oldServiceAddress)
 		if err := p.deleteFrontendByIp(removeServiceAddress); err != nil {
-			return fmt.Errorf("frontend map delete failed: %v", err)
+			return fmt.Errorf("frontend map delete failed: %w", err)
 		}
 	}
 
 	// normal update
 	if err := p.bpf.ServiceUpdate(&sk, &newServiceInfo); err != nil {
-		return fmt.Errorf("service map update failed: %v", err)
+		return fmt.Errorf("service map update failed: %w", err)
 	}
 
 	if err := p.updateServiceFrontendMap(sk.ServiceId, service); err != nil {
-		return fmt.Errorf("updateServiceFrontendMap failed: %v", err)
+		return fmt.Errorf("updateServiceFrontendMap failed: %w", err)
 	}
 
 	return nil
@@ -1047,7 +1047,7 @@ func (p *Processor) handleAuthorizationTypeResponse(rsp *service_discovery_v3.De
 
 		policyKey := authPolicy.ResourceName()
 		if err := maps_v2.AuthorizationUpdate(p.hashName.Hash(policyKey), authPolicy); err != nil {
-			return fmt.Errorf("AuthorizationUpdate %s failed %v ", policyKey, err)
+			return fmt.Errorf("AuthorizationUpdate %s failed %w ", policyKey, err)
 		}
 	}
 

--- a/pkg/controller/xdstest/fake_xdsclient.go
+++ b/pkg/controller/xdstest/fake_xdsclient.go
@@ -41,16 +41,16 @@ func NewClient(xdsServer *XDSServer) (*XDSClient, error) {
 			return xdsServer.Listener.Dial()
 		}))
 	if err != nil {
-		return nil, fmt.Errorf("grpc connection client create failed, %s", err)
+		return nil, fmt.Errorf("grpc connection client create failed, %w", err)
 	}
 	client := discoveryv3.NewAggregatedDiscoveryServiceClient(conn)
 	deltaClient, err := client.DeltaAggregatedResources(context.Background())
 	if err != nil {
-		return nil, fmt.Errorf("DeltaAggregatedResources failed, %s", err)
+		return nil, fmt.Errorf("DeltaAggregatedResources failed, %w", err)
 	}
 	adsClient, err := client.StreamAggregatedResources(context.Background())
 	if err != nil {
-		return nil, fmt.Errorf("StreamAggregatedResources failed, %s", err)
+		return nil, fmt.Errorf("StreamAggregatedResources failed, %w", err)
 	}
 
 	return &XDSClient{

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -144,7 +144,7 @@ func (r *DNSResolver) resolve(domainName string) ([]string, time.Duration, error
 
 	addrs, ttl, err := r.doResolve(domainName)
 	if err != nil {
-		return []string{}, DeRefreshInterval, fmt.Errorf("dns resolve failed: %v", err)
+		return []string{}, DeRefreshInterval, fmt.Errorf("dns resolve failed: %w", err)
 	}
 
 	r.RLock()

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -89,7 +89,7 @@ func newPortForwarder(cliClient *client, podName string, ns string, localAddress
 		localPort, err = getAvailablePort()
 		if err != nil {
 			cancel()
-			return nil, fmt.Errorf("failed to find an available port: %v", err)
+			return nil, fmt.Errorf("failed to find an available port: %w", err)
 		}
 	}
 

--- a/pkg/kube/portforwarder.go
+++ b/pkg/kube/portforwarder.go
@@ -82,12 +82,12 @@ func (p *portForwarder) Start() error {
 
 	f := cmdutil.NewFactory(p.RESTClientGetter)
 	if err := pfOptions.Complete(f, p.cmd, []string{p.podName, ports}); err != nil {
-		return fmt.Errorf("complete failed: %v", err)
+		return fmt.Errorf("complete failed: %w", err)
 	}
 
 	go func() {
 		if err := pfOptions.RunPortForwardContext(p.ctx); err != nil {
-			p.errCh <- fmt.Errorf("error running port forward: %v", err)
+			p.errCh <- fmt.Errorf("error running port forward: %w", err)
 			return
 		}
 	}()
@@ -96,7 +96,7 @@ func (p *portForwarder) Start() error {
 	case <-pfOptions.ReadyChannel:
 		return nil
 	case err := <-p.errCh:
-		return fmt.Errorf("failure running port forward process: %v", err)
+		return fmt.Errorf("failure running port forward process: %w", err)
 	}
 }
 

--- a/pkg/utils/ebpf.go
+++ b/pkg/utils/ebpf.go
@@ -34,17 +34,17 @@ func GetProgramByName(name string) (*ebpf.Program, error) {
 
 	for {
 		if progID, err = ebpf.ProgramGetNextID(progID); err != nil {
-			err = fmt.Errorf("failed to get system next program id, err is %v\n", err)
+			err = fmt.Errorf("failed to get system next program id, err is %w\n", err)
 			return nil, err
 		}
 
 		if targetProg, err = ebpf.NewProgramFromID(progID); err != nil {
-			err = fmt.Errorf("failed to get new program from id:%v, err is %v\n", progID, err)
+			err = fmt.Errorf("failed to get new program from id:%v, err is %w\n", progID, err)
 			return nil, err
 		}
 
 		if targetProgInfo, err = targetProg.Info(); err != nil {
-			err = fmt.Errorf("failed to get new program info from fd:%v, err is %v\n", targetProg, err)
+			err = fmt.Errorf("failed to get new program info from fd:%v, err is %w\n", targetProg, err)
 			return nil, err
 		}
 
@@ -66,17 +66,17 @@ func GetMapByName(name string) (*ebpf.Map, error) {
 
 	for {
 		if mapID, err = ebpf.MapGetNextID(mapID); err != nil {
-			err = fmt.Errorf("failed to get system next map id, err is %v\n", err)
+			err = fmt.Errorf("failed to get system next map id, err is %w\n", err)
 			return nil, err
 		}
 
 		if targetMap, err = ebpf.NewMapFromID(mapID); err != nil {
-			err = fmt.Errorf("failed to get new map from id:%v, err is %v\n", mapID, err)
+			err = fmt.Errorf("failed to get new map from id:%v, err is %w\n", mapID, err)
 			return nil, err
 		}
 
 		if targetMapInfo, err = targetMap.Info(); err != nil {
-			err = fmt.Errorf("failed to get new map info from fd:%v, err is %v\n", targetMap, err)
+			err = fmt.Errorf("failed to get new map info from fd:%v, err is %w\n", targetMap, err)
 			return nil, err
 		}
 

--- a/pkg/utils/enroll.go
+++ b/pkg/utils/enroll.go
@@ -91,7 +91,7 @@ func HandleKmeshManage(ns string, enroll bool) error {
 	}
 
 	if err := netns.WithNetNSPath(ns, execFunc); err != nil {
-		err = fmt.Errorf("enter ns path :%v, run execFunc failed: %v", ns, err)
+		err = fmt.Errorf("enter ns path :%v, run execFunc failed: %w", ns, err)
 		return err
 	}
 	return nil

--- a/pkg/utils/fileop.go
+++ b/pkg/utils/fileop.go
@@ -53,7 +53,7 @@ func AtomicWrite(path string, data []byte, mode os.FileMode) error {
 	basename := filepath.Base(path) + ".tmp.file"
 	tempfile, err := os.CreateTemp(dir, basename)
 	if err != nil {
-		err = fmt.Errorf("failed to create tempfile %v/%v: %v", dir, basename, err)
+		err = fmt.Errorf("failed to create tempfile %v/%v: %w", dir, basename, err)
 		log.Error(err)
 		return err
 	}
@@ -63,25 +63,25 @@ func AtomicWrite(path string, data []byte, mode os.FileMode) error {
 	}()
 
 	if err = os.Chmod(tempfile.Name(), mode); err != nil {
-		err = fmt.Errorf("failed to chmod tempfile %v: %v", tempfile.Name(), err)
+		err = fmt.Errorf("failed to chmod tempfile %v: %w", tempfile.Name(), err)
 		log.Error(err)
 		return err
 	}
 
 	if _, err = tempfile.Write(data); err != nil {
-		err = fmt.Errorf("failed to write tempfile %v: %v", tempfile.Name(), err)
+		err = fmt.Errorf("failed to write tempfile %v: %w", tempfile.Name(), err)
 		log.Error(err)
 		return err
 	}
 
 	if err = tempfile.Close(); err != nil {
-		err = fmt.Errorf("failed to close tempfile %v: %v", tempfile.Name(), err)
+		err = fmt.Errorf("failed to close tempfile %v: %w", tempfile.Name(), err)
 		log.Error(err)
 		return err
 	}
 
 	if err = os.Rename(tempfile.Name(), path); err != nil {
-		err = fmt.Errorf("failed to rename tempfile %v to %v: %v", tempfile.Name(), path, err)
+		err = fmt.Errorf("failed to rename tempfile %v to %v: %w", tempfile.Name(), path, err)
 		log.Error(err)
 		return err
 	}

--- a/pkg/utils/tc.go
+++ b/pkg/utils/tc.go
@@ -32,7 +32,7 @@ import (
 func ManageTCProgramByFd(link netlink.Link, tcFd int, mode int) error {
 	if mode == constants.TC_ATTACH {
 		if err := replaceQdisc(link); err != nil {
-			return fmt.Errorf("failed to replace qdisc for interface %v: %v", link.Attrs().Name, err)
+			return fmt.Errorf("failed to replace qdisc for interface %v: %w", link.Attrs().Name, err)
 		}
 	}
 
@@ -53,11 +53,11 @@ func ManageTCProgramByFd(link netlink.Link, tcFd int, mode int) error {
 
 	if mode == constants.TC_ATTACH {
 		if err := netlink.FilterReplace(filter); err != nil {
-			return fmt.Errorf("failed to replace filter for interface %v: %v", link.Attrs().Name, err)
+			return fmt.Errorf("failed to replace filter for interface %v: %w", link.Attrs().Name, err)
 		}
 	} else if mode == constants.TC_DETACH {
 		if err := netlink.FilterDel(filter); err != nil {
-			return fmt.Errorf("failed to delete filter for interface %v: %v", link.Attrs().Name, err)
+			return fmt.Errorf("failed to delete filter for interface %v: %w", link.Attrs().Name, err)
 		}
 	} else {
 		return fmt.Errorf("invalid mode in ManageTCProgramByFd")
@@ -92,13 +92,13 @@ func GetVethPeerIndexFromName(ifaceName string) (uint64, error) {
 	}
 	defer ethHandle.Close()
 	if driver, err := ethHandle.DriverName(ifaceName); err != nil {
-		return 0, fmt.Errorf("failed to get %v driver name, %v", ifaceName, err)
+		return 0, fmt.Errorf("failed to get %v driver name, %w", ifaceName, err)
 	} else if strings.Compare(driver, "veth") != 0 {
 		return 0, fmt.Errorf("interface: %v is %v, not a veth", ifaceName, driver)
 	}
 
 	if stats, err := ethHandle.Stats(ifaceName); err != nil {
-		return 0, fmt.Errorf("failed to get %v stats, %v", ifaceName, err)
+		return 0, fmt.Errorf("failed to get %v stats, %w", ifaceName, err)
 	} else {
 		ifIndex = stats["peer_ifindex"]
 	}
@@ -120,7 +120,7 @@ func GetVethPeerIndexFromInterface(iface net.Interface) (uint64, error) {
 func IfaceContainIPs(iface net.Interface, IPs []string) (bool, error) {
 	addresses, err := iface.Addrs()
 	if err != nil {
-		return false, fmt.Errorf("failed to get interface %v address: %v", iface.Name, err)
+		return false, fmt.Errorf("failed to get interface %v address: %w", iface.Name, err)
 	}
 
 	for _, rawAddr := range addresses {


### PR DESCRIPTION
## What this PR does

Fixes #1608

Replaces all instances of `fmt.Errorf("...: %v", err)` and `fmt.Errorf("...: %s", err)` with `fmt.Errorf("...: %w", err)` across the `pkg/` directory.

## Why

Using `%w` instead of `%v`/`%s` preserves the original error chain, enabling callers to use:
- `errors.Is(err, target)` — sentinel error matching
- `errors.As(err, &target)` — type-based error extraction

Without `%w`, the error is converted to a plain string and the chain is broken.

## Changes

- 32 files changed, 147 insertions(+), 147 deletions(-)
- All changes are pure `%v` → `%w` / `%s` → `%w` substitutions in `fmt.Errorf` calls — no logic changes
- Packages covered: `bpf/`, `cni/`, `controller/`, `dns/`, `kube/`, `utils/`, `consistenthash/`, `cache/`