### PR TITLE
feat: add --enable-dns-proxy startup parameter and kmeshctl dnsproxy …

### DIFF
--- a/ctl/common/common.go
+++ b/ctl/common/common.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kmesh.net/kmesh/ctl/authz"
+	"kmesh.net/kmesh/ctl/dnsproxy"
 	"kmesh.net/kmesh/ctl/dump"
 	logcmd "kmesh.net/kmesh/ctl/log"
 	"kmesh.net/kmesh/ctl/monitoring"
@@ -45,6 +46,7 @@ func GetRootCommand() *cobra.Command {
 	rootCmd.AddCommand(monitoring.NewCmd())
 	rootCmd.AddCommand(authz.NewCmd())
 	rootCmd.AddCommand(secret.NewCmd())
+	rootCmd.AddCommand(dnsproxy.NewCmd())
 
 	return rootCmd
 }

--- a/ctl/dnsproxy/dnsproxy.go
+++ b/ctl/dnsproxy/dnsproxy.go
@@ -1,0 +1,183 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dnsproxy
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/spf13/cobra"
+
+	"kmesh.net/kmesh/ctl/utils"
+	"kmesh.net/kmesh/pkg/kube"
+	"kmesh.net/kmesh/pkg/logger"
+)
+
+const (
+	patternDnsproxy = "/dnsproxy"
+)
+
+var log = logger.NewLoggerScope("kmeshctl/dnsproxy")
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "dnsproxy",
+		Short: "Control Kmesh's DNS proxy to be enabled or disabled at runtime",
+		Example: `# Enable DNS proxy for a specific kmesh daemon pod:
+kmeshctl dnsproxy <kmesh-daemon-pod> enable
+
+# Disable DNS proxy for a specific kmesh daemon pod:
+kmeshctl dnsproxy <kmesh-daemon-pod> disable
+
+# Check DNS proxy status for a specific kmesh daemon pod:
+kmeshctl dnsproxy <kmesh-daemon-pod> status
+
+# Enable DNS proxy for all kmesh daemon pods:
+kmeshctl dnsproxy enable
+
+# Disable DNS proxy for all kmesh daemon pods:
+kmeshctl dnsproxy disable
+
+# Check DNS proxy status for all kmesh daemon pods:
+kmeshctl dnsproxy status`,
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return controlDnsproxy(args)
+		},
+	}
+	return cmd
+}
+
+func controlDnsproxy(args []string) error {
+	client, err := utils.CreateKubeClient()
+	if err != nil {
+		return fmt.Errorf("failed to create cli client: %v", err)
+	}
+
+	var podName, action string
+
+	if len(args) == 2 {
+		// kmeshctl dnsproxy <podName> enable/disable/status
+		podName = args[0]
+		action = args[1]
+	} else {
+		// kmeshctl dnsproxy enable/disable/status
+		action = args[0]
+	}
+
+	if action != "enable" && action != "disable" && action != "status" {
+		return fmt.Errorf("invalid action %q: must be 'enable', 'disable', or 'status'", action)
+	}
+
+	if podName != "" {
+		// Target a specific pod
+		return handlePodAction(client, podName, action)
+	}
+
+	// Target all kmesh daemon pods
+	podList, err := client.PodsForSelector(context.TODO(), utils.KmeshNamespace, utils.KmeshLabel)
+	if err != nil {
+		return fmt.Errorf("failed to get kmesh podList: %v", err)
+	}
+
+	var lastErr error
+	for _, pod := range podList.Items {
+		if err := handlePodAction(client, pod.GetName(), action); err != nil {
+			log.Errorf("failed to %s dnsproxy for pod %s: %v", action, pod.GetName(), err)
+			lastErr = err
+		}
+	}
+	return lastErr
+}
+
+func handlePodAction(cli kube.CLIClient, podName, action string) error {
+	if action == "status" {
+		return fetchDnsProxyStatus(cli, podName)
+	}
+	return setDnsProxyPerKmeshDaemon(cli, podName, action)
+}
+
+func setDnsProxyPerKmeshDaemon(cli kube.CLIClient, podName, action string) error {
+	var status string
+	if action == "enable" {
+		status = "true"
+	} else {
+		status = "false"
+	}
+
+	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
+	if err != nil {
+		return fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
+	}
+	if err := fw.Start(); err != nil {
+		return fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
+	}
+	defer fw.Close()
+
+	url := fmt.Sprintf("http://%s%s?enable=%s", fw.Address(), patternDnsproxy, status)
+	req, err := http.NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		return fmt.Errorf("error creating request: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	httpClient := &http.Client{}
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to make HTTP request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("received status code %d, failed to read response body: %v", resp.StatusCode, readErr)
+		}
+		return fmt.Errorf("received status code %d, response: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	fmt.Printf("DNS proxy %sd for pod %s\n", action, podName)
+	return nil
+}
+
+func fetchDnsProxyStatus(cli kube.CLIClient, podName string) error {
+	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
+	if err != nil {
+		return fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
+	}
+	if err := fw.Start(); err != nil {
+		return fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
+	}
+	defer fw.Close()
+
+	url := fmt.Sprintf("http://%s%s", fw.Address(), patternDnsproxy)
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to get DNS proxy status: %v", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read response body: %v", err)
+	}
+
+	fmt.Printf("Pod: %s\tDNS Proxy: %s\n", podName, string(bodyBytes))
+	return nil
+}

--- a/daemon/manager/manager.go
+++ b/daemon/manager/manager.go
@@ -100,7 +100,7 @@ func Execute(configs *options.BootstrapConfigs) error {
 	log.Info("controller start successfully")
 	defer c.Stop()
 
-	statusServer := status.NewServer(c.GetXdsClient(), configs, bpfLoader)
+	statusServer := status.NewServer(c.GetXdsClient(), configs, bpfLoader, c)
 	statusServer.StartServer()
 	defer func() {
 		_ = statusServer.StopServer()

--- a/daemon/options/bpf.go
+++ b/daemon/options/bpf.go
@@ -34,6 +34,7 @@ type BpfConfig struct {
 	EnablePeriodicReport bool
 	EnableProfiling      bool
 	EnableIPsec          bool
+	EnableDnsProxy       bool
 }
 
 func (c *BpfConfig) AttachFlags(cmd *cobra.Command) {
@@ -45,6 +46,7 @@ func (c *BpfConfig) AttachFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(&c.EnablePeriodicReport, "periodic-report", false, "enable kmesh periodic report in daemon process")
 	cmd.PersistentFlags().BoolVar(&c.EnableProfiling, "profiling", false, "whether to enable profiling or not, default to false")
 	cmd.PersistentFlags().BoolVar(&c.EnableIPsec, "enable-ipsec", false, "enable ipsec encryption and authentication between nodes")
+	cmd.PersistentFlags().BoolVar(&c.EnableDnsProxy, "enable-dns-proxy", false, "enable dns proxy to redirect DNS requests of kmesh-managed pods to kmesh daemon")
 }
 
 func (c *BpfConfig) ParseConfig() error {

--- a/deploy/charts/kmesh-helm/templates/daemonset.yaml
+++ b/deploy/charts/kmesh-helm/templates/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
         prometheus.io/scrape: "true"
     spec:
       containers:
-      - args: ["./start_kmesh.sh {{ .Values.deploy.kmesh.containers.kmeshDaemonArgs }}"]
+      - args: ["./start_kmesh.sh {{ .Values.deploy.kmesh.containers.kmeshDaemonArgs }}{{ if .Values.features.dnsProxy.enabled }} --enable-dns-proxy{{ end }}"]
         command:
         - /bin/sh
         - -c
@@ -51,10 +51,6 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        {{ if .Values.features.dnsProxy.enabled }}
-        - name: KMESH_ENABLE_DNS_PROXY
-          value: {{ .Values.features.dnsProxy.enabled | quote }}
-        {{- end }}
         image: {{ .Values.deploy.kmesh.image.repository }}:{{ .Values.deploy.kmesh.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.deploy.kmesh.imagePullPolicy }}
         name: kmesh

--- a/deploy/yaml/kmesh.yaml
+++ b/deploy/yaml/kmesh.yaml
@@ -78,7 +78,7 @@ spec:
           command: ["/bin/sh", "-c"]
           args:
             [
-              "./start_kmesh.sh --mode=dual-engine --enable-bypass=false",
+              "./start_kmesh.sh --mode=dual-engine --enable-bypass=false --enable-dns-proxy",
             ]
           securityContext:
             privileged: true
@@ -107,8 +107,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: KMESH_ENABLE_DNS_PROXY
-              value: "true"
           volumeMounts:
             - name: mnt
               mountPath: /mnt

--- a/docs/ctl/kmeshctl.md
+++ b/docs/ctl/kmeshctl.md
@@ -11,6 +11,7 @@ Kmesh command line tools to operate and debug Kmesh
 ### SEE ALSO
 
 * [kmeshctl authz](kmeshctl_authz.md) - Manage xdp authz eBPF program for Kmesh's authz offloading
+* [kmeshctl dnsproxy](kmeshctl_dnsproxy.md) - Control Kmesh's DNS proxy to be enabled or disabled at runtime
 * [kmeshctl dump](kmeshctl_dump.md) - Dump config of kernel-native or dual-engine mode
 * [kmeshctl log](kmeshctl_log.md) - Get or set kmesh-daemon's logger level
 * [kmeshctl monitoring](kmeshctl_monitoring.md) - Control Kmesh's monitoring to be turned on as needed

--- a/docs/ctl/kmeshctl_dnsproxy.md
+++ b/docs/ctl/kmeshctl_dnsproxy.md
@@ -1,0 +1,35 @@
+## kmeshctl dnsproxy
+
+Control Kmesh's DNS proxy to be enabled or disabled at runtime
+
+### Examples
+
+```bash
+# Enable DNS proxy for a specific kmesh daemon pod:
+kmeshctl dnsproxy <kmesh-daemon-pod> enable
+
+# Disable DNS proxy for a specific kmesh daemon pod:
+kmeshctl dnsproxy <kmesh-daemon-pod> disable
+
+# Check DNS proxy status for a specific kmesh daemon pod:
+kmeshctl dnsproxy <kmesh-daemon-pod> status
+
+# Enable DNS proxy for all kmesh daemon pods:
+kmeshctl dnsproxy enable
+
+# Disable DNS proxy for all kmesh daemon pods:
+kmeshctl dnsproxy disable
+
+# Check DNS proxy status for all kmesh daemon pods:
+kmeshctl dnsproxy status
+```
+
+### Options
+
+```bash
+  -h, --help   help for dnsproxy
+```
+
+### SEE ALSO
+
+* [kmeshctl](kmeshctl.md) - Kmesh command line tools to operate and debug Kmesh

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/cilium/ebpf"
@@ -66,6 +67,7 @@ type Controller struct {
 	bpfConfig           *options.BpfConfig
 	loader              *bpf.BpfLoader
 	dnsServer           *dnsclient.LocalDNSServer
+	dnsProxyMu          sync.Mutex
 }
 
 func NewController(opts *options.BootstrapConfigs, bpfLoader *bpf.BpfLoader) *Controller {
@@ -172,10 +174,20 @@ func (c *Controller) Start(stopCh <-chan struct{}) error {
 	}
 
 	if c.client.WorkloadController != nil {
+		// Use startup flag; fall back to env var for backward compatibility
+		enableDnsProxy := c.bpfConfig.EnableDnsProxy || workload.EnableDNSProxy
+		c.client.WorkloadController.SetDnsProxyTrigger(enableDnsProxy)
+
 		if err := c.client.WorkloadController.Run(ctx, stopCh); err != nil {
+			// Roll back state if Run fails (PrepareDNSProxy may have failed inside)
+			c.client.WorkloadController.SetDnsProxyTrigger(false)
 			return fmt.Errorf("failed to start workload controller: %+v", err)
 		}
 		if err := c.setupDNSProxy(); err != nil {
+			c.client.WorkloadController.SetDnsProxyTrigger(false)
+			if cleanupErr := c.client.WorkloadController.Processor.PrepareDNSProxy(false); cleanupErr != nil {
+				log.Warnf("Failed to cleanup DNS proxy on setup error: %v", cleanupErr)
+			}
 			return fmt.Errorf("failed to start dns proxy: %+v", err)
 		}
 	} else {
@@ -209,7 +221,7 @@ func (c *Controller) GetXdsClient() *XdsClient {
 }
 
 func (c *Controller) setupDNSProxy() error {
-	if workload.EnableDNSProxy {
+	if c.client.WorkloadController.GetDnsProxyTrigger() {
 		server, err := dnsclient.NewLocalDNSServer(kmeshNamespace, clusterDomain, ":53", dnsForwardParallel)
 		if err != nil {
 			return fmt.Errorf("failed to start local dns server: %v", err)
@@ -228,7 +240,11 @@ func (c *Controller) setupDNSProxy() error {
 			go func() {
 				<-timer.C
 				log.Debugf("trigger name table update")
-				server.UpdateLookupTable(ntb.BuildNameTable())
+				c.dnsProxyMu.Lock()
+				defer c.dnsProxyMu.Unlock()
+				if c.dnsServer != nil {
+					c.dnsServer.UpdateLookupTable(ntb.BuildNameTable())
+				}
 			}()
 
 			return nil
@@ -239,4 +255,64 @@ func (c *Controller) setupDNSProxy() error {
 		c.dnsServer = server
 	}
 	return nil
+}
+
+// StartDnsProxy enables the DNS proxy at runtime.
+func (c *Controller) StartDnsProxy() error {
+	if c.client == nil || c.client.WorkloadController == nil {
+		return fmt.Errorf("dns proxy not supported in this mode")
+	}
+
+	c.dnsProxyMu.Lock()
+	defer c.dnsProxyMu.Unlock()
+
+	c.client.WorkloadController.SetDnsProxyTrigger(true)
+	if err := c.client.WorkloadController.Processor.PrepareDNSProxy(true); err != nil {
+		c.client.WorkloadController.SetDnsProxyTrigger(false)
+		return fmt.Errorf("failed to prepare DNS proxy: %v", err)
+	}
+
+	if c.dnsServer == nil {
+		if err := c.setupDNSProxy(); err != nil {
+			c.client.WorkloadController.SetDnsProxyTrigger(false)
+			if cleanupErr := c.client.WorkloadController.Processor.PrepareDNSProxy(false); cleanupErr != nil {
+				log.Warnf("Failed to cleanup DNS proxy state: %v", cleanupErr)
+			}
+			return fmt.Errorf("failed to setup DNS proxy: %v", err)
+		}
+	}
+
+	log.Info("DNS proxy started successfully")
+	return nil
+}
+
+// StopDnsProxy disables the DNS proxy at runtime.
+func (c *Controller) StopDnsProxy() error {
+	if c.client == nil || c.client.WorkloadController == nil {
+		return fmt.Errorf("dns proxy not supported in this mode")
+	}
+
+	c.dnsProxyMu.Lock()
+	defer c.dnsProxyMu.Unlock()
+
+	c.client.WorkloadController.SetDnsProxyTrigger(false)
+	if err := c.client.WorkloadController.Processor.PrepareDNSProxy(false); err != nil {
+		log.Warnf("Failed to cleanup DNS proxy state: %v", err)
+	}
+
+	if c.dnsServer != nil {
+		c.dnsServer.Close()
+		c.dnsServer = nil
+	}
+
+	log.Info("DNS proxy stopped successfully")
+	return nil
+}
+
+// GetDnsProxyStatus returns the current status of the DNS proxy.
+func (c *Controller) GetDnsProxyStatus() bool {
+	if c.client == nil || c.client.WorkloadController == nil {
+		return false
+	}
+	return c.client.WorkloadController.GetDnsProxyTrigger()
 }

--- a/pkg/controller/workload/workload_controller.go
+++ b/pkg/controller/workload/workload_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
@@ -46,6 +47,7 @@ type Controller struct {
 	OperationMetricController *telemetry.BpfProgMetric
 	bpfWorkloadObj            *bpfwl.BpfWorkload
 	dnsResolverController     *dnsController
+	dnsProxyEnabled           atomic.Bool
 }
 
 func NewController(bpfWorkload *bpfwl.BpfWorkload, enableMonitoring, enablePerfMonitor bool) (*Controller, error) {
@@ -82,7 +84,7 @@ func NewController(bpfWorkload *bpfwl.BpfWorkload, enableMonitoring, enablePerfM
 }
 
 func (c *Controller) Run(ctx context.Context, stopCh <-chan struct{}) error {
-	if err := c.Processor.PrepareDNSProxy(); err != nil {
+	if err := c.Processor.PrepareDNSProxy(c.GetDnsProxyTrigger()); err != nil {
 		log.Errorf("failed to prepare for dns proxy, err: %+v", err)
 		return err
 	}
@@ -214,4 +216,12 @@ func (c *Controller) SetConnectionMetricTrigger(enable bool) {
 
 func (c *Controller) GetConnectionMetricTrigger() bool {
 	return c.MetricController.EnableConnectionMetric.Load()
+}
+
+func (c *Controller) SetDnsProxyTrigger(enabled bool) {
+	c.dnsProxyEnabled.Store(enabled)
+}
+
+func (c *Controller) GetDnsProxyTrigger() bool {
+	return c.dnsProxyEnabled.Load()
 }

--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -105,13 +105,13 @@ func (p *Processor) WithResourceHandlers(typeUrl string, h ...func(resp *service
 	return p
 }
 
-func (p *Processor) PrepareDNSProxy() error {
+func (p *Processor) PrepareDNSProxy(enabled bool) error {
 	bk := &bpf.BackendKey{
 		BackendUid: 0,
 	}
 
 	// when dns proxy is not enabled, we unregister kmesh daemon from bpf map
-	if !EnableDNSProxy {
+	if !enabled {
 		return p.bpf.BackendDelete(bk)
 	}
 
@@ -122,8 +122,13 @@ func (p *Processor) PrepareDNSProxy() error {
 
 	log.Infof("dns proxy is enabled and will be redirected, ip: %s", podIp)
 
+	addr, err := netip.ParseAddr(podIp)
+	if err != nil {
+		return fmt.Errorf("failed to parse INSTANCE_IP %q: %v", podIp, err)
+	}
+
 	bv := &bpf.BackendValue{}
-	nets.CopyIpByteFromSlice(&bv.Ip, netip.MustParseAddr(podIp).AsSlice())
+	nets.CopyIpByteFromSlice(&bv.Ip, addr.AsSlice())
 	if err := p.bpf.BackendUpdate(bk, bv); err != nil {
 		log.Errorf("failed to register kmesh daemon ip, err: %+v", err)
 		return err

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -60,6 +60,7 @@ const (
 	patternWorkloadMetrics    = "/workload_metrics"
 	patternConnectionMetrics  = "/connection_metrics"
 	patternAuthz              = "/authz"
+	patternDnsproxy           = "/dnsproxy"
 
 	bpfLoggerName = "bpf"
 
@@ -74,14 +75,16 @@ type Server struct {
 	mux       *http.ServeMux
 	server    *http.Server
 	loader    *bpf.BpfLoader
+	ctrl      *controller.Controller
 }
 
-func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs, loader *bpf.BpfLoader) *Server {
+func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs, loader *bpf.BpfLoader, ctrl *controller.Controller) *Server {
 	s := &Server{
 		config:    configs,
 		xdsClient: c,
 		mux:       http.NewServeMux(),
 		loader:    loader,
+		ctrl:      ctrl,
 	}
 	s.server = &http.Server{
 		Addr:         adminAddr,
@@ -101,6 +104,7 @@ func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs, loade
 	s.mux.HandleFunc(patternWorkloadMetrics, s.workloadMetricHandler)
 	s.mux.HandleFunc(patternConnectionMetrics, s.connectionMetricHandler)
 	s.mux.HandleFunc(patternAuthz, s.authzHandler)
+	s.mux.HandleFunc(patternDnsproxy, s.dnsproxyHandler)
 
 	// TODO: add dump certificate, authorizationPolicies and services
 	s.mux.HandleFunc(patternReadyProbe, s.readyProbe)
@@ -354,6 +358,48 @@ func (s *Server) authzHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) dnsproxyHandler(w http.ResponseWriter, r *http.Request) {
+	if s.ctrl == nil {
+		http.Error(w, "controller not available", http.StatusInternalServerError)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		// Return DNS proxy status
+		status := s.ctrl.GetDnsProxyStatus()
+		w.WriteHeader(http.StatusOK)
+		if status {
+			_, _ = w.Write([]byte("enabled"))
+		} else {
+			_, _ = w.Write([]byte("disabled"))
+		}
+	case http.MethodPost:
+		info := r.URL.Query().Get("enable")
+		enabled, err := strconv.ParseBool(info)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte(fmt.Sprintf("invalid dnsproxy enable=%s", info)))
+			return
+		}
+
+		if enabled {
+			if err := s.ctrl.StartDnsProxy(); err != nil {
+				http.Error(w, fmt.Sprintf("failed to start DNS proxy: %v", err), http.StatusInternalServerError)
+				return
+			}
+		} else {
+			if err := s.ctrl.StopDnsProxy(); err != nil {
+				http.Error(w, fmt.Sprintf("failed to stop DNS proxy: %v", err), http.StatusInternalServerError)
+				return
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	default:
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+	}
 }
 
 func (s *Server) getLoggerNames(w http.ResponseWriter) {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add `--enable-dns-proxy` startup flag and `kmeshctl dnsproxy` command for runtime DNS proxy control.

**Changes:**
> - Added `EnableDnsProxy` field and `--enable-dns-proxy` flag to `BpfConfig`
> - Added `/dnsproxy` HTTP endpoint (GET for status, POST for enable/disable)
> - Added mutex-protected `StartDnsProxy()`/`StopDnsProxy()`/`GetDnsProxyStatus()` with atomic rollback on failure
> - Replaced `netip.MustParseAddr` with safe `netip.ParseAddr`
> - Uses Cobra `RunE` with proper error propagation (no `os.Exit`)
> - Single `PrepareDNSProxy(enabled bool)` — no code duplication
> - Log all BPF cleanup errors instead of silently ignoring
> - Updated deploy YAML and Helm chart to use flag instead of env var
> - Backward compatible: falls back to env var if flag is not set
> - Added `kmeshctl_dnsproxy.md` documentation

**Which issue(s) this PR fixes**:
Fixes #1574

**Special notes for your reviewer**:
Runtime state transitions are mutex-protected with rollback on failure to prevent traffic breakage.

**Does this PR introduce a user-facing change?**:

```release-note
Add --enable-dns-proxy startup flag and kmeshctl dnsproxy command for runtime DNS proxy control.
