### PR TITLE
cleanup: standardize empty string checks in pkg/

### DIFF
--- a/pkg/auth/rbac.go
+++ b/pkg/auth/rbac.go
@@ -428,14 +428,14 @@ func internalMatchPrincipal(srcId string, principals []*security.StringMatch) bo
 	srcId = strings.TrimPrefix(srcId, SPIFFE_PREFIX)
 	m := false
 	for _, principal := range principals {
-		if len(principal.GetPrefix()) > 0 {
+		if principal.GetPrefix() != "" {
 			m = strings.HasPrefix(srcId, principal.GetPrefix())
-		} else if len(principal.GetSuffix()) > 0 {
+		} else if principal.GetSuffix() != "" {
 			m = strings.HasSuffix(srcId, principal.GetSuffix())
-		} else if len(principal.GetExact()) > 0 {
+		} else if principal.GetExact() != "" {
 			m = srcId == principal.GetExact()
 		} else {
-			m = len(srcId) == 0
+			m = srcId == ""
 		}
 		if m {
 			return true
@@ -447,14 +447,14 @@ func internalMatchPrincipal(srcId string, principals []*security.StringMatch) bo
 func internalMatchNamespace(srcNs string, namespaces []*security.StringMatch) bool {
 	m := false
 	for _, ns := range namespaces {
-		if len(ns.GetPrefix()) > 0 {
+		if ns.GetPrefix() != "" {
 			m = strings.HasPrefix(srcNs, ns.GetPrefix())
-		} else if len(ns.GetSuffix()) > 0 {
+		} else if ns.GetSuffix() != "" {
 			m = strings.HasSuffix(srcNs, ns.GetSuffix())
-		} else if len(ns.GetExact()) > 0 {
+		} else if ns.GetExact() != "" {
 			m = srcNs == ns.GetExact()
 		} else {
-			m = len(srcNs) == 0
+			m = srcNs == ""
 		}
 		if m {
 			return true

--- a/pkg/cni/chained.go
+++ b/pkg/cni/chained.go
@@ -39,7 +39,7 @@ const (
 
 func (i *Installer) getCniConfigPath() (string, error) {
 	var confFile string
-	if len(i.CniConfigName) != 0 {
+	if i.CniConfigName != "" {
 		confFile = filepath.Join(i.CniMountNetEtcDIR, i.CniConfigName)
 		confList, err := libcni.ConfListFromFile(confFile)
 		if err != nil {

--- a/pkg/cni/kubeconfig.go
+++ b/pkg/cni/kubeconfig.go
@@ -45,11 +45,11 @@ import (
 
 func createKubeConfig(serviceAccountPath string) (string, error) {
 	k8sServiceHost := os.Getenv("KUBERNETES_SERVICE_HOST")
-	if len(k8sServiceHost) == 0 {
+	if k8sServiceHost == "" {
 		return "", fmt.Errorf("KUBERNETES_SERVICE_HOST not set. Is this not running within a pod?")
 	}
 	k8sServicePort := os.Getenv("KUBERNETES_SERVICE_PORT")
-	if len(k8sServicePort) == 0 {
+	if k8sServicePort == "" {
 		return "", fmt.Errorf("KUBERNETES_SERVICE_PORT not set. Is this not running within a pod?")
 	}
 

--- a/pkg/utils/kernel_version.go
+++ b/pkg/utils/kernel_version.go
@@ -29,7 +29,7 @@ import (
 // and will fallback to less BPF log ability(return true) if error
 func KernelVersionLowerThan5_13() bool {
 	kernelVersion := GetKernelVersion()
-	if len(kernelVersion) == 0 {
+	if kernelVersion == "" {
 		return true
 	}
 	splitVers := strings.Split(kernelVersion, ".")


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Replaces inconsistent `len(x) == 0`, `len(x) != 0`, and `len(x) > 0` patterns
with idiomatic Go `x == ""` / `x != ""` for string variables across `pkg/`.

Files changed:
- `pkg/cni/kubeconfig.go`: `k8sServiceHost`, `k8sServicePort`
- `pkg/utils/kernel_version.go`: `kernelVersion`
- `pkg/cni/chained.go`: `CniConfigName`
- `pkg/auth/rbac.go`: `srcId`, `srcNs`, `GetPrefix()`, `GetSuffix()`, `GetExact()`

No logic changes — purely style/cleanup.

**Which issue(s) this PR fixes**:
Fixes #1659

**Special notes for your reviewer**:

Only string variables were changed. All `len()` checks on slices, maps, and
byte slices were intentionally left untouched.

**Does this PR introduce a user-facing change?**:

```release note
NONE
