### PR TITLE
[Feature] Allow selective binary compilation in make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ uninstall:
 
 .PHONY: build
 build:
-	 VERSION=$(VERSION) TARGET=$(TARGET) ./kmesh_compile.sh
+	 VERSION=$(VERSION) BUILD_TARGET=$(BUILD_TARGET) ./kmesh_compile.sh
 
 .PHONY: docker
 docker: build

--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ fi
 
 if [ -z "$1" -o "$1" == "-b" -o "$1" == "--build" ]; then
 	prepare
-	make $TARGET
+	make $BUILD_TARGET
 	exit
 fi
 

--- a/hack/utils.sh
+++ b/hack/utils.sh
@@ -30,8 +30,8 @@ function get_arch() {
 function build_kmesh() {
         local container_id=$1
         docker exec $container_id git config --global --add safe.directory /kmesh
-        docker exec -e VERSION=$VERSION -e TARGET=$TARGET $container_id sh /kmesh/build.sh
-        if [ -z "$TARGET" ]; then
+        docker exec -e VERSION=$VERSION -e BUILD_TARGET=$BUILD_TARGET $container_id sh /kmesh/build.sh
+        if [ -z "$BUILD_TARGET" ]; then
                 docker exec -e VERSION=$VERSION $container_id sh /kmesh/build.sh -i
                 docker exec $container_id sh -c "$(declare -f copy_to_host); copy_to_host"
         fi


### PR DESCRIPTION
Currently, running make build compiles the entire Kmesh project, which slows down iteration when a developer only needs to test a specific binary.

This PR modifies the build pipeline (Makefile, hack/utils.sh, and build.sh) to accept a TARGET argument.

Running make build maintains the default behavior (builds all, installs, and extracts to /out).

Running make build TARGET=kmeshctl (or any specific binary) selectively compiles only that target inside the Docker container and bypasses the global install/extraction phase to prevent missing file errors.                                                                     
