### PR TITLE
clean up unnecessary init bpf map in unit test

### DIFF
--- a/pkg/auth/policy_store_test.go
+++ b/pkg/auth/policy_store_test.go
@@ -20,20 +20,9 @@ import (
 	"testing"
 
 	"kmesh.net/kmesh/api/v2/workloadapi/security"
-	"kmesh.net/kmesh/daemon/options"
-	"kmesh.net/kmesh/pkg/constants"
-	"kmesh.net/kmesh/pkg/utils/test"
 )
 
 func Test_policyStore_updatePolicy(t *testing.T) {
-	config := options.BpfConfig{
-		Mode:        constants.DualEngineMode,
-		BpfFsPath:   "/sys/fs/bpf",
-		Cgroup2Path: "/mnt/kmesh_cgroup2",
-	}
-	cleanup, _ := test.InitBpfMap(t, config)
-	t.Cleanup(cleanup)
-
 	type args struct {
 		auth *security.Authorization
 	}
@@ -97,14 +86,6 @@ func Test_policyStore_updatePolicy(t *testing.T) {
 }
 
 func Test_policyStore_removePolicy(t *testing.T) {
-	config := options.BpfConfig{
-		Mode:        constants.DualEngineMode,
-		BpfFsPath:   "/sys/fs/bpf",
-		Cgroup2Path: "/mnt/kmesh_cgroup2",
-	}
-	cleanup, _ := test.InitBpfMap(t, config)
-	t.Cleanup(cleanup)
-
 	type args struct {
 		policyKey string
 	}

--- a/pkg/auth/rbac_test.go
+++ b/pkg/auth/rbac_test.go
@@ -31,10 +31,8 @@ import (
 
 	"kmesh.net/kmesh/api/v2/workloadapi"
 	"kmesh.net/kmesh/api/v2/workloadapi/security"
-	"kmesh.net/kmesh/daemon/options"
 	"kmesh.net/kmesh/pkg/constants"
 	"kmesh.net/kmesh/pkg/controller/workload/cache"
-	"kmesh.net/kmesh/pkg/utils/test"
 )
 
 const (
@@ -1982,14 +1980,6 @@ func TestRbac_doRbac(t *testing.T) {
 }
 
 func Test_handleAuthorizationTypeResponse(t *testing.T) {
-	config := options.BpfConfig{
-		Mode:        constants.DualEngineMode,
-		BpfFsPath:   "/sys/fs/bpf",
-		Cgroup2Path: "/mnt/kmesh_cgroup2",
-	}
-	cleanup, _ := test.InitBpfMap(t, config)
-	t.Cleanup(cleanup)
-
 	policy1 := &security.Authorization{
 		Name:      "p1",
 		Namespace: "test",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

clean up unnecessary init bpf map in unit test.

The processing of init bpf map is reduced to optimize the execution efficiency of the unit test.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```
