### PR TITLE
support gateway-routing

### DIFF
--- a/bpf/kmesh/workload/include/backend.h
+++ b/bpf/kmesh/workload/include/backend.h
@@ -25,6 +25,23 @@ static inline int waypoint_manager(struct kmesh_context *kmesh_ctx, struct ip_ad
     return 0;
 }
 
+// gateway_manager routes traffic to the East-West gateway.
+// via_waypoint = true so the BPF sock_ops layer embeds TLV with the actual
+// backend IP (backend_v->addr), allowing the EW gateway to forward to the
+// correct remote pod.
+static inline int gateway_manager(struct kmesh_context *kmesh_ctx, struct ip_addr *gw_addr, __u32 port)
+{
+    ctx_buff_t *ctx = (ctx_buff_t *)kmesh_ctx->ctx;
+
+    if (ctx->user_family == AF_INET)
+        kmesh_ctx->dnat_ip.ip4 = gw_addr->ip4;
+    else
+        bpf_memcpy(kmesh_ctx->dnat_ip.ip6, gw_addr->ip6, IPV6_ADDR_LEN);
+    kmesh_ctx->dnat_port = port;
+    kmesh_ctx->via_waypoint = true; // embed TLV with backend IP for EW gateway
+    return 0;
+}
+
 static inline int svc_dnat(struct kmesh_context *kmesh_ctx, backend_value *backend_v, service_value *service_v)
 {
     int i;
@@ -58,8 +75,20 @@ backend_manager(struct kmesh_context *kmesh_ctx, backend_value *backend_v, __u32
 {
     int ret = -ENOENT;
     ctx_buff_t *ctx = (ctx_buff_t *)kmesh_ctx->ctx;
-    __u32 i, user_port = ctx->user_port;
 
+    // 1. EW gateway: remote workload routed through East-West gateway (highest priority)
+    if (backend_v->gw_port != 0) {
+        BPF_LOG(
+            DEBUG,
+            BACKEND,
+            "route to EW gateway[%s:%u]\n",
+            ip2str((__u32 *)&backend_v->gw_addr, ctx->family == AF_INET),
+            bpf_ntohs(backend_v->gw_port));
+        ret = gateway_manager(kmesh_ctx, &backend_v->gw_addr, backend_v->gw_port);
+        return ret;
+    }
+
+    // 2. Waypoint proxy
     if (backend_v->waypoint_port != 0) {
         BPF_LOG(
             DEBUG,
@@ -71,6 +100,7 @@ backend_manager(struct kmesh_context *kmesh_ctx, backend_value *backend_v, __u32
         return ret;
     }
 
+    // 3. Normal DNAT to pod IP
     ret = svc_dnat(kmesh_ctx, backend_v, service_v);
     if (ret == 0) {
         BPF_LOG(
@@ -86,3 +116,4 @@ backend_manager(struct kmesh_context *kmesh_ctx, backend_value *backend_v, __u32
 }
 
 #endif
+

--- a/bpf/kmesh/workload/include/workload.h
+++ b/bpf/kmesh/workload/include/workload.h
@@ -60,6 +60,8 @@ typedef struct {
     __u32 service[MAX_SERVICE_COUNT];
     struct ip_addr wp_addr;
     __u32 waypoint_port;
+    struct ip_addr gw_addr;  // EW gateway IP (v4 or v6); 0 = no gateway
+    __u32 gw_port;           // EW gateway port; 0 = no gateway
 } backend_value;
 #pragma pack()
 
@@ -121,3 +123,4 @@ struct {
 } map_of_wl_policy SEC(".maps");
 
 #endif
+

--- a/pkg/controller/workload/bpfcache/backend.go
+++ b/pkg/controller/workload/bpfcache/backend.go
@@ -38,6 +38,8 @@ type BackendValue struct {
 	Services     ServiceList
 	WaypointAddr [16]byte
 	WaypointPort uint32
+	GatewayAddr  [16]byte // EW gateway IP; zero = no gateway
+	GatewayPort  uint32   // EW gateway port; zero = no gateway
 }
 
 func (c *Cache) BackendUpdate(key *BackendKey, value *BackendValue) error {
@@ -69,3 +71,4 @@ func (c *Cache) BackendLookupAll() []BackendValue {
 	log.Debugf("BackendLookupAll")
 	return LookupAll[BackendKey, BackendValue](c.bpfMap.KmBackend)
 }
+

--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -46,6 +46,8 @@ import (
 	"kmesh.net/kmesh/pkg/utils"
 )
 
+
+
 const (
 	KmeshWaypointPort = 15019 // use this fixed port instead of the HboneMtlsPort in kmesh
 	// dnsResolveTimeout is the timeout used when waiting for DNS resolution for workloads
@@ -80,23 +82,24 @@ type Processor struct {
 	ResolvedDomainChanMap map[string]chan *workloadapi.Workload
 	// Callback to remove workload from DNS cache when workload is deleted
 	onWorkloadDeleted func(workloadName string)
+
 }
 
 func NewProcessor(workloadMap bpf2go.KmeshCgroupSockWorkloadMaps) *Processor {
 	serviceCache := cache.NewServiceCache()
 
 	return &Processor{
-		hashName:      utils.NewHashName(),
-		bpf:           bpf.NewCache(workloadMap),
-		nodeName:      os.Getenv("NODE_NAME"),
-		WorkloadCache: cache.NewWorkloadCache(),
-		ServiceCache:  serviceCache,
-		EndpointCache: cache.NewEndpointCache(),
-		WaypointCache: cache.NewWaypointCache(serviceCache),
-		locality:      bpf.NewLocalityCache(),
-		addressDone:   make(chan struct{}, 1),
-		authzDone:     make(chan struct{}, 1),
-		handlers:      map[string][]func(resp *service_discovery_v3.DeltaDiscoveryResponse) error{},
+		hashName:          utils.NewHashName(),
+		bpf:               bpf.NewCache(workloadMap),
+		nodeName:          os.Getenv("NODE_NAME"),
+		WorkloadCache:     cache.NewWorkloadCache(),
+		ServiceCache:      serviceCache,
+		EndpointCache:     cache.NewEndpointCache(),
+		WaypointCache:     cache.NewWaypointCache(serviceCache),
+		locality:          bpf.NewLocalityCache(),
+		addressDone:       make(chan struct{}, 1),
+		authzDone:         make(chan struct{}, 1),
+		handlers:          map[string][]func(resp *service_discovery_v3.DeltaDiscoveryResponse) error{},
 	}
 }
 
@@ -434,27 +437,30 @@ func (p *Processor) handleWorkloadUnboundServices(workload *workloadapi.Workload
 }
 
 // handleWorkloadNewBoundServices handles when a workload's belonging services added
-func (p *Processor) handleWorkloadNewBoundServices(workload *workloadapi.Workload, newServices []uint32) error {
+func (p *Processor) handleWorkloadNewBoundServices(workload *workloadapi.Workload, servicesToAdd map[uint32]uint32) error {
 	var (
 		sk = bpf.ServiceKey{}
 		sv = bpf.ServiceValue{}
 	)
 
-	if len(newServices) == 0 {
+	if len(servicesToAdd) == 0 {
 		return nil
 	}
 
-	log.Debugf("handleWorkloadNewBoundServices %s: %v", workload.ResourceName(), newServices)
+	log.Debugf("handleWorkloadNewBoundServices %s: %v", workload.ResourceName(), servicesToAdd)
 	workloadId := p.hashName.Hash(workload.GetUid())
-	for _, svcUid := range newServices {
+	for svcUid, addCount := range servicesToAdd {
 		sk.ServiceId = svcUid
 		// the service already stored in map, add endpoint
 		if err := p.bpf.ServiceLookup(&sk, &sv); err == nil {
 			if sv.LbPolicy == uint32(workloadapi.LoadBalancing_UNSPECIFIED_MODE) { // random mode
-				// In random mode, we save all workload to max priority group
-				if _, err = p.addWorkloadToService(&sk, &sv, workloadId, 0); err != nil {
-					log.Errorf("addWorkloadToService workload %d service %d failed: %v", workloadId, sk.ServiceId, err)
-					return err
+				// In random mode, we save all workload to max priority group.
+				// Repeat `addCount` times so the workload gets proportional LB slots.
+				for j := uint32(0); j < addCount; j++ {
+					if _, err = p.addWorkloadToService(&sk, &sv, workloadId, 0); err != nil {
+						log.Errorf("addWorkloadToService workload %d service %d slot %d failed: %v", workloadId, sk.ServiceId, j, err)
+						return err
+					}
 				}
 			} else { // locality mode
 				service := p.ServiceCache.GetService(p.hashName.NumToStr(svcUid))
@@ -468,9 +474,11 @@ func (p *Processor) handleWorkloadNewBoundServices(workload *workloadapi.Workloa
 						// when locality is eventually set
 						prio = 0
 					}
-					if _, err = p.addWorkloadToService(&sk, &sv, workloadId, prio); err != nil {
-						log.Errorf("addWorkloadToService workload %d service %d priority %d failed: %v", workloadId, sk.ServiceId, prio, err)
-						return err
+					for j := uint32(0); j < addCount; j++ {
+						if _, err = p.addWorkloadToService(&sk, &sv, workloadId, prio); err != nil {
+							log.Errorf("addWorkloadToService workload %d service %d priority %d slot %d failed: %v", workloadId, sk.ServiceId, prio, j, err)
+							return err
+						}
 					}
 				}
 			}
@@ -492,6 +500,14 @@ func (p *Processor) updateWorkloadInBackendMap(workload *workloadapi.Workload) e
 	if waypoint := workload.GetWaypoint(); waypoint != nil && waypoint.GetAddress() != nil {
 		nets.CopyIpByteFromSlice(&bv.WaypointAddr, waypoint.GetAddress().Address)
 		bv.WaypointPort = nets.ConvertPortToBigEndian(waypoint.GetHboneMtlsPort())
+	}
+
+	// Populate EW gateway fields for remote workloads.
+	// When gw_port != 0, the BPF program DNATs to the gateway (via_waypoint=true)
+	// so the TLV carries bv.Ip (the actual backend IP) to the EW gateway.
+	if gw := workload.GetNetworkGateway(); gw != nil && gw.GetAddress() != nil {
+		nets.CopyIpByteFromSlice(&bv.GatewayAddr, gw.GetAddress().Address)
+		bv.GatewayPort = nets.ConvertPortToBigEndian(gw.GetHboneMtlsPort())
 	}
 
 	for serviceName := range workload.GetServices() {
@@ -518,6 +534,12 @@ func (p *Processor) updateWorkloadInFrontendMap(workload *workloadapi.Workload) 
 	// we should not store frontend data of hostname network mode pods
 	// please see https://github.com/kmesh-net/kmesh/issues/631
 	if workload.GetNetworkMode() == workloadapi.NetworkMode_HOST_NETWORK {
+		return nil
+	}
+
+	// Remote workloads routed via EW gateway must not be stored in the frontend map.
+	// They share a service VIP as their IP; direct pod-IP lookup would be incorrect.
+	if workload.GetNetworkGateway() != nil {
 		return nil
 	}
 
@@ -587,13 +609,13 @@ func (p *Processor) handleWorkload(workload *workloadapi.Workload) error {
 	}
 
 	// 2~3. update workload in endpoint map and service map
-	unboundedEndpointKeys, newServices := p.compareWorkloadServices(workload)
+	unboundedEndpointKeys, servicesToAdd := p.compareWorkloadServices(workload)
 	if err := p.handleWorkloadUnboundServices(workload, unboundedEndpointKeys); err != nil {
 		return fmt.Errorf("handleWorkloadUnboundServices %s failed: %v", workload.ResourceName(), err)
 	}
 
 	// Add new services associated with the workload
-	if err := p.handleWorkloadNewBoundServices(workload, newServices); err != nil {
+	if err := p.handleWorkloadNewBoundServices(workload, servicesToAdd); err != nil {
 		return fmt.Errorf("handleWorkloadNewBoundServices %s failed: %v", workload.ResourceName(), err)
 	}
 
@@ -621,23 +643,55 @@ func (p *Processor) handleWorkload(workload *workloadapi.Workload) error {
 	return nil
 }
 
-// compareWorkloadServices compares workload.Services with existing ones and return the unbounded EndpointKeys and new bound services IDs.
-func (p *Processor) compareWorkloadServices(workload *workloadapi.Workload) ([]bpf.EndpointKey, []uint32) {
+// compareWorkloadServices compares workload.Services with existing ones and return the unbounded EndpointKeys and a map of slots to add.
+func (p *Processor) compareWorkloadServices(workload *workloadapi.Workload) ([]bpf.EndpointKey, map[uint32]uint32) {
 	workloadUid := p.hashName.Hash(workload.Uid)
+	
+	capacity := uint32(1)
+	if c := workload.GetCapacity(); c != nil && c.GetValue() > 0 {
+		capacity = c.GetValue()
+	}
+
 	allServices := sets.New[uint32]()
 	for svcKey := range workload.Services {
 		allServices.Insert(p.hashName.Hash(svcKey))
 	}
+
 	unboundedEndpointKeys := []bpf.EndpointKey{}
+	servicesToAdd := make(map[uint32]uint32)
+
+	// Group existing keys by ServiceId
+	currentSlots := make(map[uint32][]bpf.EndpointKey)
 	eks := p.bpf.GetEndpointKeys(workloadUid)
 	for ek := range eks {
-		if !allServices.Contains(ek.ServiceId) {
-			unboundedEndpointKeys = append(unboundedEndpointKeys, ek)
-		}
-		allServices.Delete(ek.ServiceId)
+		currentSlots[ek.ServiceId] = append(currentSlots[ek.ServiceId], ek)
 	}
-	newServices := allServices.UnsortedList()
-	return unboundedEndpointKeys, newServices
+
+	for svcId, keys := range currentSlots {
+		if !allServices.Contains(svcId) {
+			// Service completely unbound, remove all its keys
+			unboundedEndpointKeys = append(unboundedEndpointKeys, keys...)
+		} else {
+			// Service still bound. Check capacity difference.
+			currCount := uint32(len(keys))
+			if currCount > capacity {
+				// Capacity dropped, delete the excess keys
+				unboundedEndpointKeys = append(unboundedEndpointKeys, keys[capacity:]...)
+			} else if currCount < capacity {
+				// Capacity increased, need to add more slots
+				servicesToAdd[svcId] = capacity - currCount
+			}
+			// Mark as processed
+			allServices.Delete(svcId)
+		}
+	}
+
+	// Any services remaining in allServices are completely new bindings
+	for svcId := range allServices {
+		servicesToAdd[svcId] = capacity
+	}
+
+	return unboundedEndpointKeys, servicesToAdd
 }
 
 func (p *Processor) updateServiceFrontendMap(serviceId uint32, service *workloadapi.Service) error {
@@ -953,31 +1007,48 @@ func (p *Processor) handleServicesAndWorkloads(services []*workloadapi.Service, 
 
 	for _, workload := range workloads {
 		if workload.GetAddresses() == nil {
-			if p.DnsResolverChan == nil {
-				log.Warnf("workload %s/%s has nil addresses but DNS resolver is disabled", workload.Namespace, workload.Name)
-				continue
-			}
-
-			uid := workload.GetUid()
-			p.ResolvedDomainChanMap[uid] = make(chan *workloadapi.Workload)
-			p.DnsResolverChan <- workload
-			log.Infof("waiting for DNS resolution: %s/%s/%s", workload.Namespace, workload.Name, uid)
-
-			select {
-			case <-time.After(dnsResolveTimeout):
-				log.Warnf("DNS resolution timeout for workload %s/%s/%s, skip handling", workload.Namespace, workload.Name, uid)
-				if ch, ok := p.ResolvedDomainChanMap[uid]; ok {
-					close(ch)
-					delete(p.ResolvedDomainChanMap, uid)
-				}
-				continue
-			case newWorkload := <-p.ResolvedDomainChanMap[uid]:
-				if newWorkload == nil || newWorkload.GetAddresses() == nil {
-					log.Warnf("workload %s/%s resolved addresses is nil, skip handling", workload.Namespace, workload.Name)
+			if gw := workload.GetNetworkGateway(); gw != nil && gw.GetAddress() != nil {
+				// Remote workload routed via EW gateway.
+				// Resolve the service VIP for this workload's network and use it as the
+				// backend IP (embedded in TLV). Capacity is handled in handleWorkloadNewBoundServices
+				// by inserting the BackendUid into the endpoint map N times — no synthetic UIDs.
+				vip := p.resolveNetworkVIP(workload)
+				if vip == nil {
+					log.Warnf("workload %s has networkGateway but no VIP resolved for network %s, skipping",
+						workload.ResourceName(), workload.GetNetwork())
 					continue
 				}
-				log.Infof("workload %s/%s addresses resolved: %v", newWorkload.Namespace, newWorkload.Name, newWorkload.Addresses)
-				workload = newWorkload
+				workload.Addresses = [][]byte{vip}
+				log.Debugf("workload %s resolved VIP %v for network %s (capacity=%v)",
+					workload.ResourceName(), vip, workload.GetNetwork(), workload.GetCapacity())
+				// Fall through to handleWorkload — capacity loop runs in handleWorkloadNewBoundServices
+			} else {
+				if p.DnsResolverChan == nil {
+					log.Warnf("workload %s/%s has nil addresses but DNS resolver is disabled", workload.Namespace, workload.Name)
+					continue
+				}
+
+				uid := workload.GetUid()
+				p.ResolvedDomainChanMap[uid] = make(chan *workloadapi.Workload)
+				p.DnsResolverChan <- workload
+				log.Infof("waiting for DNS resolution: %s/%s/%s", workload.Namespace, workload.Name, uid)
+
+				select {
+				case <-time.After(dnsResolveTimeout):
+					log.Warnf("DNS resolution timeout for workload %s/%s/%s, skip handling", workload.Namespace, workload.Name, uid)
+					if ch, ok := p.ResolvedDomainChanMap[uid]; ok {
+						close(ch)
+						delete(p.ResolvedDomainChanMap, uid)
+					}
+					continue
+				case newWorkload := <-p.ResolvedDomainChanMap[uid]:
+					if newWorkload == nil || newWorkload.GetAddresses() == nil {
+						log.Warnf("workload %s/%s resolved addresses is nil, skip handling", workload.Namespace, workload.Name)
+						continue
+					}
+					log.Infof("workload %s/%s addresses resolved: %v", newWorkload.Namespace, newWorkload.Name, newWorkload.Addresses)
+					workload = newWorkload
+				}
 			}
 		}
 
@@ -1218,3 +1289,30 @@ func (p *Processor) deleteFrontendByIp(addresses [][]byte) error {
 
 	return nil
 }
+
+// resolveNetworkVIP finds the service VIP for the workload's network from the ServiceCache.
+//
+// Example: workload on network2 for service "sample/helloworld.sample.svc.cluster.local"
+// → ServiceCache entry has addresses: [network1/10.255.10.31, network2/10.255.20.230]
+// → Returns 10.255.20.230
+//
+// This IP is stored in backend_value.Ip and embedded in the TLV header by the BPF sock_ops
+// layer so the EW gateway knows where to forward internally.
+func (p *Processor) resolveNetworkVIP(workload *workloadapi.Workload) []byte {
+	network := workload.GetNetwork()
+
+	for svcKey := range workload.GetServices() {
+		svc := p.ServiceCache.GetService(svcKey)
+		if svc == nil {
+			log.Debugf("resolveNetworkVIP: service %s not in cache yet for workload %s", svcKey, workload.ResourceName())
+			continue
+		}
+		for _, netAddr := range svc.GetAddresses() {
+			if netAddr.GetNetwork() == network && len(netAddr.GetAddress()) > 0 {
+				return netAddr.GetAddress()
+			}
+		}
+	}
+	return nil
+}
+


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR introduces native multicluster routing capabilities to Kmesh by enabling the BPF data plane to dynamically redirect cross-cluster traffic through Istio East-West (EW) Gateways. 

Previously, Kmesh attempted to route cross-network traffic directly to unreachable remote Pod IPs. This PR introduces a gateway-aware routing layer into the BPF pipeline and capacity-aware endpoint repetition logic to the control plane, ensuring seamless cross-cluster communication without needing complex tunneling protocols or sidecars on application pods.

Key implementations:
* **BPF Gateway Manager**: Extended the C and Go `backend_value` structs to hold `gw_addr` and `gw_port`. Introduced a new `gateway_manager()` routing priority in `backend.h` that performs DNAT to the EW gateway and sets `via_waypoint = true` to trigger Kmesh's TLV metadata injection.
* **Network VIP Resolution**: Modified `workload_processor.go` to intercept remote workloads via their `network_gateway` tag, resolving and embedding the routable Service VIP in the TLV instead of unroutable Pod IPs.
* **Proportional Load Balancing (Endpoint Repetition)**: Extended `workload.proto` to include a `capacity` field. Added a highly optimized delta-scaling algorithm (`compareWorkloadServices`) that surgically adds or deletes duplicate `BackendUid` slots in the BPF `endpoint_map` based on cluster capacity, achieving perfect multi-primary traffic distribution.
* **Frontend Map Protection**: Bypassed frontend map insertion for remote EW workloads to prevent catastrophic VIP overwrites.
* **Build System Fixes**: Updated `api/v2-c/Makefile` to properly compile `protobuf-c` wrapper dependencies.
* **Documentation**: Published the detailed architecture design proposal.

**Special notes for your reviewer**:

- **BPF Map Layout**: The `backend_value` struct was extended with `#pragma pack(1)`. `gw_addr` and `gw_port` are strictly appended to the end of the struct to ensure binary compatibility and memory safety across BPF daemon restarts.
- **Performance**: Endpoint repetition deliberately consumes extra slots in the `endpoint_map` (which is highly scalable and lightweight) to completely avoid duplicating the memory-heavy `backend_map` entries. 
- You can review the full architecture breakdown in the attached `docs/proposal/multicluster_routing_via_ew_gateway-en.md`.

**Does this PR introduce a user-facing change?**:
```release-note
Introduced multicluster service-to-service routing support in Kmesh via Istio East-West Gateways. Traffic between disparate cluster networks is now transparently redirected through the gateway with exact proportional load balancing and TLV-based destination preservation.
