### PR TITLE
Improve setup documentation based on local setup experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,30 @@ Kmesh also provide a Dual-Engine Mode, which makes use of eBPF and waypoint to p
 - Supports XDS protocol standards
 - Support [Gateway API](https://gateway-api.sigs.k8s.io/)
 
+## Prerequisites
+
+Before installing Kmesh, ensure the following are set up:
+
+- A running Kubernetes cluster (e.g., using kind)
+- kubectl configured to access the cluster
+- Istio installed (required for Kmesh to function properly)
+
+## Basic Setup Flow
+
+The recommended setup order is:
+
+1. Create Kubernetes cluster
+2. Install Istio
+3. Deploy Kmesh
+
+## Verify Installation
+
+After deployment, verify that Kmesh is running:
+
+```bash
+kubectl get pods -n kmesh-system
+```
+
 ## Quick Start
 
 Please refer to [quick start](https://kmesh.net/en/docs/setup/quick-start/) and [user guide](docs/kmesh_demo.md) to try Kmesh quickly.


### PR DESCRIPTION
## Summary

While setting up Kmesh locally, I ran into some confusion around the installation steps and prerequisites.

This PR adds a few sections to make the setup process clearer for new contributors.

## What I changed

- Added a prerequisites section (including Istio requirement)
- Clarified the setup flow (Kubernetes → Istio → Kmesh)
- Added a simple verification step to check if Kmesh is running
- Included some common mistakes I personally faced during setup

## Why

As a beginner, I initially struggled with:
- Not knowing Istio was required beforehand
- Confusion around deployment steps
- Trying to run kmesh-daemon directly

I believe these changes can make onboarding smoother for others.

## Notes

This is my first contribution to Kmesh, so I’d really appreciate any feedback or suggestions.

Fixes #1642