### PR TITLE
test: strengthen murmur3 hash coverage

### DIFF
--- a/pkg/utils/hash/hash_test.go
+++ b/pkg/utils/hash/hash_test.go
@@ -131,19 +131,38 @@ func TestHash128_DifferentInputs(t *testing.T) {
 }
 
 func TestHash128_AllTailLengths(t *testing.T) {
-	// Test all tail lengths from 0 to 15 bytes
 	seed := uint32(0)
-	baseData := []byte("0123456789abcdef") // 16 bytes base
+	baseData := []byte("0123456789abcdef")
+	tailData := []byte("extra tail bytes")
+	expected := []struct {
+		h1 uint64
+		h2 uint64
+	}{
+		{5467490433528156583, 9782763267945859290},
+		{7365496233626374817, 4509812671008863076},
+		{12573662846152529695, 7461964302156406396},
+		{9835107160104111132, 10470535468262275298},
+		{361946897411615576, 17996517921075712664},
+		{16846892524183029451, 13280208045458370287},
+		{4578864950277010102, 12632592208615550477},
+		{14800598385962173449, 5191467188622709264},
+		{17098945199622310944, 7563156776339729347},
+		{156324995665638904, 17134821293174869613},
+		{12380062088919656819, 16542457023974195919},
+		{1082955700493610954, 6369146761905933195},
+		{14036760400416503843, 5952865372487413191},
+		{11535319495064235047, 7524327669449282404},
+		{14149555822753749515, 10930268772313463049},
+		{8065951757315601820, 11099135757563705731},
+	}
 
-	for tailLen := 0; tailLen <= 15; tailLen++ {
-		data := append(baseData, []byte("extra tail bytes")[:tailLen]...)
+	for tailLen, want := range expected {
+		data := append(append([]byte{}, baseData...), tailData[:tailLen]...)
 		h1, h2 := Hash128(data, seed)
 
-		// This check is a sanity check to catch a hash function that is broken
-		// (e.g., always returning zero).  It is not a strict correctness check,
-		// as a valid hash function could theoretically return (0, 0) for some input.
-		if h1 == 0 && h2 == 0 && len(data) > 0 {
-			t.Errorf("Hash128 with tail length %d produced zero hash for non-empty input", tailLen)
+		if h1 != want.h1 || h2 != want.h2 {
+			t.Errorf("Hash128 with tail length %d = (%d, %d), want (%d, %d)",
+				tailLen, h1, h2, want.h1, want.h2)
 		}
 	}
 }
@@ -229,6 +248,11 @@ func Test_fmix64(t *testing.T) {
 			name:     "test value 2",
 			input:    0xfedcba9876543210,
 			expected: 0x03ebebcc1f4a6fd7,
+		},
+		{
+			name:     "test value 3",
+			input:    0x123456789abcdef0,
+			expected: 0x18b8c062f6f42398,
 		},
 	}
 

--- a/pkg/utils/hash/murmur3_test.go
+++ b/pkg/utils/hash/murmur3_test.go
@@ -16,10 +16,7 @@
 
 package hash
 
-import (
-	"fmt"
-	"testing"
-)
+import "testing"
 
 func TestHash128_DifferentSeeds(t *testing.T) {
 	input := []byte("test input")
@@ -29,47 +26,6 @@ func TestHash128_DifferentSeeds(t *testing.T) {
 
 	if (h1_seed0 == h1_seed1) && (h2_seed0 == h2_seed1) {
 		t.Errorf("Different seeds produced same hash: (%d, %d)", h1_seed0, h2_seed0)
-	}
-}
-
-func TestHash128_TailCases(t *testing.T) {
-	seed := uint32(0)
-	expected := []struct {
-		h1 uint64
-		h2 uint64
-	}{
-		{5467490433528156583, 9782763267945859290},
-		{7365496233626374817, 4509812671008863076},
-		{12573662846152529695, 7461964302156406396},
-		{9835107160104111132, 10470535468262275298},
-		{361946897411615576, 17996517921075712664},
-		{16846892524183029451, 13280208045458370287},
-		{4578864950277010102, 12632592208615550477},
-		{14800598385962173449, 5191467188622709264},
-		{17098945199622310944, 7563156776339729347},
-		{156324995665638904, 17134821293174869613},
-		{12380062088919656819, 16542457023974195919},
-		{1082955700493610954, 6369146761905933195},
-		{14036760400416503843, 5952865372487413191},
-		{11535319495064235047, 7524327669449282404},
-		{14149555822753749515, 10930268772313463049},
-		{8065951757315601820, 11099135757563705731},
-	}
-
-	baseData := []byte("0123456789abcdef")
-	tailData := []byte("extra tail bytes")
-
-	for tailLen, want := range expected {
-		t.Run(fmt.Sprintf("tail_len_%d", tailLen), func(t *testing.T) {
-			input := append([]byte{}, baseData...)
-			input = append(input, tailData[:tailLen]...)
-
-			h1, h2 := Hash128(input, seed)
-			if h1 != want.h1 || h2 != want.h2 {
-				t.Errorf("Hash128 with tail length %d = (%d, %d), want (%d, %d)",
-					tailLen, h1, h2, want.h1, want.h2)
-			}
-		})
 	}
 }
 
@@ -130,39 +86,6 @@ func TestRotl64(t *testing.T) {
 			result := rotl64(tt.x, tt.r)
 			if result != tt.expected {
 				t.Errorf("rotl64(0x%x, %d) = 0x%x, want 0x%x", tt.x, tt.r, result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestFmix64(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    uint64
-		expected uint64
-	}{
-		{
-			name:     "zero",
-			input:    0,
-			expected: 0,
-		},
-		{
-			name:     "max value",
-			input:    0xffffffffffffffff,
-			expected: 0x64b5720b4b825f21,
-		},
-		{
-			name:     "test value",
-			input:    0x123456789abcdef0,
-			expected: 0x18b8c062f6f42398,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := fmix64(tt.input)
-			if result != tt.expected {
-				t.Errorf("fmix64(0x%x) = 0x%x, want 0x%x", tt.input, result, tt.expected)
 			}
 		})
 	}

--- a/pkg/utils/hash/murmur3_test.go
+++ b/pkg/utils/hash/murmur3_test.go
@@ -17,6 +17,7 @@
 package hash
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -33,21 +34,42 @@ func TestHash128_DifferentSeeds(t *testing.T) {
 
 func TestHash128_TailCases(t *testing.T) {
 	seed := uint32(0)
+	expected := []struct {
+		h1 uint64
+		h2 uint64
+	}{
+		{5467490433528156583, 9782763267945859290},
+		{7365496233626374817, 4509812671008863076},
+		{12573662846152529695, 7461964302156406396},
+		{9835107160104111132, 10470535468262275298},
+		{361946897411615576, 17996517921075712664},
+		{16846892524183029451, 13280208045458370287},
+		{4578864950277010102, 12632592208615550477},
+		{14800598385962173449, 5191467188622709264},
+		{17098945199622310944, 7563156776339729347},
+		{156324995665638904, 17134821293174869613},
+		{12380062088919656819, 16542457023974195919},
+		{1082955700493610954, 6369146761905933195},
+		{14036760400416503843, 5952865372487413191},
+		{11535319495064235047, 7524327669449282404},
+		{14149555822753749515, 10930268772313463049},
+		{8065951757315601820, 11099135757563705731},
+	}
 
-	// Test all possible tail lengths (1-15 bytes after 16-byte blocks)
-	for i := 1; i <= 15; i++ {
-		input := make([]byte, 16+i) // 16 bytes + i tail bytes
-		for j := range input {
-			input[j] = byte(j)
-		}
+	baseData := []byte("0123456789abcdef")
+	tailData := []byte("extra tail bytes")
 
-		h1, h2 := Hash128(input, seed)
+	for tailLen, want := range expected {
+		t.Run(fmt.Sprintf("tail_len_%d", tailLen), func(t *testing.T) {
+			input := append([]byte{}, baseData...)
+			input = append(input, tailData[:tailLen]...)
 
-		// Test deterministic behavior
-		h1_2, h2_2 := Hash128(input, seed)
-		if h1 != h1_2 || h2 != h2_2 {
-			t.Errorf("Hash128 with tail length %d is not deterministic", i)
-		}
+			h1, h2 := Hash128(input, seed)
+			if h1 != want.h1 || h2 != want.h2 {
+				t.Errorf("Hash128 with tail length %d = (%d, %d), want (%d, %d)",
+					tailLen, h1, h2, want.h1, want.h2)
+			}
+		})
 	}
 }
 
@@ -127,23 +149,20 @@ func TestFmix64(t *testing.T) {
 		{
 			name:     "max value",
 			input:    0xffffffffffffffff,
-			expected: 0x49a3af502d8a9f23, // This would need to be calculated/verified
+			expected: 0x64b5720b4b825f21,
 		},
 		{
 			name:     "test value",
 			input:    0x123456789abcdef0,
-			expected: 0, // This would need to be calculated/verified - testing for determinism instead
+			expected: 0x18b8c062f6f42398,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := fmix64(tt.input)
-
-			// Test deterministic behavior
-			result2 := fmix64(tt.input)
-			if result != result2 {
-				t.Errorf("fmix64(0x%x) is not deterministic: 0x%x != 0x%x", tt.input, result, result2)
+			if result != tt.expected {
+				t.Errorf("fmix64(0x%x) = 0x%x, want 0x%x", tt.input, result, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
## What changed
- Add golden-value checks for Hash128 tail lengths 0 through 15 after a full block.
- Replace placeholder fmix64 expectations with asserted vectors.

Closes #1528.

## Validation
- go test ./pkg/utils/hash