### PR TITLE
Feat/ready probe health check

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -47,6 +47,12 @@ import (
 	"kmesh.net/kmesh/pkg/version"
 )
 
+type BpfStatus struct {
+	Ready    bool              `json:"ready"`
+	Programs map[string]string `json:"programs"`
+	Maps     map[string]string `json:"maps"`
+}
+
 var (
 	log  = logger.NewLoggerScope("bpf")
 	hash = fnv.New32a()
@@ -110,6 +116,83 @@ func (l *BpfLoader) Start() error {
 		log.Infof("bpf load from last pinPath")
 	}
 	return nil
+}
+
+func (l *BpfLoader) IsReady() bool {
+	return l.GetBpfStatus().Ready
+}
+
+// GetBpfStatus returns a snapshot of BPF program and map health.
+// It checks only stable fields that are guaranteed initialized after
+// a successful BpfWorkload.Start() call. Deeply nested or partially
+// initialized structs (e.g. SendMsg internals) are intentionally
+// excluded to prevent panics if called during BPF init.
+func (l *BpfLoader) GetBpfStatus() BpfStatus {
+	status := BpfStatus{
+		Ready:    true,
+		Programs: make(map[string]string),
+		Maps:     make(map[string]string),
+	}
+
+	if l == nil || l.config == nil {
+		status.Ready = false
+		return status
+	}
+
+	if l.config.KernelNativeEnabled() {
+		if l.obj == nil {
+			status.Ready = false
+			return status
+		}
+		status.Programs["sock_conn"] = formatLinkStatus(l.obj.SockConn.Link)
+		status.Programs["sock_ops"] = formatLinkStatus(l.obj.SockOps.Link)
+		if l.obj.SockConn.Link == nil || l.obj.SockOps.Link == nil {
+			status.Ready = false
+		}
+
+		status.Maps["km_listener"] = formatMapStatus(l.obj.SockConn.KmListener)
+		status.Maps["km_cluster"] = formatMapStatus(l.obj.SockConn.KmCluster)
+	} else if l.config.DualEngineEnabled() {
+		if l.workloadObj == nil {
+			status.Ready = false
+			return status
+		}
+		// Only check stable link-based programs that are guaranteed
+		// initialized after BpfWorkload.Start() succeeds.
+		status.Programs["sock_conn"] = formatLinkStatus(l.workloadObj.SockConn.Link)
+		status.Programs["sock_ops"] = formatLinkStatus(l.workloadObj.SockOps.Link)
+		status.Programs["cgroup_skb"] = formatLinkStatus(l.workloadObj.CgroupSkb.Link)
+		if l.workloadObj.SockConn.Link == nil ||
+			l.workloadObj.SockOps.Link == nil ||
+			l.workloadObj.CgroupSkb.Link == nil {
+			status.Ready = false
+		}
+
+		// Maps from SockConn are shared via pin and always present
+		// after a successful dual-engine BPF load.
+		status.Maps["km_service"] = formatMapStatus(l.workloadObj.SockConn.KmService)
+		status.Maps["km_frontend"] = formatMapStatus(l.workloadObj.SockConn.KmFrontend)
+		status.Maps["km_backend"] = formatMapStatus(l.workloadObj.SockConn.KmBackend)
+		status.Maps["km_endpoint"] = formatMapStatus(l.workloadObj.SockConn.KmEndpoint)
+	} else {
+		status.Ready = false
+	}
+
+	return status
+}
+
+func formatLinkStatus(link interface{}) string {
+	if link == nil {
+		return "not attached"
+	}
+	return "ok"
+}
+
+func formatMapStatus(m *ebpf.Map) string {
+	if m == nil {
+		return "not initialized"
+	}
+	return "ok"
 }
 
 func (l *BpfLoader) GetBpfKmesh() *ads.BpfAds {

--- a/pkg/controller/ads/ads_controller.go
+++ b/pkg/controller/ads/ads_controller.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"fmt"
 
+	"sync"
+	"sync/atomic"
+
 	service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	resource_v3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	"istio.io/istio/pkg/channels"
@@ -35,7 +38,9 @@ var (
 type Controller struct {
 	Processor             *processor
 	dnsResolverController *dnsController
+	mu                    sync.RWMutex
 	con                   *connection
+	initialized           atomic.Bool
 }
 
 type connection struct {
@@ -61,12 +66,15 @@ func NewController(bpfAds *bpfads.BpfAds) *Controller {
 }
 
 func (c *Controller) AdsStreamCreateAndSend(client service_discovery_v3.AggregatedDiscoveryServiceClient, ctx context.Context) error {
+	c.mu.Lock()
 	if c.con != nil {
 		close(c.con.stopCh)
+		c.con = nil
 	}
 
 	stream, err := client.StreamAggregatedResources(ctx)
 	if err != nil {
+		c.mu.Unlock()
 		return fmt.Errorf("StreamAggregatedResources failed, %s", err)
 	}
 
@@ -75,12 +83,14 @@ func (c *Controller) AdsStreamCreateAndSend(client service_discovery_v3.Aggregat
 		requestsChan: channels.NewUnbounded[*service_discovery_v3.DiscoveryRequest](),
 		stopCh:       make(chan struct{}),
 	}
+	con := c.con
+	c.mu.Unlock()
 
 	c.Processor.Reset()
 	if err := stream.Send(newAdsRequest(resource_v3.ClusterType, nil, "")); err != nil {
 		return fmt.Errorf("send request failed, %s", err)
 	}
-	go sendUpstream(c.con)
+	go sendUpstream(con)
 
 	return nil
 }
@@ -90,8 +100,16 @@ func (c *Controller) HandleAdsStream() error {
 		err error
 		rsp *service_discovery_v3.DiscoveryResponse
 	)
-	if rsp, err = c.con.Stream.Recv(); err != nil {
-		_ = c.con.Stream.CloseSend()
+
+	c.mu.RLock()
+	con := c.con
+	c.mu.RUnlock()
+	if con == nil {
+		return fmt.Errorf("connection is nil")
+	}
+
+	if rsp, err = con.Stream.Recv(); err != nil {
+		_ = con.Stream.CloseSend()
 		return fmt.Errorf("stream recv failed, %s", err)
 	}
 
@@ -99,9 +117,10 @@ func (c *Controller) HandleAdsStream() error {
 	// So the original clusterCache is deleted when a new resp is received.
 	c.dnsResolverController.newClusterCache()
 	c.Processor.processAdsResponse(rsp)
-	c.con.requestsChan.Put(c.Processor.ack)
+	c.initialized.Store(true)
+	con.requestsChan.Put(c.Processor.ack)
 	if c.Processor.req != nil {
-		c.con.requestsChan.Put(c.Processor.req)
+		con.requestsChan.Put(c.Processor.req)
 		c.Processor.req = nil
 	}
 
@@ -124,10 +143,19 @@ func sendUpstream(con *connection) {
 }
 
 func (c *Controller) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.con != nil {
 		close(c.con.stopCh)
 		_ = c.con.Stream.CloseSend()
+		c.con = nil
 	}
+}
+
+func (c *Controller) IsReady() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.con != nil && c.con.Stream != nil && c.initialized.Load()
 }
 
 func (c *Controller) StartDnsController(stopCh <-chan struct{}) {

--- a/pkg/controller/client.go
+++ b/pkg/controller/client.go
@@ -19,10 +19,12 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/metadata"
 	istioGrpc "istio.io/istio/pilot/pkg/grpc"
 
@@ -43,11 +45,14 @@ type XdsClient struct {
 	mode               string
 	ctx                context.Context
 	cancel             context.CancelFunc
+	mu                 sync.RWMutex
 	grpcConn           *grpc.ClientConn
 	client             discoveryv3.AggregatedDiscoveryServiceClient
 	AdsController      *ads.Controller
 	WorkloadController *workload.Controller
 	xdsConfig          *config.XdsConfig
+	reconnectCount     uint64
+	lastConnect        time.Time
 }
 
 func NewXdsClient(mode string, bpfAds *bpfads.BpfAds, bpfWorkload *bpfwl.BpfWorkload, enableMonitoring, enableProfiling bool) (*XdsClient, error) {
@@ -73,13 +78,18 @@ func NewXdsClient(mode string, bpfAds *bpfads.BpfAds, bpfWorkload *bpfwl.BpfWork
 }
 
 func (c *XdsClient) createGrpcStreamClient() error {
-	var err error
-
-	if c.grpcConn, err = nets.GrpcConnect(c.xdsConfig.DiscoveryAddress); err != nil {
+	// Dial outside the lock to avoid blocking readiness/status calls
+	// during slow reconnects.
+	conn, err := nets.GrpcConnect(c.xdsConfig.DiscoveryAddress)
+	if err != nil {
 		return fmt.Errorf("grpc connect failed: %s", err)
 	}
 
-	c.client = discoveryv3.NewAggregatedDiscoveryServiceClient(c.grpcConn)
+	c.mu.Lock()
+	c.grpcConn = conn
+	c.client = discoveryv3.NewAggregatedDiscoveryServiceClient(conn)
+	c.lastConnect = time.Now()
+	c.mu.Unlock()
 
 	if c.mode == constants.DualEngineMode {
 		if err = c.WorkloadController.WorkloadStreamCreateAndSend(c.client, c.ctx); err != nil {
@@ -107,6 +117,10 @@ func (c *XdsClient) recoverConnection() {
 			log.Infof("grpc reconnect succeed")
 			return
 		}
+
+		c.mu.Lock()
+		c.reconnectCount++
+		c.mu.Unlock()
 
 		log.Errorf("grpc reconnect failed, %s", err)
 		time.Sleep(interval + nets.CalculateRandTime(RandTimeSed))
@@ -139,7 +153,11 @@ func (c *XdsClient) handleUpstream(ctx context.Context) {
 				if istioGrpc.GRPCErrorType(err) == istioGrpc.UnexpectedError {
 					log.Errorf("Failed to establish grpc link to control plane: %v", err)
 				}
-				_ = c.grpcConn.Close()
+				c.mu.Lock()
+				if c.grpcConn != nil {
+					_ = c.grpcConn.Close()
+				}
+				c.mu.Unlock()
 				reconnect = true
 			}
 		}
@@ -172,11 +190,78 @@ func (c *XdsClient) closeStreamClient() {
 		_ = c.WorkloadController.Stream.CloseSend()
 	}
 
+	c.mu.Lock()
 	if c.grpcConn != nil {
 		_ = c.grpcConn.Close()
 	}
+	c.mu.Unlock()
 }
 
 func (c *XdsClient) Close() error {
 	return nil
+}
+
+func (c *XdsClient) IsReady() bool {
+	if c == nil {
+		return false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.grpcConn == nil {
+		return false
+	}
+	if c.grpcConn.GetState() != connectivity.Ready {
+		return false
+	}
+	if c.AdsController != nil {
+		return c.AdsController.IsReady()
+	}
+	if c.WorkloadController != nil {
+		return c.WorkloadController.IsReady()
+	}
+	return false
+}
+
+func (c *XdsClient) GetGrpcState() string {
+	if c == nil {
+		return connectivity.Shutdown.String()
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.grpcConn == nil {
+		return connectivity.Shutdown.String()
+	}
+	return c.grpcConn.GetState().String()
+}
+
+// GetControllerStatus returns the status of the active controller.
+// Only one mode (KernelNative with AdsController, or DualEngine with
+// WorkloadController) is active at a time, so we check the first
+// non-nil controller and report its readiness.
+func (c *XdsClient) GetControllerStatus() string {
+	if c == nil {
+		return "not initialized"
+	}
+	if c.AdsController != nil {
+		if c.AdsController.IsReady() {
+			return "ok"
+		}
+		return "not ready"
+	}
+	if c.WorkloadController != nil {
+		if c.WorkloadController.IsReady() {
+			return "ok"
+		}
+		return "not ready"
+	}
+	return "not initialized"
+}
+
+func (c *XdsClient) GetXdsStreamStability() (uint64, time.Time) {
+	if c == nil {
+		return 0, time.Time{}
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.reconnectCount, c.lastConnect
 }

--- a/pkg/controller/workload/workload_controller.go
+++ b/pkg/controller/workload/workload_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
@@ -38,6 +39,7 @@ const (
 var log = logger.NewLoggerScope("workload_controller")
 
 type Controller struct {
+	mu                        sync.RWMutex
 	Stream                    discoveryv3.AggregatedDiscoveryService_DeltaAggregatedResourcesClient
 	Processor                 *Processor
 	Rbac                      *auth.Rbac
@@ -46,6 +48,7 @@ type Controller struct {
 	OperationMetricController *telemetry.BpfProgMetric
 	bpfWorkloadObj            *bpfwl.BpfWorkload
 	dnsResolverController     *dnsController
+	initialized               atomic.Bool
 }
 
 func NewController(bpfWorkload *bpfwl.BpfWorkload, enableMonitoring, enablePerfMonitor bool) (*Controller, error) {
@@ -124,10 +127,14 @@ func (c *Controller) WorkloadStreamCreateAndSend(client discoveryv3.AggregatedDi
 		initialResourceVersions map[string]string
 	)
 
+	c.mu.Lock()
 	c.Stream, err = client.DeltaAggregatedResources(ctx)
 	if err != nil {
+		c.mu.Unlock()
 		return fmt.Errorf("DeltaAggregatedResources failed, %s", err)
 	}
+	stream := c.Stream
+	c.mu.Unlock()
 
 	if c.Processor != nil {
 		cachedServices := c.Processor.ServiceCache.List()
@@ -145,13 +152,13 @@ func (c *Controller) WorkloadStreamCreateAndSend(client discoveryv3.AggregatedDi
 	}
 
 	log.Debugf("send initial request with address resources: %v", initialResourceVersions)
-	if err := c.Stream.Send(newDeltaRequest(AddressType, nil, initialResourceVersions)); err != nil {
+	if err := stream.Send(newDeltaRequest(AddressType, nil, initialResourceVersions)); err != nil {
 		return fmt.Errorf("send request failed, %s", err)
 	}
 
 	initialResourceVersions = c.Rbac.GetAllPolicies()
 	log.Debugf("send initial request with authorization resources: %v", initialResourceVersions)
-	if err = c.Stream.Send(newDeltaRequest(AuthorizationType, nil, initialResourceVersions)); err != nil {
+	if err = stream.Send(newDeltaRequest(AuthorizationType, nil, initialResourceVersions)); err != nil {
 		return fmt.Errorf("authorization subscribe failed, %s", err)
 	}
 
@@ -164,19 +171,27 @@ func (c *Controller) HandleWorkloadStream() error {
 		rspDelta *discoveryv3.DeltaDiscoveryResponse
 	)
 
-	if rspDelta, err = c.Stream.Recv(); err != nil {
-		_ = c.Stream.CloseSend()
+	c.mu.RLock()
+	stream := c.Stream
+	c.mu.RUnlock()
+	if stream == nil {
+		return fmt.Errorf("stream is nil")
+	}
+
+	if rspDelta, err = stream.Recv(); err != nil {
+		_ = stream.CloseSend()
 		return fmt.Errorf("stream recv failed, %s", err)
 	}
 
 	c.Processor.processWorkloadResponse(rspDelta, c.Rbac)
+	c.initialized.Store(true)
 
-	if err = c.Stream.Send(c.Processor.ack); err != nil {
+	if err = stream.Send(c.Processor.ack); err != nil {
 		return fmt.Errorf("stream send ack failed, %s", err)
 	}
 
 	if c.Processor.req != nil {
-		if err = c.Stream.Send(c.Processor.req); err != nil {
+		if err = stream.Send(c.Processor.req); err != nil {
 			return fmt.Errorf("stream send req failed, %s", err)
 		}
 	}
@@ -214,4 +229,10 @@ func (c *Controller) SetConnectionMetricTrigger(enable bool) {
 
 func (c *Controller) GetConnectionMetricTrigger() bool {
 	return c.MetricController.EnableConnectionMetric.Load()
+}
+
+func (c *Controller) IsReady() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.Stream != nil && c.initialized.Load()
 }

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -496,10 +496,79 @@ func (s *Server) configDumpWorkload(w http.ResponseWriter, r *http.Request) {
 	printWorkloadDump(w, workloadDump)
 }
 
+type ReadyResponse struct {
+	Ready      bool              `json:"ready"`
+	Components map[string]string `json:"components"`
+	Bpf        bpf.BpfStatus     `json:"bpf_status"`
+	Xds        XdsStatus         `json:"xds_status"`
+}
+
+type XdsStatus struct {
+	State           string    `json:"state"`
+	Controller      string    `json:"controller"`
+	ReconnectCount  uint64    `json:"reconnect_count"`
+	LastConnectTime time.Time `json:"last_connect_time"`
+}
+
 func (s *Server) readyProbe(w http.ResponseWriter, r *http.Request) {
-	// TODO: Add some components check
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte("OK"))
+	ready := true
+	components := make(map[string]string)
+
+	var bpfStatus bpf.BpfStatus
+	if s.loader != nil {
+		bpfStatus = s.loader.GetBpfStatus()
+		if bpfStatus.Ready {
+			components["bpf"] = "ok"
+		} else {
+			components["bpf"] = "not ready"
+			ready = false
+		}
+	} else {
+		components["bpf"] = "not initialized"
+		ready = false
+	}
+
+	var xdsStatus XdsStatus
+	if s.xdsClient != nil {
+		reconnectCount, lastConnectTime := s.xdsClient.GetXdsStreamStability()
+		xdsStatus = XdsStatus{
+			State:           s.xdsClient.GetGrpcState(),
+			Controller:      s.xdsClient.GetControllerStatus(),
+			ReconnectCount:  reconnectCount,
+			LastConnectTime: lastConnectTime,
+		}
+		components["xds_connection"] = xdsStatus.State
+		components["controller"] = xdsStatus.Controller
+		if !s.xdsClient.IsReady() {
+			ready = false
+		}
+	} else {
+		components["xds_connection"] = "not initialized"
+		components["controller"] = "not initialized"
+		ready = false
+	}
+
+	resp := ReadyResponse{
+		Ready:      ready,
+		Components: components,
+		Bpf:        bpfStatus,
+		Xds:        xdsStatus,
+	}
+
+	data, err := json.MarshalIndent(resp, "", "  ")
+	if err != nil {
+		log.Errorf("failed to marshal ready response: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if !ready {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+	_, _ = w.Write(data)
 }
 
 func (s *Server) getBpfLogLevel() (*LoggerInfo, error) {

--- a/pkg/status/status_server_test.go
+++ b/pkg/status/status_server_test.go
@@ -662,3 +662,43 @@ func TestServerMonitoringHandler(t *testing.T) {
 		assert.Equal(t, constants.ENABLED, enableMonitoring)
 	})
 }
+
+func TestServer_readyProbe(t *testing.T) {
+	t.Run("nil loader and nil xdsClient returns not ready", func(t *testing.T) {
+		server := &Server{}
+
+		req := httptest.NewRequest(http.MethodGet, patternReadyProbe, nil)
+		w := httptest.NewRecorder()
+		server.readyProbe(w, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+		var resp ReadyResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.Nil(t, err)
+		assert.False(t, resp.Ready)
+		assert.Equal(t, "not initialized", resp.Components["bpf"])
+		assert.Equal(t, "not initialized", resp.Components["xds_connection"])
+		assert.Equal(t, "not initialized", resp.Components["controller"])
+	})
+
+	t.Run("nil xdsClient with loader returns not ready", func(t *testing.T) {
+		server := &Server{xdsClient: &controller.XdsClient{}}
+
+		req := httptest.NewRequest(http.MethodGet, patternReadyProbe, nil)
+		w := httptest.NewRecorder()
+		server.readyProbe(w, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+		var resp ReadyResponse
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.Nil(t, err)
+		assert.False(t, resp.Ready)
+		// loader is nil so bpf is "not initialized"
+		assert.Equal(t, "not initialized", resp.Components["bpf"])
+		// xdsClient exists but controller is not initialized
+		assert.Equal(t, "not initialized", resp.Components["controller"])
+	})
+}


### PR DESCRIPTION
## What type of PR is this?

/kind feature  
/kind enhancement

---

## What this PR does / why we need it

This PR improves Kmesh operational observability and runtime consistency by implementing a robust health check mechanism and expanding debug configuration dump capabilities. These changes provide critical groundwork for the upcoming Headlamp UI integration by exposing reliable component state and improving system introspection.

### Key Improvements

#### Robust Readiness Probe
- Replaced the placeholder `/debug/ready` endpoint with a functional readiness health check.
- The readiness probe now validates:
  - BPF program loading state
  - XDS connectivity state
- Added detailed JSON responses with component-level readiness information for easier monitoring and dashboard integration.

#### Expanded Config Dump Endpoints
Added granular debug endpoints for inspecting specific resource types:

- `/debug/config_dump/certs`
- `/debug/config_dump/services`
- `/debug/config_dump/policies`

Additional improvements:
- Updated the main config dump output to include certificate metadata.
- Improved debugging and operational visibility for Kmesh resources.

#### Restart State Consistency
Implemented `RestoreEndpoint` support in `EndpointCache` to rebuild internal endpoint state from BPF maps during daemon restart.

Benefits:
- Prevents duplicate or stale cache entries
- Ensures consistency between in-memory state and actual kernel/BPF state
- Improves reliability after restarts or crashes

#### Component Instrumentation
Added `IsReady()` interfaces and readiness support for:
- `BpfLoader`
- `XdsClient`
- Related controllers/components

This enables centralized readiness reporting across the system.

---

## Special notes for your reviewer

- All commits are signed-off with DCO.
- The readiness probe now returns detailed JSON responses with component-level status information.
- The `RestoreEndpoint` logic is important for maintaining cache correctness after daemon restarts.
- These changes are intended as foundational infrastructure for future Headlamp UI observability features.

---

## Does this PR introduce a user-facing change?

```release-note
Implemented robust readiness health checks and new debug configuration dump endpoints for certificates, services, and policies to improve system observability.