### PR TITLE
Fixed IPv6 panic, corrected IPv4 zero-tail check, and prevented inval…

### DIFF
--- a/pkg/nets/nets.go
+++ b/pkg/nets/nets.go
@@ -35,12 +35,8 @@ func ConvertIpToUint32(ip string) uint32 {
 	if netIP == nil {
 		return 0
 	}
-	// TODO: is this right?
-	if len(netIP) == net.IPv6len {
-		return binary.LittleEndian.Uint32(netIP.To4())
-	}
-	if len(netIP) == net.IPv4len {
-		return binary.LittleEndian.Uint32(netIP)
+	if ipv4 := netIP.To4(); ipv4 != nil {
+		return binary.LittleEndian.Uint32(ipv4)
 	}
 	return 0
 }
@@ -77,7 +73,7 @@ func CopyIpByteFromSlice(dst *[16]byte, src []byte) {
 // TODO: this may conflict with IpV6 addresses with the same pattern,
 // we should find a better way to indicate the ipv4 address.
 func IpString(ip [16]byte) string {
-	if isZeros(ip[5:]) {
+	if isZeros(ip[4:]) {
 		return net.IP(ip[:4]).String()
 	}
 	return net.IP(ip[:]).String()
@@ -135,6 +131,7 @@ func CompareIpByte(a, b [][]byte) [][]byte {
 		ip, ok := netip.AddrFromSlice(item)
 		if !ok {
 			log.Error("cannot compared IP: Unsupported data types")
+			continue
 		}
 
 		aSet[ip.String()] = item
@@ -145,6 +142,7 @@ func CompareIpByte(a, b [][]byte) [][]byte {
 		ip, ok := netip.AddrFromSlice(item)
 		if !ok {
 			log.Error("cannot compared IP: Unsupported data types")
+			continue
 		}
 		if _, ok := aSet[ip.String()]; !ok {
 			bMissing = append(bMissing, item)

--- a/pkg/nets/nets_test.go
+++ b/pkg/nets/nets_test.go
@@ -24,12 +24,34 @@ import (
 )
 
 func Test_ConvertIpToUint32(t *testing.T) {
+	// existing: regular IPv4
 	ip := "192.168.0.1"
 	val := ConvertIpToUint32(ip)
 	assert.Equal(t, uint32(0x100a8c0), val)
-
-	// It can not panic even for invalid ip
+ 
+	// existing: invalid ip
 	val = ConvertIpToUint32("a.b.c.d")
+	assert.Equal(t, uint32(0), val)
+ 
+	// new: pure IPv6 address — should return 0, must not panic
+	val = ConvertIpToUint32("2001:db8::1")
+	assert.Equal(t, uint32(0), val)
+ 
+	// new: another pure IPv6 address
+	val = ConvertIpToUint32("fe80::1")
+	assert.Equal(t, uint32(0), val)
+ 
+	// new: IPv4-mapped IPv6 address (::ffff:192.168.0.1) — should return same as IPv4
+	val = ConvertIpToUint32("::ffff:192.168.0.1")
+	assert.Equal(t, uint32(0x100a8c0), val)
+ 
+	// new: IPv4-mapped IPv6 address (::ffff:1.2.3.4)
+	val = ConvertIpToUint32("::ffff:1.2.3.4")
+	expected := ConvertIpToUint32("1.2.3.4")
+	assert.Equal(t, expected, val)
+ 
+	// new: empty string — should return 0
+	val = ConvertIpToUint32("")
 	assert.Equal(t, uint32(0), val)
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

Fixed IPv6 panic risk  by using To4() safely and only converting when non-nil, and fixed IPv4 zero-tail detection by checking from byte 4 (ip[4:]) instead of byte 5, and also fixed invalid-slice handling  by continueing after failed `AddrFromSlice`, preventing bad keys from corrupting compare results.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Handled edge cases in nets.go to avoid panic, ensure correct IPv4 checks, and prevent invalid data from affecting comparisons.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
