### PR TITLE
fixing the syntax error in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 VERSION ?= 1.1-dev
 GIT_COMMIT_HASH ?= $(shell git rev-parse HEAD)
-GIT_TREESTATE=$(shell if [ -n "$(git status --porcelain)" ]; then echo "dirty"; else echo "clean"; fi)
+GIT_TREESTATE=$(shell if [ -n "$$(git status --porcelain)" ]; then echo "dirty"; else echo "clean"; fi)
 BUILD_DATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 ROOT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently the root `Makefile` computers `GIT_TREESTATE` like below:

`GIT_TREESTATE=$(shell if [ -n "$(git status --porcelain)" ]; then echo "dirty"; else echo "clean"; fi)
`

The issue with this is that the syntax $(git status --porcelain) is parsed by the make command as a variable and not as a shell command substitution. As a result it expands into a empty string before the shell runs, and `GIT_TREESTATE` always resolves to `clean`.

Below examples uses the echo command to illustrate the issue:

### Current Behaviour:

- It shows that the GIT Treestate is clean even when is not
<img width="665" height="220" alt="Image" src="https://github.com/user-attachments/assets/221f1003-b27e-4967-9b99-f4d20595a822" />

### Expected Behaviour:

<img width="678" height="257" alt="Image" src="https://github.com/user-attachments/assets/5bea4cdd-5285-4f7f-be5b-92ebf5064c6a" />


**Which issue(s) this PR fixes**:
Fixes #1673 

