### PR TITLE
test: add E2E test cases for egress gateway

### DIFF
--- a/test/e2e/gateway_test.go
+++ b/test/e2e/gateway_test.go
@@ -432,3 +432,133 @@ func runIngressTest(t *testing.T, f func(t framework.TestContext, src ingress.In
 		}
 	})
 }
+
+const (
+	defaultEgressServiceName      = "istio-egressgateway"
+	defaultEgressServiceNamespace = "istio-system"
+)
+
+// TestEgress verifies that traffic from mesh pods can be routed through the egress gateway before reaching an external service. We use one of the existing echo apps as the "external" backend (registered under a fake hostname) so the test doesn't need real internet access.
+func TestEgress(t *testing.T) {
+	framework.NewTest(t).Run(func(t framework.TestContext) {
+		dst := apps.EnrolledToKmesh
+		if len(dst) == 0 {
+			t.Skip("no enrolled-to-kmesh instances found")
+			return
+		}
+
+		dstIP := dst[0].Address()
+		dstPort := dst[0].Config().Ports.MustForName("http").ServicePort
+
+		// the virtual IP below is IPv4 — skip in IPv6-only clusters
+		if ip := net.ParseIP(dstIP); ip != nil && ip.To4() == nil {
+			t.Skip("skipping egress test in IPv6-only environment: ServiceEntry virtual IP is IPv4")
+			return
+		}
+
+		// 240.240.0.100 is in the range Istio reserves for ServiceEntry virtual IPs, so it won't clash
+		// with any real pod or service address.
+		const (
+			externalHost = "external-svc.example.com"
+			externalVIP  = "240.240.0.100"
+		)
+
+		// Apply config once for all source subtests — it only depends on dst, not src.
+		t.ConfigIstio().Eval(apps.Namespace.Name(), map[string]string{
+			"ExternalHost": externalHost,
+			"ExternalVIP":  externalVIP,
+			"DstIP":        dstIP,
+			"DstPort":      fmt.Sprintf("%d", dstPort),
+			"EgressSvc":    defaultEgressServiceName,
+			"EgressNs":     defaultEgressServiceNamespace,
+		}, `
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: external-svc
+spec:
+  hosts:
+  - "{{.ExternalHost}}"
+  addresses:
+  - {{.ExternalVIP}}
+  ports:
+  - number: 80
+    name: http
+    protocol: HTTP
+  location: MESH_EXTERNAL
+  resolution: STATIC
+  endpoints:
+  - address: {{.DstIP}}
+    ports:
+      http: {{.DstPort}}
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: egress-gateway
+spec:
+  selector:
+    istio: egressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - "{{.ExternalHost}}"
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: external-svc-via-egress
+spec:
+  hosts:
+  - "{{.ExternalHost}}"
+  gateways:
+  - egress-gateway
+  - mesh
+  http:
+  # traffic from mesh pods: divert it to the egress gateway first
+  - match:
+    - gateways:
+      - mesh
+      port: 80
+    route:
+    - destination:
+        host: {{.EgressSvc}}.{{.EgressNs}}.svc.cluster.local
+        port:
+          number: 80
+  # traffic arriving at the egress gateway: forward to the actual destination
+  - match:
+    - gateways:
+      - egress-gateway
+      port: 80
+    route:
+    - destination:
+        host: "{{.ExternalHost}}"
+        port:
+          number: 80
+`).ApplyOrFail(t)
+
+		for _, src := range apps.All {
+			src := src
+			t.NewSubTestf("from %v", src.Config().Service).Run(func(t framework.TestContext) {
+				opt := echo.CallOptions{
+					// Do NOT set To — we route by raw Address+Port so the echo caller
+					// doesn't try to resolve endpoints from the Instances slice.
+					Address: externalVIP,
+					Port:    echo.Port{ServicePort: 80},
+					Scheme:  scheme.HTTP,
+					Count:   5,
+					Timeout: time.Second * 10,
+					Check:   check.OK(),
+					HTTP: echo.HTTP{
+						Headers: map[string][]string{},
+					},
+				}
+				opt.HTTP.Headers.Set(headers.Host, externalHost)
+				src.CallOrFail(t, opt)
+			})
+		}
+	})
+}

--- a/test/e2e/run_test.sh
+++ b/test/e2e/run_test.sh
@@ -116,7 +116,13 @@ function setup_istio() {
 
 	helm install istiod istio/istiod --namespace istio-system --version $ISTIO_VERSION --set pilot.env.PILOT_ENABLE_AMBIENT=true --create-namespace
 
-	helm install istio-ingressgateway istio/gateway -n istio-system --create-namespace
+	helm install istio-ingressgateway istio/gateway -n istio-system --version "$ISTIO_VERSION" --create-namespace
+
+	# egress gateway only needs to be reachable from inside the cluster
+	helm install istio-egressgateway istio/gateway -n istio-system --version "$ISTIO_VERSION" --create-namespace \
+		--set labels.istio=egressgateway \
+		--set labels.app=istio-egressgateway \
+		--set service.type=ClusterIP
 
 	while true; do
 		pod_info=$(kubectl get pods -n istio-system -l app=istiod -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.phase}{"\n"}{end}')


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Picks up where #1002 left off that PR added ingress gateway tests, this one adds the egress side to fully close #1001.
Since the tests run in KinD with no internet, the "external" service is faked using a `ServiceEntry` with a virtual IP (`240.240.0.100`) pointing to one of the echo pods. Tests the full egress routing path without needing anything outside the cluster.

**Changes**
> - `test/e2e/run_test.sh` : adds `istio-egressgateway` install via Helm
> - `test/e2e/gateway_test.go` : adds `TestEgress` and `runEgressTest`

**Which issue(s) this PR fixes**:
Fixes #1001

**Special notes for your reviewer**:
Using a virtual IP instead of a hostname to avoid any dependency on DNS proxy being enabled in the test environment.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
