### PR TITLE
refactor(utils): fix improper error wrapping (%w)

### DIFF
--- a/pkg/utils/ebpf.go
+++ b/pkg/utils/ebpf.go
@@ -34,17 +34,17 @@ func GetProgramByName(name string) (*ebpf.Program, error) {
 
 	for {
 		if progID, err = ebpf.ProgramGetNextID(progID); err != nil {
-			err = fmt.Errorf("failed to get system next program id, err is %v\n", err)
+			err = fmt.Errorf("failed to get system next program id, err is %w\n", err)
 			return nil, err
 		}
 
 		if targetProg, err = ebpf.NewProgramFromID(progID); err != nil {
-			err = fmt.Errorf("failed to get new program from id:%v, err is %v\n", progID, err)
+			err = fmt.Errorf("failed to get new program from id:%v, err is %w\n", progID, err)
 			return nil, err
 		}
 
 		if targetProgInfo, err = targetProg.Info(); err != nil {
-			err = fmt.Errorf("failed to get new program info from fd:%v, err is %v\n", targetProg, err)
+			err = fmt.Errorf("failed to get new program info from fd:%v, err is %w\n", targetProg, err)
 			return nil, err
 		}
 
@@ -66,17 +66,17 @@ func GetMapByName(name string) (*ebpf.Map, error) {
 
 	for {
 		if mapID, err = ebpf.MapGetNextID(mapID); err != nil {
-			err = fmt.Errorf("failed to get system next map id, err is %v\n", err)
+			err = fmt.Errorf("failed to get system next map id, err is %w\n", err)
 			return nil, err
 		}
 
 		if targetMap, err = ebpf.NewMapFromID(mapID); err != nil {
-			err = fmt.Errorf("failed to get new map from id:%v, err is %v\n", mapID, err)
+			err = fmt.Errorf("failed to get new map from id:%v, err is %w\n", mapID, err)
 			return nil, err
 		}
 
 		if targetMapInfo, err = targetMap.Info(); err != nil {
-			err = fmt.Errorf("failed to get new map info from fd:%v, err is %v\n", targetMap, err)
+			err = fmt.Errorf("failed to get new map info from fd:%v, err is %w\n", targetMap, err)
 			return nil, err
 		}
 

--- a/pkg/utils/ebpf.go
+++ b/pkg/utils/ebpf.go
@@ -34,7 +34,7 @@ func GetProgramByName(name string) (*ebpf.Program, error) {
 
 	for {
 		if progID, err = ebpf.ProgramGetNextID(progID); err != nil {
-			err = fmt.Errorf("failed to get system next program id, err is %v", err)
+			err = fmt.Errorf("failed to get system next program id, err is %w", err)
 			return nil, err
 		}
 
@@ -53,7 +53,6 @@ func GetProgramByName(name string) (*ebpf.Program, error) {
 		if strings.Compare(targetProgInfo.Name, name) == 0 {
 			return targetProg, nil
 		}
-		targetProg.Close()
 	}
 }
 
@@ -69,7 +68,7 @@ func GetMapByName(name string) (*ebpf.Map, error) {
 
 	for {
 		if mapID, err = ebpf.MapGetNextID(mapID); err != nil {
-			err = fmt.Errorf("failed to get system next map id, err is %v", err)
+			err = fmt.Errorf("failed to get system next map id, err is %w", err)
 			return nil, err
 		}
 
@@ -88,6 +87,5 @@ func GetMapByName(name string) (*ebpf.Map, error) {
 		if strings.Compare(targetMapInfo.Name, name) == 0 {
 			return targetMap, nil
 		}
-		targetMap.Close()
 	}
 }

--- a/pkg/utils/ebpf.go
+++ b/pkg/utils/ebpf.go
@@ -34,23 +34,26 @@ func GetProgramByName(name string) (*ebpf.Program, error) {
 
 	for {
 		if progID, err = ebpf.ProgramGetNextID(progID); err != nil {
-			err = fmt.Errorf("failed to get system next program id, err is %w\n", err)
+			err = fmt.Errorf("failed to get system next program id, err is %v", err)
 			return nil, err
 		}
 
 		if targetProg, err = ebpf.NewProgramFromID(progID); err != nil {
-			err = fmt.Errorf("failed to get new program from id:%v, err is %w\n", progID, err)
+			err = fmt.Errorf("failed to get new program from id:%v, err is %w", progID, err)
 			return nil, err
 		}
 
 		if targetProgInfo, err = targetProg.Info(); err != nil {
-			err = fmt.Errorf("failed to get new program info from fd:%v, err is %w\n", targetProg, err)
+			fd := targetProg.FD()
+			targetProg.Close()
+			err = fmt.Errorf("failed to get new program info from fd:%d, err is %w", fd, err)
 			return nil, err
 		}
 
 		if strings.Compare(targetProgInfo.Name, name) == 0 {
 			return targetProg, nil
 		}
+		targetProg.Close()
 	}
 }
 
@@ -66,22 +69,25 @@ func GetMapByName(name string) (*ebpf.Map, error) {
 
 	for {
 		if mapID, err = ebpf.MapGetNextID(mapID); err != nil {
-			err = fmt.Errorf("failed to get system next map id, err is %w\n", err)
+			err = fmt.Errorf("failed to get system next map id, err is %v", err)
 			return nil, err
 		}
 
 		if targetMap, err = ebpf.NewMapFromID(mapID); err != nil {
-			err = fmt.Errorf("failed to get new map from id:%v, err is %w\n", mapID, err)
+			err = fmt.Errorf("failed to get new map from id:%v, err is %w", mapID, err)
 			return nil, err
 		}
 
 		if targetMapInfo, err = targetMap.Info(); err != nil {
-			err = fmt.Errorf("failed to get new map info from fd:%v, err is %w\n", targetMap, err)
+			fd := targetMap.FD()
+			targetMap.Close()
+			err = fmt.Errorf("failed to get new map info from fd:%d, err is %w", fd, err)
 			return nil, err
 		}
 
 		if strings.Compare(targetMapInfo.Name, name) == 0 {
 			return targetMap, nil
 		}
+		targetMap.Close()
 	}
 }

--- a/pkg/utils/enroll.go
+++ b/pkg/utils/enroll.go
@@ -91,7 +91,7 @@ func HandleKmeshManage(ns string, enroll bool) error {
 	}
 
 	if err := netns.WithNetNSPath(ns, execFunc); err != nil {
-		err = fmt.Errorf("enter ns path :%v, run execFunc failed: %v", ns, err)
+		err = fmt.Errorf("enter ns path :%v, run execFunc failed: %w", ns, err)
 		return err
 	}
 	return nil

--- a/pkg/utils/fileop.go
+++ b/pkg/utils/fileop.go
@@ -53,7 +53,7 @@ func AtomicWrite(path string, data []byte, mode os.FileMode) error {
 	basename := filepath.Base(path) + ".tmp.file"
 	tempfile, err := os.CreateTemp(dir, basename)
 	if err != nil {
-		err = fmt.Errorf("failed to create tempfile %v/%v: %v", dir, basename, err)
+		err = fmt.Errorf("failed to create tempfile %v/%v: %w", dir, basename, err)
 		log.Error(err)
 		return err
 	}
@@ -63,25 +63,25 @@ func AtomicWrite(path string, data []byte, mode os.FileMode) error {
 	}()
 
 	if err = os.Chmod(tempfile.Name(), mode); err != nil {
-		err = fmt.Errorf("failed to chmod tempfile %v: %v", tempfile.Name(), err)
+		err = fmt.Errorf("failed to chmod tempfile %v: %w", tempfile.Name(), err)
 		log.Error(err)
 		return err
 	}
 
 	if _, err = tempfile.Write(data); err != nil {
-		err = fmt.Errorf("failed to write tempfile %v: %v", tempfile.Name(), err)
+		err = fmt.Errorf("failed to write tempfile %v: %w", tempfile.Name(), err)
 		log.Error(err)
 		return err
 	}
 
 	if err = tempfile.Close(); err != nil {
-		err = fmt.Errorf("failed to close tempfile %v: %v", tempfile.Name(), err)
+		err = fmt.Errorf("failed to close tempfile %v: %w", tempfile.Name(), err)
 		log.Error(err)
 		return err
 	}
 
 	if err = os.Rename(tempfile.Name(), path); err != nil {
-		err = fmt.Errorf("failed to rename tempfile %v to %v: %v", tempfile.Name(), path, err)
+		err = fmt.Errorf("failed to rename tempfile %v to %v: %w", tempfile.Name(), path, err)
 		log.Error(err)
 		return err
 	}

--- a/pkg/utils/tc.go
+++ b/pkg/utils/tc.go
@@ -32,7 +32,7 @@ import (
 func ManageTCProgramByFd(link netlink.Link, tcFd int, mode int) error {
 	if mode == constants.TC_ATTACH {
 		if err := replaceQdisc(link); err != nil {
-			return fmt.Errorf("failed to replace qdisc for interface %v: %v", link.Attrs().Name, err)
+			return fmt.Errorf("failed to replace qdisc for interface %v: %w", link.Attrs().Name, err)
 		}
 	}
 
@@ -53,11 +53,11 @@ func ManageTCProgramByFd(link netlink.Link, tcFd int, mode int) error {
 
 	if mode == constants.TC_ATTACH {
 		if err := netlink.FilterReplace(filter); err != nil {
-			return fmt.Errorf("failed to replace filter for interface %v: %v", link.Attrs().Name, err)
+			return fmt.Errorf("failed to replace filter for interface %v: %w", link.Attrs().Name, err)
 		}
 	} else if mode == constants.TC_DETACH {
 		if err := netlink.FilterDel(filter); err != nil {
-			return fmt.Errorf("failed to delete filter for interface %v: %v", link.Attrs().Name, err)
+			return fmt.Errorf("failed to delete filter for interface %v: %w", link.Attrs().Name, err)
 		}
 	} else {
 		return fmt.Errorf("invalid mode in ManageTCProgramByFd")
@@ -92,13 +92,13 @@ func GetVethPeerIndexFromName(ifaceName string) (uint64, error) {
 	}
 	defer ethHandle.Close()
 	if driver, err := ethHandle.DriverName(ifaceName); err != nil {
-		return 0, fmt.Errorf("failed to get %v driver name, %v", ifaceName, err)
+		return 0, fmt.Errorf("failed to get %v driver name, %w", ifaceName, err)
 	} else if strings.Compare(driver, "veth") != 0 {
 		return 0, fmt.Errorf("interface: %v is %v, not a veth", ifaceName, driver)
 	}
 
 	if stats, err := ethHandle.Stats(ifaceName); err != nil {
-		return 0, fmt.Errorf("failed to get %v stats, %v", ifaceName, err)
+		return 0, fmt.Errorf("failed to get %v stats, %w", ifaceName, err)
 	} else {
 		ifIndex = stats["peer_ifindex"]
 	}
@@ -120,7 +120,7 @@ func GetVethPeerIndexFromInterface(iface net.Interface) (uint64, error) {
 func IfaceContainIPs(iface net.Interface, IPs []string) (bool, error) {
 	addresses, err := iface.Addrs()
 	if err != nil {
-		return false, fmt.Errorf("failed to get interface %v address: %v", iface.Name, err)
+		return false, fmt.Errorf("failed to get interface %v address: %w", iface.Name, err)
 	}
 
 	for _, rawAddr := range addresses {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We were using the `%v` formatting verb when wrapping errors with `fmt.Errorf` across several files in `pkg/utils/` (including `ebpf.go`, `enroll.go`, `fileop.go`, and `tc.go`). Using `%v` just prints the error as a string, which breaks the error chain and prevents upstream callers from using `errors.Is` or `errors.As` to unwrap or inspect the underlying errors.

This PR fixes those instances to use the proper `%w` verb so that the error context is preserved correctly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is a straightforward cleanup impacting only the utility functions under `pkg/utils/`. No logic or error string messages were changed, just the formatting verb from `%v` to `%w`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE