### PR TITLE
fix(ctl/dump): add exit on fw.Start() failure in RunDump

### DIFF
--- a/ctl/dump/dump.go
+++ b/ctl/dump/dump.go
@@ -87,6 +87,7 @@ func RunDump(cmd *cobra.Command, args []string, outputFormat string) error {
 	}
 	if err := fw.Start(); err != nil {
 		log.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
+		os.Exit(1)
 	}
 
 	url := fmt.Sprintf("http://%s%s/%s", fw.Address(), configDumpPrefix, mode)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`RunDump` in `ctl/dump/dump.go` logs the error from `fw.Start()` but still continues execution. It then makes HTTP requests using a forwarder that never started, leading to misleading downstream errors.

The process also exits with code 0, which hides the failure from scripts.

This PR fixes that by adding `os.Exit(1)` right after the log, making it consistent with other error paths in the same function.

**Which issue(s) this PR fixes**:
Fixes #1634

**Special notes for your reviewer**:
Returning the error (`return err`) would be more idiomatic since `RunDump(...)` returns an error. However, the caller currently ignores it (`_ = RunDump(...)`), so it would still exit with code 0.

Using `os.Exit(1)` matches the existing pattern and ensures the failure is visible.

Switching to `RunE` and proper error propagation would be a cleaner fix, but that can be handled separately.
