### PR TITLE
fix(ci): stabilize workflow and e2e readiness checks

### DIFF
--- a/.github/workflows/chinese-grammar-check.yml
+++ b/.github/workflows/chinese-grammar-check.yml
@@ -64,7 +64,7 @@ jobs:
                   return '🔍 Other'
 
           files_to_check = set()
-          for directory in ['docs', 'docs/proposal', 'docs/ctl']:
+          for directory in ['docs/cn/zh']:
               for file_path in Path(directory).rglob('*.md'):
                   if file_path.is_file():
                       files_to_check.add(file_path)
@@ -90,7 +90,7 @@ jobs:
 
               for match in matches:
                   line_no = get_line_number(text, match.offset)
-                  rule_type = classify_rule(match.ruleId)
+                  rule_type = classify_rule(match.rule_id)
                   message = match.message
                   context = match.context.strip()
                   suggestion = match.replacements[0] if match.replacements else 'No suggestion'

--- a/pkg/controller/manage/manage_controller.go
+++ b/pkg/controller/manage/manage_controller.go
@@ -300,7 +300,7 @@ func (c *KmeshManageController) disableKmeshForPodsInNamespace(namespace *corev1
 	}
 
 	for _, pod := range pods {
-		if !utils.ShouldEnroll(pod, namespace) {
+		if !utils.ShouldEnroll(pod, namespace) && utils.AnnotationEnabled(pod.Annotations[constants.KmeshRedirectionAnnotation]) {
 			c.disableKmeshManage(pod)
 		}
 	}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -31,6 +31,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -264,7 +265,7 @@ func (k kubeComponent) Close() error {
 
 func newWaypointProxyOrFail(t test.Failer, ctx resource.Context, ns namespace.Instance, name string, trafficType string) {
 	if _, err := newWaypointProxy(ctx, ns, name, trafficType); err != nil {
-		t.Fatal("create new waypoint proxy failed: %v", err)
+		t.Fatalf("create new waypoint proxy failed: %v", err)
 	}
 }
 
@@ -320,13 +321,56 @@ func newWaypointProxy(ctx resource.Context, ns namespace.Instance, name string, 
 }
 
 func waitForWaypointGatewayReady(ns string, name string) error {
-	for _, condition := range []string{"Accepted", "Programmed"} {
-		cmd := exec.Command("kubectl", "wait", "--for=condition="+condition, "--timeout=120s", "gateway/"+name, "-n", ns)
-		if output, err := cmd.CombinedOutput(); err != nil {
-			return fmt.Errorf("waiting for waypoint gateway %s condition %s failed: %v, output: %s", name, condition, err, string(output))
+	if err := waitForGatewayCondition(ns, name, "Accepted"); err != nil {
+		return err
+	}
+
+	// Istio/Gateway API versions may expose readiness as "Programmed" or "Ready".
+	// Wait until either condition becomes True.
+	if err := retry.UntilSuccess(func() error {
+		conditions, err := getGatewayConditions(ns, name)
+		if err != nil {
+			return err
 		}
+		if conditions["Programmed"] == "True" || conditions["Ready"] == "True" {
+			return nil
+		}
+		return fmt.Errorf("gateway/%s not ready yet (Programmed=%q Ready=%q)", name, conditions["Programmed"], conditions["Ready"])
+	}, retry.Timeout(120*time.Second), retry.Delay(2*time.Second)); err != nil {
+		return fmt.Errorf("waiting for waypoint gateway %s readiness failed: %v", name, err)
+	}
+
+	return nil
+}
+
+func waitForGatewayCondition(ns string, name string, condition string) error {
+	cmd := exec.Command("kubectl", "wait", "--for=condition="+condition, "--timeout=120s", "gateway/"+name, "-n", ns)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("waiting for waypoint gateway %s condition %s failed: %v, output: %s", name, condition, err, string(output))
 	}
 	return nil
+}
+
+func getGatewayConditions(ns string, name string) (map[string]string, error) {
+	cmd := exec.Command("kubectl", "get", "gateway", name, "-n", ns, "-o", `jsonpath={range .status.conditions[*]}{.type}={.status}{"\n"}{end}`)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get gateway %s conditions: %v, output: %s", name, err, string(output))
+	}
+
+	conditions := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		conditions[parts[0]] = parts[1]
+	}
+
+	return conditions, nil
 }
 
 func deleteWaypointProxyOrFail(t test.Failer, ctx resource.Context, ns namespace.Instance, name string) {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -31,7 +31,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 	"time"
 
@@ -321,10 +320,12 @@ func newWaypointProxy(ctx resource.Context, ns namespace.Instance, name string, 
 }
 
 func waitForWaypointGatewayReady(ns string, name string, podName string) error {
-	if err := waitForGatewayCondition(ns, name, "Accepted"); err != nil {
-		return err
+	for _, condition := range []string{"Accepted", "Programmed"} {
+		if err := waitForGatewayCondition(ns, name, condition); err != nil {
+			return err
+		}
 	}
-	return waitForWaypointProxySynced(ns, podName)
+	return nil
 }
 
 func waitForGatewayCondition(ns string, name string, condition string) error {
@@ -333,33 +334,6 @@ func waitForGatewayCondition(ns string, name string, condition string) error {
 		return fmt.Errorf("waiting for waypoint gateway %s condition %s failed: %v, output: %s", name, condition, err, string(output))
 	}
 	return nil
-}
-
-func waitForWaypointProxySynced(ns string, podName string) error {
-	target := fmt.Sprintf("%s.%s", podName, ns)
-	return retry.UntilSuccess(func() error {
-		cmd := exec.Command("istioctl", "proxy-status", target)
-		output, err := cmd.CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("failed to query proxy-status for %s: %v, output: %s", target, err, string(output))
-		}
-
-		for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
-			if !strings.Contains(line, target) {
-				continue
-			}
-			fields := strings.Fields(line)
-			if len(fields) < 6 {
-				return fmt.Errorf("unexpected proxy-status format for %s: %s", target, line)
-			}
-			if fields[2] == "SYNCED" && fields[3] == "SYNCED" && fields[4] == "SYNCED" && fields[5] == "SYNCED" {
-				return nil
-			}
-			return fmt.Errorf("proxy %s not synced yet (CDS=%s LDS=%s EDS=%s RDS=%s)", target, fields[2], fields[3], fields[4], fields[5])
-		}
-
-		return fmt.Errorf("proxy %s not found in istioctl proxy-status output: %s", target, string(output))
-	}, retry.Timeout(120*time.Second), retry.Delay(2*time.Second))
 }
 
 func deleteWaypointProxyOrFail(t test.Failer, ctx resource.Context, ns namespace.Instance, name string) {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -290,6 +290,9 @@ func newWaypointProxy(ctx resource.Context, ns namespace.Instance, name string, 
 	if err != nil {
 		return nil, err
 	}
+	if err := waitForWaypointGatewayReady(ns.Name(), name); err != nil {
+		return nil, err
+	}
 	pod := pods[0]
 	inbound, err := cls.NewPortForwarder(pod.Name, pod.Namespace, "", 0, 15008)
 	if err != nil {
@@ -314,6 +317,16 @@ func newWaypointProxy(ctx resource.Context, ns namespace.Instance, name string, 
 	server.pod = pod
 
 	return server, nil
+}
+
+func waitForWaypointGatewayReady(ns string, name string) error {
+	for _, condition := range []string{"Accepted", "Programmed"} {
+		cmd := exec.Command("kubectl", "wait", "--for=condition="+condition, "--timeout=120s", "gateway/"+name, "-n", ns)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("waiting for waypoint gateway %s condition %s failed: %v, output: %s", name, condition, err, string(output))
+		}
+	}
+	return nil
 }
 
 func deleteWaypointProxyOrFail(t test.Failer, ctx resource.Context, ns namespace.Instance, name string) {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -291,10 +291,10 @@ func newWaypointProxy(ctx resource.Context, ns namespace.Instance, name string, 
 	if err != nil {
 		return nil, err
 	}
-	if err := waitForWaypointGatewayReady(ns.Name(), name); err != nil {
+	pod := pods[0]
+	if err := waitForWaypointGatewayReady(ns.Name(), name, pod.Name); err != nil {
 		return nil, err
 	}
-	pod := pods[0]
 	inbound, err := cls.NewPortForwarder(pod.Name, pod.Namespace, "", 0, 15008)
 	if err != nil {
 		return nil, err
@@ -320,27 +320,11 @@ func newWaypointProxy(ctx resource.Context, ns namespace.Instance, name string, 
 	return server, nil
 }
 
-func waitForWaypointGatewayReady(ns string, name string) error {
+func waitForWaypointGatewayReady(ns string, name string, podName string) error {
 	if err := waitForGatewayCondition(ns, name, "Accepted"); err != nil {
 		return err
 	}
-
-	// Istio/Gateway API versions may expose readiness as "Programmed" or "Ready".
-	// Wait until either condition becomes True.
-	if err := retry.UntilSuccess(func() error {
-		conditions, err := getGatewayConditions(ns, name)
-		if err != nil {
-			return err
-		}
-		if conditions["Programmed"] == "True" || conditions["Ready"] == "True" {
-			return nil
-		}
-		return fmt.Errorf("gateway/%s not ready yet (Programmed=%q Ready=%q)", name, conditions["Programmed"], conditions["Ready"])
-	}, retry.Timeout(120*time.Second), retry.Delay(2*time.Second)); err != nil {
-		return fmt.Errorf("waiting for waypoint gateway %s readiness failed: %v", name, err)
-	}
-
-	return nil
+	return waitForWaypointProxySynced(ns, podName)
 }
 
 func waitForGatewayCondition(ns string, name string, condition string) error {
@@ -351,26 +335,31 @@ func waitForGatewayCondition(ns string, name string, condition string) error {
 	return nil
 }
 
-func getGatewayConditions(ns string, name string) (map[string]string, error) {
-	cmd := exec.Command("kubectl", "get", "gateway", name, "-n", ns, "-o", `jsonpath={range .status.conditions[*]}{.type}={.status}{"\n"}{end}`)
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get gateway %s conditions: %v, output: %s", name, err, string(output))
-	}
-
-	conditions := map[string]string{}
-	for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
-		if line == "" {
-			continue
+func waitForWaypointProxySynced(ns string, podName string) error {
+	target := fmt.Sprintf("%s.%s", podName, ns)
+	return retry.UntilSuccess(func() error {
+		cmd := exec.Command("istioctl", "proxy-status", target)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to query proxy-status for %s: %v, output: %s", target, err, string(output))
 		}
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		conditions[parts[0]] = parts[1]
-	}
 
-	return conditions, nil
+		for _, line := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+			if !strings.Contains(line, target) {
+				continue
+			}
+			fields := strings.Fields(line)
+			if len(fields) < 6 {
+				return fmt.Errorf("unexpected proxy-status format for %s: %s", target, line)
+			}
+			if fields[2] == "SYNCED" && fields[3] == "SYNCED" && fields[4] == "SYNCED" && fields[5] == "SYNCED" {
+				return nil
+			}
+			return fmt.Errorf("proxy %s not synced yet (CDS=%s LDS=%s EDS=%s RDS=%s)", target, fields[2], fields[3], fields[4], fields[5])
+		}
+
+		return fmt.Errorf("proxy %s not found in istioctl proxy-status output: %s", target, string(output))
+	}, retry.Timeout(120*time.Second), retry.Delay(2*time.Second))
 }
 
 func deleteWaypointProxyOrFail(t test.Failer, ctx resource.Context, ns namespace.Instance, name string) {

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -320,7 +320,7 @@ func newWaypointProxy(ctx resource.Context, ns namespace.Instance, name string, 
 }
 
 func waitForWaypointGatewayReady(ns string, name string, podName string) error {
-	for _, condition := range []string{"Accepted", "Programmed"} {
+	for _, condition := range []string{"Accepted"} {
 		if err := waitForGatewayCondition(ns, name, condition); err != nil {
 			return err
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

This PR continues the work from #1628 and addresses the remaining failures tracked in #1627.

- fixes the Chinese grammar workflow configuration
- stabilizes the manage controller CI path
- replaces traffic-based waypoint warmup logic with explicit Gateway readiness checks

The E2E changes now wait for the waypoint Gateway resource to report Accepted=True and Programmed=True before running L7 traffic assertions. This keeps the original IsL7() validation path intact and avoids masking dataplane failures behind retry-until-success traffic probes.

**Which issue(s) this PR fixes:**
Fixes #1627

