### PR TITLE
docs: fix broken link and outdated Istio URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Kmesh is a high-performance and low overhead service mesh data plane based on eB
 
 Service mesh software represented by Istio has gradually become popular and become an important component of cloud native infrastructure. However, there are still some challenges faced:
 
-- **Extra latency overhead at the proxy layer**: Add [2~3ms](https://istio.io/v1.19/docs/ops/deployment/performance-and-scalability/) latency, which cannot meet the SLA requirements of latency-sensitive applications. Although the community has come up with a variety of optimizations, the overhead introduced by sidecar cannot be completely reduced.
+- **Extra latency overhead at the proxy layer**: Add [2~3ms](https://istio.io/latest/docs/ops/deployment/performance-and-scalability/) latency, which cannot meet the SLA requirements of latency-sensitive applications. Although the community has come up with a variety of optimizations, the overhead introduced by sidecar cannot be completely reduced.
 - **High resources occupation**: Occupy 0.5 vCPU and 50 MB memory per 1000 requests per second going through the proxy, and the deployment density of service container decreases.
 
 ### Kmesh Architecture

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Kmesh also provide a Dual-Engine Mode, which makes use of eBPF and waypoint to p
 
 ## Quick Start
 
-Please refer to [quick start](https://kmesh.net/en/docs/setup/quick-start/) and [user guide](docs/kmesh_demo.md) to try Kmesh quickly.
+Please refer to [quick start](https://kmesh.net/en/docs/setup/quick-start/) and [user guide](docs/en/kmesh_demo.md) to try Kmesh quickly.
 
 ### Guided Install
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:
Fixes two documentation issues in `README.md`:

1. **Broken user guide link** (line 80) — `docs/kmesh_demo.md` does not exist in the repository. Fixed to `docs/en/kmesh_demo.md`.
2. **Outdated Istio link** (line 16) — hardcoded to `istio.io/v1.19/...` which is an old unsupported version. Updated to `istio.io/latest/...`.

**Which issue(s) this PR fixes**:
Fixes #1668

**Special notes for your reviewer**:
Two one-line documentation fixes in README.md. Used Claude Code to locate the issues; reviewed and verified each change manually.

**Does this PR introduce a user-facing change?**:
```release-note
NONE