### PR TITLE
fix: correct error messages in workloadMetricHandler and connectionMe…

### DIFF
--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -284,7 +284,7 @@ func (s *Server) workloadMetricHandler(w http.ResponseWriter, r *http.Request) {
 	enabled, err := strconv.ParseBool(info)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(fmt.Sprintf("invalid accesslog enable=%s", info)))
+		_, _ = w.Write([]byte(fmt.Sprintf("invalid workload_metrics enable=%s", info)))
 		return
 	}
 
@@ -307,7 +307,7 @@ func (s *Server) connectionMetricHandler(w http.ResponseWriter, r *http.Request)
 	enabled, err := strconv.ParseBool(info)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(fmt.Sprintf("invalid accesslog enable=%s", info)))
+		_, _ = w.Write([]byte(fmt.Sprintf("invalid connection_metrics enable=%s", info)))
 		return
 	}
 


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This fixes a small copy-paste error in `status_server.go`. The `workloadMetricHandler` and `connectionMetricHandler` were returning "invalid accesslog enable=..." when passed a bad enable value, instead of their respective handler names. This updates the error strings to say "invalid workload_metrics" and "invalid connection_metrics".

**Which issue(s) this PR fixes**:
Fixes #1660 

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
