### PR TITLE
workload: implement RestoreEndpoint() to rebuild in-memory cache on w…

### DIFF
--- a/pkg/controller/workload/bpfcache/endpoint.go
+++ b/pkg/controller/workload/bpfcache/endpoint.go
@@ -128,6 +128,32 @@ func (c *Cache) EndpointLookup(key *EndpointKey, value *EndpointValue) error {
 	return c.bpfMap.KmEndpoint.Lookup(key, value)
 }
 
+// EndpointEntry is a key-value pair read from the BPF endpoint map.
+// It is returned by IterateEndpoints and consumed by the warm-restart
+// restore path in the workload controller.
+type EndpointEntry struct {
+	Key   EndpointKey
+	Value EndpointValue
+}
+
+// IterateEndpoints returns all entries currently stored in the BPF endpoint
+// map. It is called during a warm restart so that the in-memory endpoint
+// cache can be rebuilt to match the persisted BPF state.
+func (c *Cache) IterateEndpoints() []EndpointEntry {
+	log.Debugf("IterateEndpoints: reading all BPF endpoint map entries")
+	var (
+		key     = EndpointKey{}
+		value   = EndpointValue{}
+		entries []EndpointEntry
+	)
+
+	iter := c.bpfMap.KmEndpoint.Iterate()
+	for iter.Next(&key, &value) {
+		entries = append(entries, EndpointEntry{Key: key, Value: value})
+	}
+	return entries
+}
+
 // RestoreEndpointKeys called on restart to construct endpoint indexes from bpf map
 func (c *Cache) RestoreEndpointKeys() {
 	log.Debugf("init endpoint keys")

--- a/pkg/controller/workload/cache/endpoint_cache.go
+++ b/pkg/controller/workload/cache/endpoint_cache.go
@@ -20,6 +20,16 @@ import (
 	"sync"
 )
 
+// EndpointEntry holds the data needed to restore a single endpoint into the
+// in-memory cache. ServiceId, Prio and BackendIndex come from the BPF
+// endpoint map key; WorkloadId is the BackendUid stored in the value.
+type EndpointEntry struct {
+	ServiceId    uint32
+	Prio         uint32
+	BackendIndex uint32
+	WorkloadId   uint32
+}
+
 // TODO: use `EndpointKey` struct
 type Endpoint struct {
 	ServiceId    uint32
@@ -36,6 +46,9 @@ type EndpointCache interface {
 	DeleteEndpointWithPriority(serviceID, workloadID, prio uint32)
 	// DeleteEndpointByServiceId delete all endpoints belong to a given service
 	DeleteEndpointByServiceId(uint32)
+	// RestoreEndpoint rebuilds the in-memory cache from persisted BPF map
+	// entries on a warm restart.
+	RestoreEndpoint(entries []EndpointEntry)
 }
 
 type endpointCache struct {
@@ -82,9 +95,23 @@ func (s *endpointCache) DeleteEndpointByServiceId(serviceId uint32) {
 	delete(s.endpointsByServiceId, serviceId)
 }
 
-func (s *endpointCache) RestoreEndpoint() {
-	// we need update endpoint_cache after bpfcache.RestoreEndpointKeys
-	// Todo
+// RestoreEndpoint rebuilds the in-memory endpoint cache from persisted BPF
+// endpoint map entries after a warm restart. The caller is responsible for
+// supplying the entries (typically obtained by iterating the BPF map).
+func (s *endpointCache) RestoreEndpoint(entries []EndpointEntry) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	for _, entry := range entries {
+		ep := Endpoint{
+			ServiceId:    entry.ServiceId,
+			Prio:         entry.Prio,
+			BackendIndex: entry.BackendIndex,
+		}
+		if s.endpointsByServiceId[entry.ServiceId] == nil {
+			s.endpointsByServiceId[entry.ServiceId] = make(map[uint32]Endpoint)
+		}
+		s.endpointsByServiceId[entry.ServiceId][entry.WorkloadId] = ep
+	}
 }
 
 func (s *endpointCache) List(serviceId uint32) map[uint32]Endpoint {

--- a/pkg/controller/workload/cache/endpoint_cache_test.go
+++ b/pkg/controller/workload/cache/endpoint_cache_test.go
@@ -76,3 +76,36 @@ func TestEndpointCache(t *testing.T) {
 	ec.DeleteEndpointByServiceId(serviceId1)
 	assert.Equal(t, 0, len(ec.List(serviceId1)))
 }
+
+func TestRestoreEndpoint(t *testing.T) {
+	ec := NewEndpointCache()
+
+	entries := []EndpointEntry{
+		{ServiceId: 1, Prio: 0, BackendIndex: 1, WorkloadId: 100},
+		{ServiceId: 1, Prio: 0, BackendIndex: 2, WorkloadId: 200},
+		{ServiceId: 1, Prio: 1, BackendIndex: 1, WorkloadId: 300},
+		{ServiceId: 2, Prio: 0, BackendIndex: 1, WorkloadId: 400},
+	}
+
+	ec.RestoreEndpoint(entries)
+
+	// service 1 should have 3 workloads (100, 200, 300 keyed by workload id)
+	svc1 := ec.List(1)
+	assert.Equal(t, 3, len(svc1))
+	assert.Equal(t, Endpoint{ServiceId: 1, Prio: 0, BackendIndex: 1}, svc1[100])
+	assert.Equal(t, Endpoint{ServiceId: 1, Prio: 0, BackendIndex: 2}, svc1[200])
+	assert.Equal(t, Endpoint{ServiceId: 1, Prio: 1, BackendIndex: 1}, svc1[300])
+
+	// service 2 should have 1 workload
+	svc2 := ec.List(2)
+	assert.Equal(t, 1, len(svc2))
+	assert.Equal(t, Endpoint{ServiceId: 2, Prio: 0, BackendIndex: 1}, svc2[400])
+
+	// non-existent service returns empty map
+	assert.Equal(t, 0, len(ec.List(99)))
+
+	// calling RestoreEndpoint again on a fresh cache with an empty slice is a no-op
+	ec2 := NewEndpointCache()
+	ec2.RestoreEndpoint([]EndpointEntry{})
+	assert.Equal(t, 0, len(ec2.List(1)))
+}

--- a/pkg/controller/workload/workload_controller.go
+++ b/pkg/controller/workload/workload_controller.go
@@ -27,6 +27,7 @@ import (
 	"kmesh.net/kmesh/pkg/bpf/restart"
 	bpfwl "kmesh.net/kmesh/pkg/bpf/workload"
 	"kmesh.net/kmesh/pkg/controller/telemetry"
+	"kmesh.net/kmesh/pkg/controller/workload/cache"
 	"kmesh.net/kmesh/pkg/logger"
 )
 
@@ -71,7 +72,21 @@ func NewController(bpfWorkload *bpfwl.BpfWorkload, enableMonitoring, enablePerfM
 	// restore endpoint index, otherwise endpoint number can double
 	if restart.GetStartType() == restart.Restart {
 		c.Processor.bpf.RestoreEndpointKeys()
+		// Rebuild the in-memory endpoint cache from persisted BPF endpoint
+		// map data so that it is consistent with the BPF state on warm restart.
+		bpfEntries := c.Processor.bpf.IterateEndpoints()
+		cacheEntries := make([]cache.EndpointEntry, 0, len(bpfEntries))
+		for _, e := range bpfEntries {
+			cacheEntries = append(cacheEntries, cache.EndpointEntry{
+				ServiceId:    e.Key.ServiceId,
+				Prio:         e.Key.Prio,
+				BackendIndex: e.Key.BackendIndex,
+				WorkloadId:   e.Value.BackendUid,
+			})
+		}
+		c.Processor.EndpointCache.RestoreEndpoint(cacheEntries)
 	}
+
 	c.Rbac = auth.NewRbac(c.Processor.WorkloadCache)
 	c.MetricController = telemetry.NewMetric(c.Processor.WorkloadCache, c.Processor.ServiceCache, enableMonitoring)
 	if enablePerfMonitor {


### PR DESCRIPTION
# What type of PR is this?

/kind feature

---

# What this PR does / why we need it

This PR implements the previously empty:

```go
RestoreEndpoint()
```

method in the Kmesh Endpoint Cache.

During a warm restart, Kmesh must rebuild its in-memory state from persisted eBPF maps to maintain runtime consistency.

Before this change:
- The `endpointsByServiceId` map remained empty after restart
- Internal endpoint state became inconsistent with the kernel/BPF state
- Endpoint-related logic operated on incomplete data
- Observability tooling reported incorrect endpoint counts

This caused issues including:
- Endpoint priority calculations behaving incorrectly
- The Headlamp plugin reporting zero endpoints
- Missing endpoint visibility until the next full xDS synchronization from Istiod

This PR restores endpoint cache state directly from persisted BPF data during restart, ensuring the in-memory cache accurately reflects the actual dataplane state immediately after startup.

---

# Which issue(s) this PR fixes

Fixes #4

---

# Special notes for your reviewer

The implementation follows a decoupled architecture to avoid circular dependencies between the cache and `bpfcache` packages.

---

## BPF iteration support

Added:

```go
IterateEndpoints()
```

in the `bpfcache` layer to scan persisted endpoint entries from the eBPF maps.

---

## Controller bridge layer

`workload_controller` now acts as the bridge between:
- BPF endpoint structures
- Cache-friendly endpoint primitives

It converts low-level BPF types into simple:

```go
cache.EndpointEntry
```

objects before restoration.

---

## Safe cache reconstruction

Implemented restoration logic in:

```go
cache.RestoreEndpoint()
```

using a write lock to safely rebuild:
- `endpointsByServiceId`
- Service-to-endpoint mappings

during restart recovery.

---

## Testing

Added comprehensive unit tests in:

```text
endpoint_cache_test.go
```

covering:
- Multi-service endpoint restoration
- Correct service-to-endpoint reconstruction
- Cache consistency after restore

---

# Why this matters

Without endpoint restoration:
- Warm restarts leave the in-memory endpoint cache incomplete
- Internal service state becomes temporarily inaccurate
- Observability tooling shows incorrect endpoint data
- Endpoint-aware features behave inconsistently until a fresh xDS sync occurs

With this implementation:
- Cache state survives warm restart correctly
- Endpoint mappings are immediately restored
- Observability tools remain accurate
- Internal endpoint calculations stay consistent

This improves:
- Restart reliability
- State consistency
- Headlamp integration correctness
- Overall operational observability

---

# Does this PR introduce a user-facing change?

```release-note
NONE
```