### PR TITLE
build: fix GIT_TREESTATE evaluation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 
 VERSION ?= 1.1-dev
 GIT_COMMIT_HASH ?= $(shell git rev-parse HEAD)
-GIT_TREESTATE=$(shell if [ -n "$(git status --porcelain)" ]; then echo "dirty"; else echo "clean"; fi)
+GIT_TREESTATE ?= $(shell git status --porcelain | grep -q . && echo "dirty" || echo "clean")
 BUILD_DATE = $(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 ROOT_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 


### PR DESCRIPTION
Fixes #1673