### PR TITLE
feat(status): add config dump endpoints for certificates, policies

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -112,16 +112,16 @@ func (c *Controller) Start(stopCh <-chan struct{}) error {
 		tcFd = -1
 	}
 
+	var secretManager *security.SecretManager
 	if c.mode == constants.DualEngineMode {
-		var secertManager *security.SecretManager
 		if c.enableSecretManager {
-			secertManager, err = security.NewSecretManager()
+			secretManager, err = security.NewSecretManager()
 			if err != nil {
 				return fmt.Errorf("secretManager create failed: %v", err)
 			}
-			go secertManager.Run(stopCh)
+			go secretManager.Run(stopCh)
 		}
-		kmeshManageController, err = manage.NewKmeshManageController(clientset, secertManager, c.bpfWorkloadObj.XdpAuth.XdpAuthz.FD(), tcFd, c.mode)
+		kmeshManageController, err = manage.NewKmeshManageController(clientset, secretManager, c.bpfWorkloadObj.XdpAuth.XdpAuthz.FD(), tcFd, c.mode)
 	} else {
 		kolog.KmeshModuleLog(stopCh)
 		kmeshManageController, err = manage.NewKmeshManageController(clientset, nil, -1, tcFd, c.mode)
@@ -172,6 +172,7 @@ func (c *Controller) Start(stopCh <-chan struct{}) error {
 	}
 
 	if c.client.WorkloadController != nil {
+		c.client.WorkloadController.SecretManager = secretManager
 		if err := c.client.WorkloadController.Run(ctx, stopCh); err != nil {
 			return fmt.Errorf("failed to start workload controller: %+v", err)
 		}

--- a/pkg/controller/security/manager.go
+++ b/pkg/controller/security/manager.go
@@ -257,3 +257,16 @@ func (s *SecretManager) retryFetchCert(identity string) {
 
 	go s.fetchCert(identity)
 }
+
+// ListCerts returns a snapshot of all cached certificates.
+func (s *SecretManager) ListCerts() map[string]*istiosecurity.SecretItem {
+	s.certsCache.mu.RLock()
+	defer s.certsCache.mu.RUnlock()
+	result := make(map[string]*istiosecurity.SecretItem, len(s.certsCache.certs))
+	for identity, item := range s.certsCache.certs {
+		if item.cert != nil {
+			result[identity] = item.cert
+		}
+	}
+	return result
+}

--- a/pkg/controller/security/manager_test.go
+++ b/pkg/controller/security/manager_test.go
@@ -190,3 +190,52 @@ func runTestretryFetchCert(t *testing.T) {
 
 	close(stopCh)
 }
+
+func TestListCerts(t *testing.T) {
+	t.Run("empty cache returns empty map", func(t *testing.T) {
+		sm := &SecretManager{
+			certsCache: newCertCache(),
+		}
+		result := sm.ListCerts()
+		assert.NotNil(t, result)
+		assert.Equal(t, 0, len(result))
+	})
+
+	t.Run("returns only certs with non-nil cert field", func(t *testing.T) {
+		sm := &SecretManager{
+			certsCache: newCertCache(),
+		}
+		now := time.Now()
+		sm.certsCache.certs["identity1"] = &certItem{
+			cert: &security.SecretItem{
+				ResourceName:     "identity1",
+				CertificateChain: []byte("chain1"),
+				ExpireTime:       now.Add(2 * time.Hour),
+				CreatedTime:      now,
+			},
+			refCnt: 1,
+		}
+		// nil cert should be filtered out
+		sm.certsCache.certs["identity2"] = &certItem{
+			cert:   nil,
+			refCnt: 1,
+		}
+		sm.certsCache.certs["identity3"] = &certItem{
+			cert: &security.SecretItem{
+				ResourceName:     "identity3",
+				CertificateChain: []byte("chain3"),
+				ExpireTime:       now.Add(4 * time.Hour),
+				CreatedTime:      now,
+			},
+			refCnt: 2,
+		}
+
+		result := sm.ListCerts()
+		assert.Equal(t, 2, len(result))
+		assert.NotNil(t, result["identity1"])
+		assert.Nil(t, result["identity2"])
+		assert.NotNil(t, result["identity3"])
+		assert.Equal(t, "identity1", result["identity1"].ResourceName)
+		assert.Equal(t, "identity3", result["identity3"].ResourceName)
+	})
+}

--- a/pkg/controller/security/testing.go
+++ b/pkg/controller/security/testing.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package security
+
+import (
+	istiosecurity "istio.io/istio/pkg/security"
+)
+
+// NewTestSecretManager creates a SecretManager with pre-populated certificates for testing.
+func NewTestSecretManager(certs map[string]*istiosecurity.SecretItem) *SecretManager {
+	sm := &SecretManager{
+		certsCache: newCertCache(),
+	}
+	for identity, cert := range certs {
+		sm.certsCache.certs[identity] = &certItem{
+			cert:   cert,
+			refCnt: 1,
+		}
+	}
+	return sm
+}

--- a/pkg/controller/workload/workload_controller.go
+++ b/pkg/controller/workload/workload_controller.go
@@ -26,6 +26,7 @@ import (
 	"kmesh.net/kmesh/pkg/auth"
 	"kmesh.net/kmesh/pkg/bpf/restart"
 	bpfwl "kmesh.net/kmesh/pkg/bpf/workload"
+	"kmesh.net/kmesh/pkg/controller/security"
 	"kmesh.net/kmesh/pkg/controller/telemetry"
 	"kmesh.net/kmesh/pkg/logger"
 )
@@ -41,6 +42,7 @@ type Controller struct {
 	Stream                    discoveryv3.AggregatedDiscoveryService_DeltaAggregatedResourcesClient
 	Processor                 *Processor
 	Rbac                      *auth.Rbac
+	SecretManager             *security.SecretManager
 	MetricController          *telemetry.MetricController
 	MapMetricController       *telemetry.MapMetricController
 	OperationMetricController *telemetry.BpfProgMetric

--- a/pkg/status/api.go
+++ b/pkg/status/api.go
@@ -21,6 +21,9 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"time"
+
+	istiosecurity "istio.io/istio/pkg/security"
 
 	"kmesh.net/kmesh/api/v2/workloadapi"
 	"kmesh.net/kmesh/api/v2/workloadapi/security"
@@ -28,6 +31,27 @@ import (
 	"kmesh.net/kmesh/pkg/nets"
 	"kmesh.net/kmesh/pkg/utils"
 )
+
+// Certificate represents a cached TLS certificate for config dump output.
+type Certificate struct {
+	ResourceName     string    `json:"resourceName"`
+	CertificateChain string    `json:"certificateChain"`
+	ExpireTime       time.Time `json:"expireTime"`
+	CreatedTime      time.Time `json:"createdTime"`
+}
+
+// ConvertSecretItem converts an Istio SecretItem into a Certificate for JSON serialization.
+func ConvertSecretItem(s *istiosecurity.SecretItem) *Certificate {
+	if s == nil {
+		return nil
+	}
+	return &Certificate{
+		ResourceName:     s.ResourceName,
+		CertificateChain: string(s.CertificateChain),
+		ExpireTime:       s.ExpireTime,
+		CreatedTime:      s.CreatedTime,
+	}
+}
 
 type Workload struct {
 	Uid                   string            `json:"uid,omitempty"`

--- a/pkg/status/api_test.go
+++ b/pkg/status/api_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package status
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	istiosecurity "istio.io/istio/pkg/security"
+)
+
+func TestConvertSecretItem(t *testing.T) {
+	t.Run("nil input returns nil", func(t *testing.T) {
+		result := ConvertSecretItem(nil)
+		assert.Nil(t, result)
+	})
+
+	t.Run("valid input converts correctly", func(t *testing.T) {
+		now := time.Now()
+		expire := now.Add(24 * time.Hour)
+		item := &istiosecurity.SecretItem{
+			ResourceName:     "default",
+			CertificateChain: []byte("cert-chain-data"),
+			ExpireTime:       expire,
+			CreatedTime:      now,
+		}
+
+		result := ConvertSecretItem(item)
+		assert.NotNil(t, result)
+		assert.Equal(t, "default", result.ResourceName)
+		assert.Equal(t, "cert-chain-data", result.CertificateChain)
+		assert.Equal(t, expire, result.ExpireTime)
+		assert.Equal(t, now, result.CreatedTime)
+	})
+}

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -60,6 +60,9 @@ const (
 	patternWorkloadMetrics    = "/workload_metrics"
 	patternConnectionMetrics  = "/connection_metrics"
 	patternAuthz              = "/authz"
+	patternConfigDumpServices = configDumpPrefix + "/services"
+	patternConfigDumpPolicies = configDumpPrefix + "/policies"
+	patternConfigDumpCerts    = configDumpPrefix + "/certs"
 
 	bpfLoggerName = "bpf"
 
@@ -101,8 +104,9 @@ func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs, loade
 	s.mux.HandleFunc(patternWorkloadMetrics, s.workloadMetricHandler)
 	s.mux.HandleFunc(patternConnectionMetrics, s.connectionMetricHandler)
 	s.mux.HandleFunc(patternAuthz, s.authzHandler)
-
-	// TODO: add dump certificate, authorizationPolicies and services
+	s.mux.HandleFunc(patternConfigDumpServices, s.configDumpServices)
+	s.mux.HandleFunc(patternConfigDumpPolicies, s.configDumpPolicies)
+	s.mux.HandleFunc(patternConfigDumpCerts, s.configDumpCerts)
 	s.mux.HandleFunc(patternReadyProbe, s.readyProbe)
 
 	// support pprof
@@ -464,9 +468,10 @@ func (s *Server) configDumpAds(w http.ResponseWriter, r *http.Request) {
 }
 
 type WorkloadDump struct {
-	Workloads []*Workload            `json:"workloads"`
-	Services  []*Service             `json:"services"`
-	Policies  []*AuthorizationPolicy `json:"policies"`
+	Workloads    []*Workload            `json:"workloads"`
+	Services     []*Service             `json:"services"`
+	Policies     []*AuthorizationPolicy `json:"policies"`
+	Certificates []*Certificate         `json:"certificates,omitempty"`
 }
 
 func (s *Server) configDumpWorkload(w http.ResponseWriter, r *http.Request) {
@@ -479,10 +484,22 @@ func (s *Server) configDumpWorkload(w http.ResponseWriter, r *http.Request) {
 	workloads := client.WorkloadController.Processor.WorkloadCache.List()
 	services := client.WorkloadController.Processor.ServiceCache.List()
 	policies := client.WorkloadController.Rbac.PoliciesList()
+	certificates := make([]*Certificate, 0)
+	if client.WorkloadController.SecretManager != nil {
+		certs := client.WorkloadController.SecretManager.ListCerts()
+		for _, c := range certs {
+			certificates = append(certificates, ConvertSecretItem(c))
+		}
+		sort.SliceStable(certificates, func(i, j int) bool {
+			return certificates[i].ResourceName < certificates[j].ResourceName
+		})
+	}
+
 	workloadDump := WorkloadDump{
-		Workloads: make([]*Workload, 0, len(workloads)),
-		Services:  make([]*Service, 0, len(services)),
-		Policies:  make([]*AuthorizationPolicy, 0, len(policies)),
+		Workloads:    make([]*Workload, 0, len(workloads)),
+		Services:     make([]*Service, 0, len(services)),
+		Policies:     make([]*AuthorizationPolicy, 0, len(policies)),
+		Certificates: certificates,
 	}
 	for _, w := range workloads {
 		workloadDump.Workloads = append(workloadDump.Workloads, ConvertWorkload(w))
@@ -494,6 +511,84 @@ func (s *Server) configDumpWorkload(w http.ResponseWriter, r *http.Request) {
 		workloadDump.Policies = append(workloadDump.Policies, ConvertAuthorizationPolicy(p))
 	}
 	printWorkloadDump(w, workloadDump)
+}
+
+func (s *Server) configDumpServices(w http.ResponseWriter, r *http.Request) {
+	if !s.checkWorkloadMode(w) {
+		return
+	}
+	services := s.xdsClient.WorkloadController.Processor.ServiceCache.List()
+	out := make([]*Service, 0, len(services))
+	for _, svc := range services {
+		out = append(out, ConvertService(svc))
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].Hostname < out[j].Hostname
+	})
+	data, err := json.MarshalIndent(out, "", "    ")
+	if err != nil {
+		log.Errorf("Failed to marshal configDumpServices: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+func (s *Server) configDumpPolicies(w http.ResponseWriter, r *http.Request) {
+	if !s.checkWorkloadMode(w) {
+		return
+	}
+	policies := s.xdsClient.WorkloadController.Rbac.PoliciesList()
+	out := make([]*AuthorizationPolicy, 0, len(policies))
+	for _, pol := range policies {
+		out = append(out, ConvertAuthorizationPolicy(pol))
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		return out[i].Name < out[j].Name
+	})
+	data, err := json.MarshalIndent(out, "", "    ")
+	if err != nil {
+		log.Errorf("Failed to marshal configDumpPolicies: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+func (s *Server) configDumpCerts(w http.ResponseWriter, r *http.Request) {
+	if !s.checkWorkloadMode(w) {
+		return
+	}
+	if s.xdsClient.WorkloadController.SecretManager == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("[]"))
+		return
+	}
+	certs := s.xdsClient.WorkloadController.SecretManager.ListCerts()
+	out := make([]*Certificate, 0, len(certs))
+	for _, c := range certs {
+		out = append(out, ConvertSecretItem(c))
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].ResourceName < out[j].ResourceName
+	})
+	data, err := json.MarshalIndent(out, "", "    ")
+	if err != nil {
+		log.Errorf("Failed to marshal configDumpCerts: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
 }
 
 func (s *Server) readyProbe(w http.ResponseWriter, r *http.Request) {

--- a/pkg/status/status_server_test.go
+++ b/pkg/status/status_server_test.go
@@ -26,11 +26,13 @@ import (
 	"net/netip"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/encoding/protojson"
 	"istio.io/istio/pilot/test/util"
+	istiosecurity "istio.io/istio/pkg/security"
 
 	"kmesh.net/kmesh/api/v2/admin"
 	"kmesh.net/kmesh/api/v2/cluster"
@@ -44,6 +46,7 @@ import (
 	"kmesh.net/kmesh/pkg/constants"
 	"kmesh.net/kmesh/pkg/controller"
 	"kmesh.net/kmesh/pkg/controller/ads"
+	securitypkg "kmesh.net/kmesh/pkg/controller/security"
 	"kmesh.net/kmesh/pkg/controller/telemetry"
 	"kmesh.net/kmesh/pkg/controller/workload"
 	"kmesh.net/kmesh/pkg/controller/workload/bpfcache"
@@ -661,4 +664,241 @@ func TestServerMonitoringHandler(t *testing.T) {
 		enableMonitoring := l.GetEnableMonitoring()
 		assert.Equal(t, constants.ENABLED, enableMonitoring)
 	})
+}
+
+func TestServer_configDumpServices(t *testing.T) {
+	t.Run("invalid mode returns error", func(t *testing.T) {
+		server := &Server{}
+		req := httptest.NewRequest(http.MethodGet, patternConfigDumpServices, nil)
+		w := httptest.NewRecorder()
+		server.configDumpServices(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns services sorted by hostname", func(t *testing.T) {
+		fakeServiceCache := cache.NewServiceCache()
+		fakeServiceCache.AddOrUpdateService(buildService("svc-b", "hostname-b"))
+		fakeServiceCache.AddOrUpdateService(buildService("svc-a", "hostname-a"))
+		fakeServiceCache.AddOrUpdateService(buildService("svc-c", "hostname-c"))
+
+		server := &Server{
+			xdsClient: &controller.XdsClient{
+				WorkloadController: &workload.Controller{
+					Processor: &workload.Processor{
+						WorkloadCache: cache.NewWorkloadCache(),
+						ServiceCache:  fakeServiceCache,
+					},
+					Rbac: auth.NewRbac(nil),
+				},
+			},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, patternConfigDumpServices, nil)
+		w := httptest.NewRecorder()
+		server.configDumpServices(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+		var services []*Service
+		err := json.Unmarshal(w.Body.Bytes(), &services)
+		assert.Nil(t, err)
+		assert.Equal(t, 3, len(services))
+		assert.Equal(t, "hostname-a", services[0].Hostname)
+		assert.Equal(t, "hostname-b", services[1].Hostname)
+		assert.Equal(t, "hostname-c", services[2].Hostname)
+	})
+}
+
+func TestServer_configDumpPolicies(t *testing.T) {
+	t.Run("invalid mode returns error", func(t *testing.T) {
+		server := &Server{}
+		req := httptest.NewRequest(http.MethodGet, patternConfigDumpPolicies, nil)
+		w := httptest.NewRecorder()
+		server.configDumpPolicies(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("returns policies sorted by namespace and name", func(t *testing.T) {
+		fakeWorkloadCache := cache.NewWorkloadCache()
+		fakeAuth := auth.NewRbac(fakeWorkloadCache)
+		fakeAuth.UpdatePolicy(&security.Authorization{
+			Name:      "policy-b",
+			Namespace: "ns-a",
+			Scope:     security.Scope_GLOBAL,
+			Action:    security.Action_ALLOW,
+		})
+		fakeAuth.UpdatePolicy(&security.Authorization{
+			Name:      "policy-a",
+			Namespace: "ns-b",
+			Scope:     security.Scope_GLOBAL,
+			Action:    security.Action_DENY,
+		})
+		fakeAuth.UpdatePolicy(&security.Authorization{
+			Name:      "policy-a",
+			Namespace: "ns-a",
+			Scope:     security.Scope_GLOBAL,
+			Action:    security.Action_ALLOW,
+		})
+
+		server := &Server{
+			xdsClient: &controller.XdsClient{
+				WorkloadController: &workload.Controller{
+					Processor: &workload.Processor{
+						WorkloadCache: fakeWorkloadCache,
+						ServiceCache:  cache.NewServiceCache(),
+					},
+					Rbac: fakeAuth,
+				},
+			},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, patternConfigDumpPolicies, nil)
+		w := httptest.NewRecorder()
+		server.configDumpPolicies(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+		var policies []*AuthorizationPolicy
+		err := json.Unmarshal(w.Body.Bytes(), &policies)
+		assert.Nil(t, err)
+		assert.Equal(t, 3, len(policies))
+		// sorted by namespace first, then name
+		assert.Equal(t, "ns-a", policies[0].Namespace)
+		assert.Equal(t, "policy-a", policies[0].Name)
+		assert.Equal(t, "ns-a", policies[1].Namespace)
+		assert.Equal(t, "policy-b", policies[1].Name)
+		assert.Equal(t, "ns-b", policies[2].Namespace)
+	})
+}
+
+func TestServer_configDumpCerts(t *testing.T) {
+	t.Run("invalid mode returns error", func(t *testing.T) {
+		server := &Server{}
+		req := httptest.NewRequest(http.MethodGet, patternConfigDumpCerts, nil)
+		w := httptest.NewRecorder()
+		server.configDumpCerts(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+
+	t.Run("nil secret manager returns empty array", func(t *testing.T) {
+		server := &Server{
+			xdsClient: &controller.XdsClient{
+				WorkloadController: &workload.Controller{
+					Processor: &workload.Processor{
+						WorkloadCache: cache.NewWorkloadCache(),
+						ServiceCache:  cache.NewServiceCache(),
+					},
+					Rbac:          auth.NewRbac(nil),
+					SecretManager: nil,
+				},
+			},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, patternConfigDumpCerts, nil)
+		w := httptest.NewRecorder()
+		server.configDumpCerts(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+		assert.Equal(t, "[]", w.Body.String())
+	})
+
+	t.Run("returns certificates sorted by resource name", func(t *testing.T) {
+		now := time.Now().Truncate(time.Second)
+		testCerts := map[string]*istiosecurity.SecretItem{
+			"spiffe://cluster.local/ns/default/sa/sleep": {
+				ResourceName:     "spiffe://cluster.local/ns/default/sa/sleep",
+				CertificateChain: []byte("chain-sleep"),
+				ExpireTime:       now.Add(24 * time.Hour),
+				CreatedTime:      now,
+			},
+			"spiffe://cluster.local/ns/default/sa/httpbin": {
+				ResourceName:     "spiffe://cluster.local/ns/default/sa/httpbin",
+				CertificateChain: []byte("chain-httpbin"),
+				ExpireTime:       now.Add(48 * time.Hour),
+				CreatedTime:      now,
+			},
+		}
+		sm := securitypkg.NewTestSecretManager(testCerts)
+
+		server := &Server{
+			xdsClient: &controller.XdsClient{
+				WorkloadController: &workload.Controller{
+					Processor: &workload.Processor{
+						WorkloadCache: cache.NewWorkloadCache(),
+						ServiceCache:  cache.NewServiceCache(),
+					},
+					Rbac:          auth.NewRbac(nil),
+					SecretManager: sm,
+				},
+			},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, patternConfigDumpCerts, nil)
+		w := httptest.NewRecorder()
+		server.configDumpCerts(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+
+		var certs []*Certificate
+		err := json.Unmarshal(w.Body.Bytes(), &certs)
+		assert.Nil(t, err)
+		assert.Equal(t, 2, len(certs))
+		// sorted by resource name
+		assert.Equal(t, "spiffe://cluster.local/ns/default/sa/httpbin", certs[0].ResourceName)
+		assert.Equal(t, "spiffe://cluster.local/ns/default/sa/sleep", certs[1].ResourceName)
+		assert.Equal(t, "chain-httpbin", certs[0].CertificateChain)
+	})
+}
+
+func TestServer_configDumpWorkloadWithCerts(t *testing.T) {
+	w := buildWorkload("name")
+	svc := buildService("svc", "hostname")
+
+	now := time.Now().Truncate(time.Second)
+	testCerts := map[string]*istiosecurity.SecretItem{
+		"spiffe://cluster.local/ns/default/sa/test": {
+			ResourceName:     "spiffe://cluster.local/ns/default/sa/test",
+			CertificateChain: []byte("test-chain"),
+			ExpireTime:       now.Add(24 * time.Hour),
+			CreatedTime:      now,
+		},
+	}
+	sm := securitypkg.NewTestSecretManager(testCerts)
+
+	fakeWorkloadCache := cache.NewWorkloadCache()
+	fakeServiceCache := cache.NewServiceCache()
+	fakeWorkloadCache.AddOrUpdateWorkload(w)
+	fakeServiceCache.AddOrUpdateService(svc)
+	fakeAuth := auth.NewRbac(fakeWorkloadCache)
+
+	server := &Server{
+		xdsClient: &controller.XdsClient{
+			WorkloadController: &workload.Controller{
+				Processor: &workload.Processor{
+					WorkloadCache: fakeWorkloadCache,
+					ServiceCache:  fakeServiceCache,
+				},
+				Rbac:          fakeAuth,
+				SecretManager: sm,
+			},
+		},
+	}
+
+	req := httptest.NewRequest(http.MethodGet, patternConfigDumpWorkload, nil)
+	rec := httptest.NewRecorder()
+	server.configDumpWorkload(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var dump WorkloadDump
+	err := json.Unmarshal(rec.Body.Bytes(), &dump)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(dump.Workloads))
+	assert.Equal(t, 1, len(dump.Services))
+	assert.Equal(t, 1, len(dump.Certificates))
+	assert.Equal(t, "spiffe://cluster.local/ns/default/sa/test", dump.Certificates[0].ResourceName)
 }


### PR DESCRIPTION
## What type of PR is this?

/kind feature

---

## What this PR does / why we need it

This PR resolves the TODO in `status_server.go`:

```text id="q8vk2m"
add dump certificate, authorizationPolicies and services by adding three dedicated debug endpoints to the status server for inspecting individual Kmesh resource types.
```
# New Debug Endpoints

| Endpoint | Description |
|----------|-------------|
| `/debug/config_dump/services` | Dumps cached service entries (sorted by hostname) |
| `/debug/config_dump/policies` | Dumps authorization policies from Rbac (sorted by namespace/name) |
| `/debug/config_dump/certs` | Dumps cached TLS certificates (sorted by resource name) |

These endpoints follow the existing:
- `configDumpWorkload`
- `configDumpAds`

patterns and return deterministic, sorted JSON responses with:

```text
Content-Type: application/json
```

---

# Why this matters

The upcoming Headlamp plugin requires dedicated API endpoints to surface detailed Kmesh resource inspection views for:

- Certificates
- Authorization Policies
- Services

Without these endpoints, users can only inspect resources through the monolithic:

```text
/debug/config_dump/dual-engine
```

endpoint, which bundles all resources together and makes granular inspection difficult.

These new endpoints improve:

- Debugging
- Observability
- UI integration
- Resource-level introspection

---

# Changes

| File | Change |
|------|--------|
| `pkg/controller/security/manager.go` | Added `ListCerts()` for thread-safe enumeration of cached certificates |
| `pkg/controller/workload/workload_controller.go` | Added `SecretManager` field so the status server can access certificates through the controller chain |
| `pkg/controller/controller.go` | Wired the existing `SecretManager` instance to `WorkloadController` (hoisted variable scope, no duplicate creation) |
| `pkg/status/api.go` | Added `Certificate` struct and `ConvertSecretItem()` conversion function |
| `pkg/status/status_server.go` | Registered three new handlers, removed the TODO comment, enriched `WorkloadDump` with certificate data, added stable sorting for services/policies in the combined dump |
| `pkg/status/api_test.go` | Added unit tests for `ConvertSecretItem()` (nil input + valid conversion cases) |

---

# Which issue(s) this PR fixes

Fixes the TODO in:

```text
status_server.go:L105
```

to add dump certificate, authorizationPolicies, and services endpoints.

---

# Does this PR introduce a user-facing change?

```release-note
Added three new debug endpoints:
/debug/config_dump/services
/debug/config_dump/policies
/debug/config_dump/certs

These endpoints enable individual resource type inspection for services, authorization policies, and TLS certificates.
```
