### PR TITLE
updated network

### DIFF
--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -69,7 +69,7 @@ func NewXDSConfig(mode string) *XdsConfig {
 	sa := env.Register("SERVICE_ACCOUNT", "", "").Get()
 	nodeName := env.Register("NODE_NAME", "", "").Get()
 	meshID := env.Register("MESH_ID", "cluster.local", "").Get()
-	nw := env.Register("NETWORK", "", "").Get()
+	nw := env.Register("ISTIO_META_NETWORK", "", "The network of the proxy.").Get()
 
 	// TODO: fix it once we want to support VM application
 	ip := localHostIPv4


### PR DESCRIPTION
feat(controller): add multicluster metadata to XDS handshake
Populate NETWORK in XdsConfig by parsing 
environment variables and injecting them into the Envoy 
BootstrapNodeMetadata. 
This ensures Istiod can correctly identify the Kmesh node's 
locality and network boundary, which is a prerequisite for 
cross-cluster service discovery and routing.
- Updated NewXDSConfig to parse environment variables