### PR TITLE
docs: replace obsolete 'workload mode' with 'dual engine mode'

### DIFF
--- a/docs/en/Startup_process_of_eBPF_programs.md
+++ b/docs/en/Startup_process_of_eBPF_programs.md
@@ -30,11 +30,11 @@ Three main eBPF programs involved in ads mode have different attach points. The 
 - ApiEnvCfg：Since Kmesh involves map-in-map and serialization, but the C language serialization code cannot obtain info such as bpf map fd and so on, this info needs to be set as environment variables for subsequent processes.
 - deserial_init: Because the xDS configuration issued by istio is a tree-structured data with too deep level of nesting, the xDS configuration info needs to be stored in the bpf program using a map-in-map method
 
-#### Startup process in workload mode (StartworkloadMode)
+#### Startup process in dual engine mode (StartworkloadMode)
 
 - NewWorkloadBpf: Create the file system directory required by eBPF according to the configuration, including the file path of BPF map and prog
 - Load: Load the e BPF program of Kmesh, obtain the type and additional type of the program, and update the tail call program to implement the routing forwarding function
 - Attach: Attach the eBPF program of Kmesh to the specified cgroup and manage the eBPF program using bpflink
-The four main eBPF programs involved in workload mode, the eBPF programs of sockconn and sockops types are mounted on cgroup2, and the path is /mnt/kmesh_cgroup2. The eBPF program of sendmsg type is mounted on the eBPF program of sockops type, and the xdpauth eBPF program is mounted in the network card driver of the pod managed by Kmesh.
+The four main eBPF programs involved in dual engine mode, the eBPF programs of sockconn and sockops types are mounted on cgroup2, and the path is /mnt/kmesh_cgroup2. The eBPF program of sendmsg type is mounted on the eBPF program of sockops type, and the xdpauth eBPF program is mounted in the network card driver of the pod managed by Kmesh.
 
-Most of the processes are the same as Ads mode. The difference is that the eBPF programs loaded in workload mode and ads mode and the mounting hook points are different. Another difference is that there is no need to add additional storage and parsing for map-in-map, because the configuration information issued by istio in workload mode can be stored in the workload structure provided by istio.
+Most of the processes are the same as Ads mode. The difference is that the eBPF programs loaded in dual engine mode and ads mode and the mounting hook points are different. Another difference is that there is no need to add additional storage and parsing for map-in-map, because the configuration information issued by istio in dual engine mode can be stored in the workload structure provided by istio.

--- a/docs/en/kmesh_deploy_and_develop_in_kind.md
+++ b/docs/en/kmesh_deploy_and_develop_in_kind.md
@@ -49,7 +49,7 @@ Let's start from setting up the required environment. You can follow the steps b
     istioctl install
     ```
 
-    If you want to use `kmesh` in `dual engine` mode, you should deploy `istio` in [ambient mode](https://istio.io/latest/docs/ambient/overview/), by adding an extra flag:
+    If you want to use `kmesh` in `dual engine mode`, you should deploy `istio` in [ambient mode](https://istio.io/latest/docs/ambient/overview/), by adding an extra flag:
 
     ```shell
     istioctl install --set profile=ambient 

--- a/docs/en/kmesh_deploy_and_develop_in_kind.md
+++ b/docs/en/kmesh_deploy_and_develop_in_kind.md
@@ -49,7 +49,7 @@ Let's start from setting up the required environment. You can follow the steps b
     istioctl install
     ```
 
-    If you want to use `kmesh` in `workload` mode, you should deploy `istio` in [ambient mode](https://istio.io/latest/docs/ambient/overview/), by adding an extra flag:
+    If you want to use `kmesh` in `dual engine` mode, you should deploy `istio` in [ambient mode](https://istio.io/latest/docs/ambient/overview/), by adding an extra flag:
 
     ```shell
     istioctl install --set profile=ambient 

--- a/docs/proposal/dns_resolve.md
+++ b/docs/proposal/dns_resolve.md
@@ -130,7 +130,7 @@ and make progress.
 
 - Do not provide node local dns service for application, at least this is not the goal of this proposal.
 
-- Since istiod doesnot support workload dns resolution, Kmesh does not support it in workload mode either.
+- Since istiod doesnot support workload dns resolution, Kmesh does not support it in dual engine mode either.
 
 ### Proposal
 

--- a/docs/proposal/dns_resolve.md
+++ b/docs/proposal/dns_resolve.md
@@ -130,7 +130,7 @@ and make progress.
 
 - Do not provide node local dns service for application, at least this is not the goal of this proposal.
 
-- Since istiod doesnot support workload dns resolution, Kmesh does not support it in dual engine mode either.
+- Since istiod does not support workload dns resolution, Kmesh does not support it in dual engine mode either.
 
 ### Proposal
 

--- a/docs/proposal/kmesh_support_localityLB.md
+++ b/docs/proposal/kmesh_support_localityLB.md
@@ -17,7 +17,7 @@ creation-date: 2024-06-07
 
 ### Summary
 
-Add Locality Load Balancing to Kmesh workload mode.
+Add Locality Load Balancing to Kmesh dual engine mode.
 
 ### Motivation
 
@@ -25,7 +25,7 @@ Currently, Kmesh does not support locality aware load balancing. Locality Load B
 
 ### Goals
 
-The purpose of this proposal is to add locality aware load balancing capabilities to kmesh workload mode, corresponding to locality load balancing in istio ambient mesh.
+The purpose of this proposal is to add locality aware load balancing capabilities to kmesh dual engine mode, corresponding to locality load balancing in istio ambient mesh.
 
 ### Proposal
 

--- a/docs/proposal/layer4_authorization.md
+++ b/docs/proposal/layer4_authorization.md
@@ -1,5 +1,5 @@
 ---
-title: support layer 4 authorization in kmesh workload mod 
+title: support layer 4 authorization in kmesh dual engine mode
 authors:
 - "@supercharge-xsy"
 reviewers:
@@ -11,11 +11,11 @@ approvers:
 
 creation-date: 2024-05-28
 ---
-## Support L4 authorization in workload mode
+## Support L4 authorization in dual engine mode
 
 ### Summary
 
-This article aims to explain how Kmesh achieves layer 4 authorization functionality in workload mode. For an introduction to the authorization features, please refer to:[Kmesh TCP Authorization](https://kmesh.net/en/docs/userguide/tcp_authorization/). Currently, Kmesh supports two authorization architectures. Packets are first processed through XDP authorization, and if that type is not supported, quintuple information is passed through a ring buffer for user-space authorization. The ultimate goal is to fully handle authorization in XDP.
+This article aims to explain how Kmesh achieves layer 4 authorization functionality in dual engine mode. For an introduction to the authorization features, please refer to:[Kmesh TCP Authorization](https://kmesh.net/en/docs/userguide/tcp_authorization/). Currently, Kmesh supports two authorization architectures. Packets are first processed through XDP authorization, and if that type is not supported, quintuple information is passed through a ring buffer for user-space authorization. The ultimate goal is to fully handle authorization in XDP.
 
 ### Userspace authorization
 

--- a/docs/proposal/observability.md
+++ b/docs/proposal/observability.md
@@ -229,7 +229,7 @@ After obtaining the metric through bpf map, we also have to support the Promethe
 <img src="pics/observability.svg" width="800" />
 </div>
 
-Observability should be achieved in both ads mode and workload mode.
+Observability should be achieved in both ads mode and dual engine mode.
 
 We now consider the realisation of only l4 layers of observability.
 

--- a/pkg/controller/manage/manage_controller.go
+++ b/pkg/controller/manage/manage_controller.go
@@ -389,7 +389,7 @@ func sendCertRequest(security *kmeshsecurity.SecretManager, pod *corev1.Pod, op 
 }
 
 func linkXdp(netNsPath string, xdpProgFd int, mode string) error {
-	// Currently only support workload mode
+	// Currently only support dual engine mode
 	if mode != constants.DualEngineMode {
 		return nil
 	}
@@ -441,7 +441,7 @@ func linkXdp(netNsPath string, xdpProgFd int, mode string) error {
 }
 
 func unlinkXdp(netNsPath string, mode string) error {
-	// Currently only support workload mode
+	// Currently only support dual engine mode
 	if mode != constants.DualEngineMode {
 		return nil
 	}

--- a/pkg/status/status_server_test.go
+++ b/pkg/status/status_server_test.go
@@ -374,7 +374,7 @@ func TestServer_dumpWorkloadBpfMap(t *testing.T) {
 		assert.Equal(t, invalidModeErrMessage, string(body))
 	})
 
-	t.Run("Workload mode test", func(t *testing.T) {
+	t.Run("Dual engine mode test", func(t *testing.T) {
 		config := options.BpfConfig{
 			Mode:        constants.DualEngineMode,
 			BpfFsPath:   "/sys/fs/bpf",
@@ -459,7 +459,7 @@ func TestServer_dumpWorkloadBpfMap(t *testing.T) {
 }
 
 func TestServer_dumpAdsBpfMap(t *testing.T) {
-	t.Run("Workload mode test", func(t *testing.T) {
+	t.Run("Dual engine mode test", func(t *testing.T) {
 		config := options.BpfConfig{
 			Mode:        constants.DualEngineMode,
 			BpfFsPath:   "/sys/fs/bpf",
@@ -468,7 +468,7 @@ func TestServer_dumpAdsBpfMap(t *testing.T) {
 		cleanup, _ := test.InitBpfMap(t, config)
 		defer cleanup()
 
-		// workload mode will failed
+		// dual engine mode will failed
 		server := &Server{}
 		req := httptest.NewRequest(http.MethodGet, patternBpfWorkloadMaps, nil)
 		w := httptest.NewRecorder()

--- a/pkg/status/status_server_test.go
+++ b/pkg/status/status_server_test.go
@@ -468,7 +468,7 @@ func TestServer_dumpAdsBpfMap(t *testing.T) {
 		cleanup, _ := test.InitBpfMap(t, config)
 		defer cleanup()
 
-		// dual engine mode will failed
+		// dual engine mode will fail
 		server := &Server{}
 		req := httptest.NewRequest(http.MethodGet, patternBpfWorkloadMaps, nil)
 		w := httptest.NewRecorder()


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
/kind cleanup

**What this PR does / why we need it**:

The term `workload mode` was renamed to `dual engine mode` in the codebase (tracked under `constants.DualEngineMode`), but several documentation files, code comments, and test names still used the old terminology. This PR updates all remaining references to use the correct term `dual engine mode` for consistency.

**Files updated:**
> - [docs/en/kmesh_deploy_and_develop_in_kind.md](cci:7://file://wsl.localhost/Ubuntu/home/sahana/kmesh/docs/en/kmesh_deploy_and_develop_in_kind.md:0:0-0:0)
> - [docs/en/Startup_process_of_eBPF_programs.md](cci:7://file://wsl.localhost/Ubuntu/home/sahana/kmesh/docs/en/Startup_process_of_eBPF_programs.md:0:0-0:0)
> - [docs/proposal/layer4_authorization.md](cci:7://file://wsl.localhost/Ubuntu/home/sahana/kmesh/docs/proposal/layer4_authorization.md:0:0-0:0)
> - [docs/proposal/kmesh_support_localityLB.md](cci:7://file://wsl.localhost/Ubuntu/home/sahana/kmesh/docs/proposal/kmesh_support_localityLB.md:0:0-0:0)
> - [docs/proposal/dns_resolve.md](cci:7://file://wsl.localhost/Ubuntu/home/sahana/kmesh/docs/proposal/dns_resolve.md:0:0-0:0)
> - [docs/proposal/observability.md](cci:7://file://wsl.localhost/Ubuntu/home/sahana/kmesh/docs/proposal/observability.md:0:0-0:0)
> - [pkg/controller/manage/manage_controller.go](cci:7://file://wsl.localhost/Ubuntu/home/sahana/kmesh/pkg/controller/manage/manage_controller.go:0:0-0:0) (code comments)
> - [pkg/status/status_server_test.go](cci:7://file://wsl.localhost/Ubuntu/home/sahana/kmesh/pkg/status/status_server_test.go:0:0-0:0) (test names and comments)

**Which issue this PR fixes**:

Fixes #1315

**Special notes for your reviewer**:

`docs/proposal/kmesh_support_workload.md` was intentionally left unchanged, it references the Istio Workload API/model, not the Kmesh mode name.
