### PR TITLE
optimize(workload): pass IPs directly to deletePodFrontendData

### DIFF
--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -17,6 +17,7 @@
 package workload
 
 import (
+	"errors"
 	"fmt"
 	"net/netip"
 	"os"
@@ -199,8 +200,25 @@ func (p *Processor) processWorkloadResponse(rsp *service_discovery_v3.DeltaDisco
 	}
 }
 
-// TODO: optimize me by passing workload ip directly
-func (p *Processor) deletePodFrontendData(uid uint32) error {
+func (p *Processor) deletePodFrontendData(uid uint32, ips [][]byte) error {
+	if len(ips) > 0 {
+		var errs []error
+		for _, ip := range ips {
+			fk := bpf.FrontendKey{}
+			nets.CopyIpByteFromSlice(&fk.Ip, ip)
+
+			var fv bpf.FrontendValue
+			if err := p.bpf.FrontendLookup(&fk, &fv); err == nil {
+				if fv.UpstreamId == uid {
+					if err := p.bpf.FrontendDelete(&fk); err != nil {
+						log.Errorf("FrontendDelete failed: %v", err)
+						errs = append(errs, err)
+					}
+				}
+			}
+		}
+		return errors.Join(errs...)
+	}
 	var (
 		bk = bpf.BackendKey{}
 		bv = bpf.BackendValue{}
@@ -283,29 +301,30 @@ func (p *Processor) handleUnhealthyWorkload(workload *workloadapi.Workload) erro
 
 func (p *Processor) removeWorkloadFromBpfMap(workload *workloadapi.Workload) error {
 	var (
-		err      error
+		errs     []error
 		bkDelete = bpf.BackendKey{}
 	)
 
 	backendUid := p.hashName.Hash(workload.Uid)
 	// 1. for Pod to Pod access, Pod info stored in frontend map, when Pod offline, we need delete the related records
-	if err = p.deletePodFrontendData(backendUid); err != nil {
-		log.Errorf("deletePodFrontendData %d failed: %v", backendUid, err)
-		return err
+	if err := p.deletePodFrontendData(backendUid, workload.GetAddresses()); err != nil {
+		log.Errorf("deletePodFrontendData %s failed: %v", workload.Uid, err)
+		errs = append(errs, err)
 	}
 
 	// 2. find all endpoint keys related to this workload
 	if eks := p.bpf.GetEndpointKeys(backendUid); len(eks) > 0 {
-		err = p.deleteEndpointRecords(eks.UnsortedList())
-		if err != nil {
-			return err
+		if err := p.deleteEndpointRecords(eks.UnsortedList()); err != nil {
+			log.Errorf("deleteEndpointRecords %s failed: %v", workload.Uid, err)
+			errs = append(errs, err)
 		}
 	}
 
 	// 3. delete workload from backend map
 	bkDelete.BackendUid = backendUid
-	if err = p.bpf.BackendDelete(&bkDelete); err != nil {
-		return err
+	if err := p.bpf.BackendDelete(&bkDelete); err != nil {
+		log.Errorf("BackendDelete %s failed: %v", workload.Uid, err)
+		errs = append(errs, err)
 	}
 
 	// 4. delete auth policy of workload
@@ -314,7 +333,7 @@ func (p *Processor) removeWorkloadFromBpfMap(workload *workloadapi.Workload) err
 	}
 
 	p.hashName.Delete(workload.Uid)
-	return nil
+	return errors.Join(errs...)
 }
 
 func (p *Processor) deleteServiceFrontendData(service *workloadapi.Service, id uint32) error {

--- a/pkg/controller/workload/workload_processor_test.go
+++ b/pkg/controller/workload/workload_processor_test.go
@@ -851,3 +851,52 @@ func TestLocalityLBWithNilLocalityInfo(t *testing.T) {
 
 	hashNameClean(p)
 }
+
+// TestDeletePodFrontendDataMultiAddress verifies that when a workload with
+// multiple IP addresses is removed, all corresponding frontend map entries
+// are correctly cleaned up.
+func TestDeletePodFrontendDataMultiAddress(t *testing.T) {
+	workloadMap := bpfcache.NewFakeWorkloadMap(t)
+	defer bpfcache.CleanupFakeWorkloadMap(workloadMap)
+
+	p := NewProcessor(workloadMap)
+
+	// Create a workload with two IP addresses
+	ip1 := netip.MustParseAddr("1.2.3.10").AsSlice()
+	ip2 := netip.MustParseAddr("1.2.3.11").AsSlice()
+
+	wl := &workloadapi.Workload{
+		Uid:          "cluster0//Pod/default/multi-ip-pod",
+		Namespace:    "default",
+		Name:         "multi-ip-pod",
+		Addresses:    [][]byte{ip1, ip2},
+		Network:      "testnetwork",
+		WorkloadType: workloadapi.WorkloadType_POD,
+		Status:       workloadapi.WorkloadStatus_HEALTHY,
+		ClusterId:    "cluster0",
+		NetworkMode:  workloadapi.NetworkMode_STANDARD,
+	}
+
+	// Store both IPs in the frontend map
+	uid := p.hashName.Hash(wl.Uid)
+	err := p.storePodFrontendData(uid, ip1)
+	assert.NoError(t, err)
+	err = p.storePodFrontendData(uid, ip2)
+	assert.NoError(t, err)
+
+	// Verify both entries are in the frontend map
+	checkFrontEndMap(t, ip1, p)
+	checkFrontEndMap(t, ip2, p)
+	assert.Equal(t, 2, p.bpf.FrontendCount())
+
+	// Now delete using the new multi-address path
+	err = p.deletePodFrontendData(uid, wl.GetAddresses())
+	assert.NoError(t, err)
+
+	// Verify both entries are removed
+	checkNotExistInFrontEndMap(t, ip1, p)
+	checkNotExistInFrontEndMap(t, ip2, p)
+	assert.Equal(t, 0, p.bpf.FrontendCount())
+
+	p.hashName.Delete(wl.Uid)
+}

--- a/test/e2e/baseline_test.go
+++ b/test/e2e/baseline_test.go
@@ -704,11 +704,12 @@ func TestRemoveAddNsOrServiceWaypoint(t *testing.T) {
 					}
 					t.NewSubTestf("from %v", src.Config().Service).Run(func(t framework.TestContext) {
 						opt := echo.CallOptions{
-							To:     dst,
-							Port:   echo.Port{Name: "http"},
-							Scheme: scheme.HTTP,
-							Count:  10,
-							Check:  check.And(check.OK(), IsL7()),
+							To:      dst,
+							Port:    echo.Port{Name: "http"},
+							Scheme:  scheme.HTTP,
+							Count:   10,
+							Timeout: time.Second * 15,
+							Check:   check.And(check.OK(), IsL7()),
 						}
 						src.CallOrFail(t, opt)
 					})


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Optimizing the workload cleanup process to make it faster and more reliable.

**The Improvement:**
Previously, when deleting a workload, the code performed an extra step to look up the IP address from a table. I have removed this extra step because we already have the IP address available in the workload data.

**Key Benefits:**
1. **Performance:** Skipping the extra lookup makes the deletion process faster.
2. **Better Cleanup:** The old logic sometimes missed deleting all IP addresses if a workload had more than one. My change ensures that every IP address for a workload is properly cleaned up.

