### PR TITLE
fix: replace improper error wrapping with %w in fmt.Errorf calls

### DIFF
--- a/ctl/authz/authz.go
+++ b/ctl/authz/authz.go
@@ -212,10 +212,10 @@ func SetAuthzPerKmeshDaemon(cli kube.CLIClient, podName, info string) {
 func fetchAuthzStatus(cli kube.CLIClient, podName string) (string, error) {
 	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
 	if err != nil {
-		return "", fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
+		return "", fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %w", podName, err)
 	}
 	if err := fw.Start(); err != nil {
-		return "", fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
+		return "", fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %w", podName, err)
 	}
 	defer fw.Close()
 
@@ -223,14 +223,14 @@ func fetchAuthzStatus(cli kube.CLIClient, podName string) (string, error) {
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
-		return "", fmt.Errorf("error creating request: %v", err)
+		return "", fmt.Errorf("error creating request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to make HTTP request: %v", err)
+		return "", fmt.Errorf("failed to make HTTP request: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -240,7 +240,7 @@ func fetchAuthzStatus(cli kube.CLIClient, podName string) (string, error) {
 
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("failed to read response body: %v", err)
+		return "", fmt.Errorf("failed to read response body: %w", err)
 	}
 
 	status := string(bodyBytes)

--- a/ctl/log/log.go
+++ b/ctl/log/log.go
@@ -66,13 +66,13 @@ kmeshctl log <kmesh-daemon-pod> default`,
 func GetJson(url string, val any) error {
 	resp, err := http.Get(url)
 	if err != nil {
-		return fmt.Errorf("failed making GET request(%s): %v", url, err)
+		return fmt.Errorf("failed making GET request(%s): %w", url, err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("failed reading response body(%s): %v", url, err)
+		return fmt.Errorf("failed reading response body(%s): %w", url, err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
@@ -81,7 +81,7 @@ func GetJson(url string, val any) error {
 
 	err = json.Unmarshal(body, val)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal response body: %v", err)
+		return fmt.Errorf("failed to unmarshal response body: %w", err)
 	}
 
 	return nil

--- a/ctl/utils/utils.go
+++ b/ctl/utils/utils.go
@@ -31,7 +31,7 @@ const (
 func CreateKubeClient() (kube.CLIClient, error) {
 	cli, err := kube.NewCLIClient()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create kube client: %v", err)
+		return nil, fmt.Errorf("failed to create kube client: %w", err)
 	}
 
 	return cli, nil
@@ -41,7 +41,7 @@ func CreateKubeClient() (kube.CLIClient, error) {
 func CreateKmeshPortForwarder(cliClient kube.CLIClient, podName string) (kube.PortForwarder, error) {
 	fw, err := cliClient.NewPortForwarder(podName, KmeshNamespace, "", 0, KmeshAdminPort)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create port forwarder: %v", err)
+		return nil, fmt.Errorf("failed to create port forwarder: %w", err)
 	}
 
 	return fw, nil

--- a/ctl/waypoint/waypoint.go
+++ b/ctl/waypoint/waypoint.go
@@ -170,7 +170,7 @@ func NewCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			gw, err := makeGateway(false)
 			if err != nil {
-				return fmt.Errorf("failed to create gateway: %v", err)
+				return fmt.Errorf("failed to create gateway: %w", err)
 			}
 			b, err := yaml.Marshal(gw)
 			if err != nil {
@@ -205,7 +205,7 @@ func NewCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			kubeClient, err := utils.CreateKubeClient()
 			if err != nil {
-				return fmt.Errorf("failed to create Kubernetes client: %v", err)
+				return fmt.Errorf("failed to create Kubernetes client: %w", err)
 			}
 			ns := namespaceOrDefault(namespace)
 			// If a user decides to enroll their namespace with a waypoint, verify that they have labeled their namespace as Kmesh.
@@ -229,7 +229,7 @@ func NewCmd() *cobra.Command {
 				}
 				namespaceIsLabeledKmesh, err := namespaceHasLabelWithValue(kubeClient, ns, label.IoIstioDataplaneMode.Name, DataplaneModeKmesh)
 				if err != nil {
-					return fmt.Errorf("failed to check if namespace is labeled Kmesh: %v", err)
+					return fmt.Errorf("failed to check if namespace is labeled Kmesh: %w", err)
 				}
 				if !namespaceIsLabeledKmesh {
 					fmt.Fprintf(cmd.OutOrStdout(), "Warning: namespace is not enrolled in Kmesh. Consider running\t"+
@@ -238,7 +238,7 @@ func NewCmd() *cobra.Command {
 			}
 			gw, err := makeGateway(true)
 			if err != nil {
-				return fmt.Errorf("failed to create gateway: %v", err)
+				return fmt.Errorf("failed to create gateway: %w", err)
 			}
 
 			_, err = kubeClient.GatewayAPI().GatewayV1().Gateways(ns).Create(context.Background(), gw, metav1.CreateOptions{
@@ -246,7 +246,7 @@ func NewCmd() *cobra.Command {
 			})
 			if err != nil {
 				if errors.IsNotFound(err) {
-					return fmt.Errorf("missing Kubernetes Gateway CRDs need to be installed before applying a waypoint: %s", err)
+					return fmt.Errorf("missing Kubernetes Gateway CRDs need to be installed before applying a waypoint: %w", err)
 				}
 				return err
 			}
@@ -282,7 +282,7 @@ func NewCmd() *cobra.Command {
 			if enrollNamespace {
 				err = labelNamespaceWithWaypoint(kubeClient, ns)
 				if err != nil {
-					return fmt.Errorf("failed to label namespace with waypoint: %v", err)
+					return fmt.Errorf("failed to label namespace with waypoint: %w", err)
 				}
 				fmt.Fprintf(cmd.OutOrStdout(), "namespace %v labeled with \"%v: %v\"\n", ns,
 					KmeshUseWaypointLabel, gw.Name)
@@ -321,7 +321,7 @@ func NewCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			kubeClient, err := utils.CreateKubeClient()
 			if err != nil {
-				return fmt.Errorf("failed to create Kubernetes client: %v", err)
+				return fmt.Errorf("failed to create Kubernetes client: %w", err)
 			}
 			ns := namespaceOrDefault(namespace)
 			gws, err := kubeClient.GatewayAPI().GatewayV1().Gateways(ns).
@@ -350,7 +350,7 @@ func NewCmd() *cobra.Command {
 			}
 			err = printWaypointStatus(w, kubeClient, filteredGws)
 			if err != nil {
-				return fmt.Errorf("failed to print waypoint status: %v", err)
+				return fmt.Errorf("failed to print waypoint status: %w", err)
 			}
 			return w.Flush()
 		},
@@ -383,7 +383,7 @@ func NewCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			kubeClient, err := utils.CreateKubeClient()
 			if err != nil {
-				return fmt.Errorf("failed to create Kubernetes client: %v", err)
+				return fmt.Errorf("failed to create Kubernetes client: %w", err)
 			}
 			ns := namespaceOrDefault(namespace)
 
@@ -411,7 +411,7 @@ func NewCmd() *cobra.Command {
 			writer := cmd.OutOrStdout()
 			kubeClient, err := utils.CreateKubeClient()
 			if err != nil {
-				return fmt.Errorf("failed to create Kubernetes client: %v", err)
+				return fmt.Errorf("failed to create Kubernetes client: %w", err)
 			}
 			var ns string
 			if allNamespaces {
@@ -579,7 +579,7 @@ func labelNamespaceWithWaypoint(kubeClient kube.CLIClient, ns string) error {
 	}
 	nsObj.Labels[KmeshUseWaypointLabel] = waypointName
 	if _, err := kubeClient.Kube().CoreV1().Namespaces().Update(context.Background(), nsObj, metav1.UpdateOptions{}); err != nil {
-		return fmt.Errorf("failed to update namespace %s: %v", ns, err)
+		return fmt.Errorf("failed to update namespace %s: %w", ns, err)
 	}
 	return nil
 }
@@ -589,7 +589,7 @@ func getNamespace(kubeClient kube.CLIClient, ns string) (*corev1.Namespace, erro
 	if errors.IsNotFound(err) {
 		return nil, fmt.Errorf("namespace: %s not found", ns)
 	} else if err != nil {
-		return nil, fmt.Errorf("failed to get namespace %s: %v", ns, err)
+		return nil, fmt.Errorf("failed to get namespace %s: %w", ns, err)
 	}
 	return nsObj, nil
 }

--- a/daemon/options/options.go
+++ b/daemon/options/options.go
@@ -58,10 +58,10 @@ func (c *BootstrapConfigs) AttachFlags(cmd *cobra.Command) {
 
 func (c *BootstrapConfigs) ParseConfigs() error {
 	if err := c.BpfConfig.ParseConfig(); err != nil {
-		return fmt.Errorf("parse BpfConfig failed, %v", err)
+		return fmt.Errorf("parse BpfConfig failed, %w", err)
 	}
 	if err := c.CniConfig.ParseConfig(); err != nil {
-		return fmt.Errorf("parse CniConfig failed, %v", err)
+		return fmt.Errorf("parse CniConfig failed, %w", err)
 	}
 	return nil
 }

--- a/pkg/bpf/ads/loader.go
+++ b/pkg/bpf/ads/loader.go
@@ -109,15 +109,15 @@ func (sc *BpfAds) Start() error {
 		if errors.As(err, &ve) {
 			return fmt.Errorf("bpf load failed: %+v", ve)
 		}
-		return fmt.Errorf("bpf load failed: %v", err)
+		return fmt.Errorf("bpf load failed: %w", err)
 	}
 
 	if err := sc.Attach(); err != nil {
-		return fmt.Errorf("bpf attach failed, %s", err)
+		return fmt.Errorf("bpf attach failed, %w", err)
 	}
 
 	if err := sc.ApiEnvCfg(); err != nil {
-		return fmt.Errorf("api env config failed, %s", err)
+		return fmt.Errorf("api env config failed, %w", err)
 	}
 
 	ret := C.deserial_init()
@@ -126,7 +126,7 @@ func (sc *BpfAds) Start() error {
 	}
 
 	if err := maglev.InitMaglevMap(); err != nil {
-		return fmt.Errorf("consistent hash lb maglev config init failed, %s", err)
+		return fmt.Errorf("consistent hash lb maglev config init failed, %w", err)
 	}
 
 	return nil

--- a/pkg/bpf/ads/loader_enhanced.go
+++ b/pkg/bpf/ads/loader_enhanced.go
@@ -109,11 +109,11 @@ func (sc *BpfAds) Start() error {
 		if errors.As(err, &ve) {
 			return fmt.Errorf("bpf Load failed: %+v", ve)
 		}
-		return fmt.Errorf("bpf Load failed: %v", err)
+		return fmt.Errorf("bpf load failed: %w", err)
 	}
 
 	if err := sc.Attach(); err != nil {
-		return fmt.Errorf("bpf Attach failed, %s", err)
+		return fmt.Errorf("bpf attach failed, %w", err)
 	}
 
 	if err := sc.ApiEnvCfg(); err != nil {

--- a/pkg/bpf/utils/pin.go
+++ b/pkg/bpf/utils/pin.go
@@ -33,10 +33,10 @@ func PinPrograms(value *reflect.Value, path string) error {
 
 		info, err := tp.Info()
 		if err != nil {
-			return fmt.Errorf("get prog info failed, %s", err)
+			return fmt.Errorf("get prog info failed, %w", err)
 		}
 		if err := tp.Pin(path + info.Name); err != nil {
-			return fmt.Errorf("pin prog failed, %s", err)
+			return fmt.Errorf("pin prog failed, %w", err)
 		}
 	}
 
@@ -50,7 +50,7 @@ func UnpinPrograms(value *reflect.Value) error {
 			continue
 		}
 		if err := tp.Unpin(); err != nil {
-			return fmt.Errorf("unpin prog failed, %s", err)
+			return fmt.Errorf("unpin prog failed, %w", err)
 		}
 	}
 
@@ -64,7 +64,7 @@ func UnpinMaps(value *reflect.Value) error {
 			continue
 		}
 		if err := tp.Unpin(); err != nil {
-			return fmt.Errorf("unpin map failed, %s", err)
+			return fmt.Errorf("unpin map failed, %w", err)
 		}
 	}
 

--- a/pkg/bpf/workload/loader.go
+++ b/pkg/bpf/workload/loader.go
@@ -83,11 +83,11 @@ func (w *BpfWorkload) Start() error {
 		if errors.As(err, &ve) {
 			return fmt.Errorf("bpf Load failed: %+v", ve)
 		}
-		return fmt.Errorf("bpf Load failed: %v", err)
+		return fmt.Errorf("bpf load failed: %w", err)
 	}
 
 	if err := w.Attach(); err != nil {
-		return fmt.Errorf("bpf Attach failed, %s", err)
+		return fmt.Errorf("bpf attach failed, %w", err)
 	}
 
 	if err := w.ApiEnvCfg(); err != nil {
@@ -95,7 +95,7 @@ func (w *BpfWorkload) Start() error {
 	}
 
 	if err := w.DeserialInit(); err != nil {
-		return fmt.Errorf("failed to init deserialization: %v", err)
+		return fmt.Errorf("failed to init deserialization: %w", err)
 	}
 	return nil
 }

--- a/pkg/cache/v2/maps/authz.go
+++ b/pkg/cache/v2/maps/authz.go
@@ -111,7 +111,7 @@ func AuthorizationUpdate(policyKey uint32, value *security_v2.Authorization) err
 	cKey := C.uint(policyKey)
 	cMsg, err := authorizationToClang(value)
 	if err != nil {
-		return fmt.Errorf("authorizationUpdate %s", err)
+		return fmt.Errorf("authorizationUpdate %w", err)
 	}
 	defer authorizationFreeClang(cMsg)
 

--- a/pkg/cache/v2/maps/cluster.go
+++ b/pkg/cache/v2/maps/cluster.go
@@ -116,7 +116,7 @@ func ClusterUpdate(key string, value *cluster_v2.Cluster) error {
 
 	cMsg, err := clusterToClang(value)
 	if err != nil {
-		return fmt.Errorf("ClusterUpdate %s", err)
+		return fmt.Errorf("ClusterUpdate %w", err)
 	}
 	if cMsg == nil {
 		return nil

--- a/pkg/cache/v2/maps/listener.go
+++ b/pkg/cache/v2/maps/listener.go
@@ -102,7 +102,7 @@ func ListenerLookup(key *core_v2.SocketAddress, value *listener_v2.Listener) err
 
 	cKey, err := socketAddressToClang(key)
 	if err != nil {
-		return fmt.Errorf("ListenerLookup %s", err)
+		return fmt.Errorf("ListenerLookup %w", err)
 	}
 	if cKey == nil {
 		return nil
@@ -129,7 +129,7 @@ func ListenerUpdate(key *core_v2.SocketAddress, value *listener_v2.Listener) err
 
 	cKey, err := socketAddressToClang(key)
 	if err != nil {
-		return fmt.Errorf("ListenerLookup %s", err)
+		return fmt.Errorf("ListenerUpdate %w", err)
 	}
 	if cKey == nil {
 		return nil
@@ -138,7 +138,7 @@ func ListenerUpdate(key *core_v2.SocketAddress, value *listener_v2.Listener) err
 
 	cMsg, err := listenerToClang(value)
 	if err != nil {
-		return fmt.Errorf("ListenerUpdate %s", err)
+		return fmt.Errorf("ListenerUpdate %w", err)
 	}
 	if cMsg == nil {
 		return nil
@@ -164,7 +164,7 @@ func ListenerDelete(key *core_v2.SocketAddress) error {
 
 	cKey, err := socketAddressToClang(key)
 	if err != nil {
-		return fmt.Errorf("ListenerLookup %s", err)
+		return fmt.Errorf("ListenerDelete %w", err)
 	}
 	if cKey == nil {
 		return nil

--- a/pkg/cache/v2/maps/route.go
+++ b/pkg/cache/v2/maps/route.go
@@ -116,7 +116,7 @@ func RouteConfigUpdate(key string, value *route_v2.RouteConfiguration) error {
 
 	cMsg, err := routeConfigToClang(value)
 	if err != nil {
-		return fmt.Errorf("RouteConfigUpdate %s", err)
+		return fmt.Errorf("RouteConfigUpdate %w", err)
 	}
 	if cMsg == nil {
 		return nil

--- a/pkg/cni/chained.go
+++ b/pkg/cni/chained.go
@@ -43,7 +43,7 @@ func (i *Installer) getCniConfigPath() (string, error) {
 		confFile = filepath.Join(i.CniMountNetEtcDIR, i.CniConfigName)
 		confList, err := libcni.ConfListFromFile(confFile)
 		if err != nil {
-			err = fmt.Errorf("failed to read conflist %v : %v", confFile, err)
+			err = fmt.Errorf("failed to read conflist %v : %w", confFile, err)
 			log.Error(err)
 			return "", err
 		}
@@ -55,7 +55,7 @@ func (i *Installer) getCniConfigPath() (string, error) {
 	} else {
 		files, err := libcni.ConfFiles(i.CniMountNetEtcDIR, []string{".conflist"})
 		if err != nil {
-			err = fmt.Errorf("failed to load conflist from dir :%v, : %v", i.CniMountNetEtcDIR, err)
+			err = fmt.Errorf("failed to load conflist from dir %v: %w", i.CniMountNetEtcDIR, err)
 			log.Error(err)
 			return "", err
 		}
@@ -65,7 +65,7 @@ func (i *Installer) getCniConfigPath() (string, error) {
 		for _, file := range files {
 			confList, err = libcni.ConfListFromFile(file)
 			if err != nil {
-				err = fmt.Errorf("failed to read conflist: %v, %v", file, err)
+				err = fmt.Errorf("failed to read conflist: %v, %w", file, err)
 				log.Info(err)
 				continue
 			}
@@ -91,7 +91,7 @@ func (i *Installer) insertCNIConfig(oldconfig []byte, mode string) ([]byte, erro
 	var cniConfigMap map[string]interface{}
 	err := json.Unmarshal(oldconfig, &cniConfigMap)
 	if err != nil {
-		err = fmt.Errorf("failed to unmarshal json: %v", err)
+		err = fmt.Errorf("failed to unmarshal json: %w", err)
 		log.Error(err)
 		return nil, err
 	}
@@ -133,7 +133,7 @@ func (i *Installer) insertCNIConfig(oldconfig []byte, mode string) ([]byte, erro
 
 	byte, err := json.MarshalIndent(cniConfigMap, "", "  ")
 	if err != nil {
-		err = fmt.Errorf("failed to marshal json: %v", err)
+		err = fmt.Errorf("failed to marshal json: %w", err)
 		log.Error(err)
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func deleteCNIConfig(oldconfig []byte) ([]byte, error) {
 
 	err := json.Unmarshal(oldconfig, &cniConfigMap)
 	if err != nil {
-		err = fmt.Errorf("failed to unmarshal json: %v", err)
+		err = fmt.Errorf("failed to unmarshal json: %w", err)
 		log.Error(err)
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func deleteCNIConfig(oldconfig []byte) ([]byte, error) {
 
 	byte, err := json.MarshalIndent(cniConfigMap, "", "  ")
 	if err != nil {
-		err = fmt.Errorf("failed to marshal json: %v", err)
+		err = fmt.Errorf("failed to marshal json: %w", err)
 		log.Error(err)
 		return nil, err
 	}
@@ -193,7 +193,7 @@ func (i *Installer) chainedKmeshCniPlugin(mode string, cniMountNetEtcDIR string)
 	// and we harm no one by doing so.
 	err := copyBinary("/usr/bin/kmesh-cni", MountedCNIBinDir)
 	if err != nil {
-		return fmt.Errorf("copy binaries: %v", err)
+		return fmt.Errorf("copy binaries: %w", err)
 	}
 
 	// Install kubeconfig (if needed) - we write/update this in the shared node CNI bin dir,
@@ -201,7 +201,7 @@ func (i *Installer) chainedKmeshCniPlugin(mode string, cniMountNetEtcDIR string)
 	// unless it's missing or the contents are not what we expect.
 	kubeconfigFilepath := filepath.Join(cniMountNetEtcDIR, kmeshCniKubeConfig)
 	if err := maybeWriteKubeConfigFile(i.ServiceAccountPath, kubeconfigFilepath); err != nil {
-		return fmt.Errorf("write kubeconfig: %v", err)
+		return fmt.Errorf("write kubeconfig: %w", err)
 	}
 
 	cniConfigFilePath, err := i.getCniConfigPath()
@@ -216,7 +216,7 @@ func (i *Installer) chainedKmeshCniPlugin(mode string, cniMountNetEtcDIR string)
 
 	existCNIConfig, err := os.ReadFile(cniConfigFilePath)
 	if err != nil {
-		err = fmt.Errorf("failed to read cni config file %v : %v", cniConfigFilePath, err)
+		err = fmt.Errorf("failed to read cni config file %v : %w", cniConfigFilePath, err)
 		log.Error(err)
 		return err
 	}
@@ -256,7 +256,7 @@ func (i *Installer) removeChainedKmeshCniPlugin() error {
 	}
 	existCNIConfig, err := os.ReadFile(cniConfigFilePath)
 	if err != nil {
-		err = fmt.Errorf("failed to read cni config file %v : %v", cniConfigFilePath, err)
+		err = fmt.Errorf("failed to read cni config file %v : %w", cniConfigFilePath, err)
 		log.Error(err)
 		return err
 	}

--- a/pkg/cni/install.go
+++ b/pkg/cni/install.go
@@ -84,7 +84,7 @@ func NewInstaller(mode string,
 func (i *Installer) WatchServiceAccountToken() error {
 	tokenPath := i.ServiceAccountPath + "/token"
 	if err := i.Watcher.Add(tokenPath); err != nil {
-		return fmt.Errorf("failed to add %s to file watcher: %v", tokenPath, err)
+		return fmt.Errorf("failed to add %s to file watcher: %w", tokenPath, err)
 	}
 
 	// Start listening for events.

--- a/pkg/cni/plugin/plugin.go
+++ b/pkg/cni/plugin/plugin.go
@@ -141,7 +141,7 @@ func enableTcMarkEncrypt(args *skel.CmdArgs) error {
 	ifIndex = 0
 
 	if tc, err = utils.GetProgramByName(constants.TC_MARK_ENCRYPT); err != nil {
-		return fmt.Errorf("failed to get tc program: %v", err)
+		return fmt.Errorf("failed to get tc program: %w", err)
 	}
 
 	getVethPeerIndexFunc := func(netns.NetNS) error {
@@ -159,11 +159,11 @@ func enableTcMarkEncrypt(args *skel.CmdArgs) error {
 	}
 
 	if link, err = netlink.LinkByIndex(int(ifIndex)); err != nil {
-		return fmt.Errorf("failed to link valid interface, %v", err)
+		return fmt.Errorf("failed to link valid interface, %w", err)
 	}
 
 	if err = utils.ManageTCProgram(link, tc, constants.TC_ATTACH); err != nil {
-		return fmt.Errorf("failed to attach tc program, %v", err)
+		return fmt.Errorf("failed to attach tc program, %w", err)
 	}
 
 	return nil
@@ -190,20 +190,20 @@ func CmdAdd(args *skel.CmdArgs) error {
 
 	client, err := kube.CreateKubeClient(cniConf.KubeConfig)
 	if err != nil {
-		err = fmt.Errorf("failed to get k8s client: %v", err)
+		err = fmt.Errorf("failed to get k8s client: %w", err)
 		log.Error(err)
 		return err
 	}
 
 	pod, err := client.CoreV1().Pods(podNamespace).Get(context.TODO(), podName, metav1.GetOptions{})
 	if err != nil {
-		err = fmt.Errorf("failed to get pod: %v", err)
+		err = fmt.Errorf("failed to get pod: %w", err)
 		return err
 	}
 
 	namespace, err := client.CoreV1().Namespaces().Get(context.TODO(), pod.Namespace, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("failed to get namespace %s: %v", pod.Namespace, err)
+		return fmt.Errorf("failed to get namespace %s: %w", pod.Namespace, err)
 	}
 
 	enableKmesh := utils.ShouldEnroll(pod, namespace)
@@ -224,7 +224,7 @@ func CmdAdd(args *skel.CmdArgs) error {
 	if cniConf.Mode == constants.DualEngineMode {
 		enableXDPFunc := func(netns.NetNS) error {
 			if err := enableXdpAuth(args.IfName); err != nil {
-				err = fmt.Errorf("failed to set xdp to dev %v, err is %v", args.IfName, err)
+				err = fmt.Errorf("failed to set xdp to dev %v, err is %w", args.IfName, err)
 				return err
 			}
 			return nil

--- a/pkg/controller/ads/ads_controller.go
+++ b/pkg/controller/ads/ads_controller.go
@@ -67,7 +67,7 @@ func (c *Controller) AdsStreamCreateAndSend(client service_discovery_v3.Aggregat
 
 	stream, err := client.StreamAggregatedResources(ctx)
 	if err != nil {
-		return fmt.Errorf("StreamAggregatedResources failed, %s", err)
+		return fmt.Errorf("StreamAggregatedResources failed, %w", err)
 	}
 
 	c.con = &connection{
@@ -78,7 +78,7 @@ func (c *Controller) AdsStreamCreateAndSend(client service_discovery_v3.Aggregat
 
 	c.Processor.Reset()
 	if err := stream.Send(newAdsRequest(resource_v3.ClusterType, nil, "")); err != nil {
-		return fmt.Errorf("send request failed, %s", err)
+		return fmt.Errorf("send request failed, %w", err)
 	}
 	go sendUpstream(c.con)
 
@@ -92,7 +92,7 @@ func (c *Controller) HandleAdsStream() error {
 	)
 	if rsp, err = c.con.Stream.Recv(); err != nil {
 		_ = c.con.Stream.CloseSend()
-		return fmt.Errorf("stream recv failed, %s", err)
+		return fmt.Errorf("stream recv failed, %w", err)
 	}
 
 	// Because Kernel-Native mode is full update.

--- a/pkg/controller/bypass/bypass_controller.go
+++ b/pkg/controller/bypass/bypass_controller.go
@@ -163,7 +163,7 @@ func addIptables(ns string) error {
 		return nil
 	}
 	if err := netns.WithNetNSPath(ns, execFunc); err != nil {
-		return fmt.Errorf("enter namespace path: %v, run command failed: %v", ns, err)
+		return fmt.Errorf("enter namespace path: %v, run command failed: %w", ns, err)
 	}
 	return nil
 }
@@ -187,7 +187,7 @@ func deleteIptables(ns string) error {
 	}
 
 	if err := netns.WithNetNSPath(ns, execFunc); err != nil {
-		return fmt.Errorf("enter namespace path: %v, run command failed: %v", ns, err)
+		return fmt.Errorf("enter namespace path: %v, run command failed: %w", ns, err)
 	}
 	return nil
 }

--- a/pkg/controller/client.go
+++ b/pkg/controller/client.go
@@ -76,7 +76,7 @@ func (c *XdsClient) createGrpcStreamClient() error {
 	var err error
 
 	if c.grpcConn, err = nets.GrpcConnect(c.xdsConfig.DiscoveryAddress); err != nil {
-		return fmt.Errorf("grpc connect failed: %s", err)
+		return fmt.Errorf("grpc connect failed: %w", err)
 	}
 
 	c.client = discoveryv3.NewAggregatedDiscoveryServiceClient(c.grpcConn)
@@ -84,12 +84,12 @@ func (c *XdsClient) createGrpcStreamClient() error {
 	if c.mode == constants.DualEngineMode {
 		if err = c.WorkloadController.WorkloadStreamCreateAndSend(c.client, c.ctx); err != nil {
 			_ = c.grpcConn.Close()
-			return fmt.Errorf("create workload stream failed, %s", err)
+			return fmt.Errorf("create workload stream failed, %w", err)
 		}
 	} else if c.mode == constants.KernelNativeMode {
 		if err = c.AdsController.AdsStreamCreateAndSend(c.client, c.ctx); err != nil {
 			_ = c.grpcConn.Close()
-			return fmt.Errorf("create ads stream failed, %s", err)
+			return fmt.Errorf("create ads stream failed, %w", err)
 		}
 	}
 
@@ -148,7 +148,7 @@ func (c *XdsClient) handleUpstream(ctx context.Context) {
 
 func (c *XdsClient) Run(stopCh <-chan struct{}) error {
 	if err := c.createGrpcStreamClient(); err != nil {
-		return fmt.Errorf("create client and stream failed, %s", err)
+		return fmt.Errorf("create client and stream failed, %w", err)
 	}
 
 	go c.handleUpstream(c.ctx)

--- a/pkg/controller/manage/manage_controller.go
+++ b/pkg/controller/manage/manage_controller.go
@@ -117,7 +117,7 @@ func NewKmeshManageController(client kubernetes.Interface, sm *kmeshsecurity.Sec
 			c.handlePodDelete(obj)
 		},
 	}); err != nil {
-		return nil, fmt.Errorf("failed to add event handler to podInformer: %v", err)
+		return nil, fmt.Errorf("failed to add event handler to podInformer: %w", err)
 	}
 
 	if _, err := namespaceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -128,7 +128,7 @@ func NewKmeshManageController(client kubernetes.Interface, sm *kmeshsecurity.Sec
 			c.handleNamespaceUpdate(oldObj, newObj)
 		},
 	}); err != nil {
-		return nil, fmt.Errorf("failed to add event handler to namespaceInformer: %v", err)
+		return nil, fmt.Errorf("failed to add event handler to namespaceInformer: %w", err)
 	}
 
 	return c, nil
@@ -357,14 +357,14 @@ func (c *KmeshManageController) syncPod(key QueueItem) error {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to get pod %s/%s: %v", key.podNs, key.podName, err)
+		return fmt.Errorf("failed to get pod %s/%s: %w", key.podNs, key.podName, err)
 	}
 	namespace, err := c.namespaceLister.Get(pod.Namespace)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil
 		}
-		return fmt.Errorf("failed to get pod namespace %s: %v", pod.Namespace, err)
+		return fmt.Errorf("failed to get pod namespace %s: %w", pod.Namespace, err)
 	}
 
 	if key.action == ActionAddAnnotation && utils.ShouldEnroll(pod, namespace) {
@@ -507,7 +507,7 @@ func managleVethTc(ifIndex uint64, tcProgFd int, mode int) error {
 		link netlink.Link
 	)
 	if link, err = netlink.LinkByIndex(int(ifIndex)); err != nil {
-		return fmt.Errorf("failed to link valid interface, %v", err)
+		return fmt.Errorf("failed to link valid interface, %w", err)
 	}
 
 	return utils.ManageTCProgramByFd(link, tcProgFd, mode)
@@ -529,14 +529,14 @@ func linkTc(netNsPath string, tcProgFd int) error {
 	}
 
 	if err = netns.WithNetNSPath(netNsPath, warpGetVethPeerNum); err != nil {
-		err = fmt.Errorf("Run get veth peer num in netNsPath %v failed, err: %v", netNsPath, err)
+		err = fmt.Errorf("run get veth peer num in netNsPath %v failed, err: %w", netNsPath, err)
 		return err
 	}
 	// set tc on node namespace veth peer
 	if err = netns.WithNetNSPath(kmesh_netns.GetNodeNSpath(), func(_ netns.NetNS) error {
 		return managleVethTc(ifIndex, tcProgFd, constants.TC_ATTACH)
 	}); err != nil {
-		err = fmt.Errorf("Run link tc in netNsPath %v failed, err: %v", netNsPath, err)
+		err = fmt.Errorf("run link tc in netNsPath %v failed, err: %w", netNsPath, err)
 		return err
 	}
 
@@ -559,14 +559,14 @@ func unlinkTc(netNsPath string, tcProgFd int) error {
 	}
 
 	if err = netns.WithNetNSPath(netNsPath, warpGetVethPeerNum); err != nil {
-		err = fmt.Errorf("Run get veth peer num in netNsPath %v failed, err: %v", netNsPath, err)
+		err = fmt.Errorf("run get veth peer num in netNsPath %v failed, err: %w", netNsPath, err)
 		return err
 	}
 	// set tc on node namespace veth peer
 	if err := netns.WithNetNSPath(kmesh_netns.GetNodeNSpath(), func(_ netns.NetNS) error {
 		return managleVethTc(ifIndex, tcProgFd, constants.TC_DETACH)
 	}); err != nil {
-		err = fmt.Errorf("Run link tc in netNsPath %v failed, err: %v", netNsPath, err)
+		err = fmt.Errorf("run unlink tc in netNsPath %v failed, err: %w", netNsPath, err)
 		return err
 	}
 	return nil

--- a/pkg/controller/security/caclient.go
+++ b/pkg/controller/security/caclient.go
@@ -60,7 +60,7 @@ func newCaClient(opts *security.Options, tlsOpts *tlsOptions) (CaClient, error) 
 
 	conn, err := nets.GrpcConnect(caAddress)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create grpcconnect : %v", err)
+		return nil, fmt.Errorf("failed to create grpcconnect : %w", err)
 	}
 
 	c.conn = conn
@@ -91,7 +91,7 @@ func (c caClient) CsrSend(csrPEM []byte, certValidsec int64, identity string) ([
 	// when certificate acquisition fails. If it still fails, return an error.
 	resp, err := c.client.CreateCertificate(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("create certificate failed: %v", err)
+		return nil, fmt.Errorf("create certificate failed: %w", err)
 	}
 
 	if len(resp.CertChain) <= 1 {
@@ -141,7 +141,7 @@ func (c *caClient) FetchCert(identity string) (*security.SecretItem, error) {
 
 	expireTime, err := nodeagentutil.ParseCertAndGetExpiryTimestamp(certChain)
 	if err != nil {
-		return nil, fmt.Errorf("%s failed to extract expire time from server certificate in CSR response %+v: %v",
+		return nil, fmt.Errorf("%s failed to extract expire time from server certificate in CSR response %+v: %w",
 			identity, certChainPEM, err)
 	}
 

--- a/pkg/controller/security/mock/mockcaclient.go
+++ b/pkg/controller/security/mock/mockcaclient.go
@@ -54,7 +54,7 @@ func NewMockCaClient(opts *security.Options, certLifetime time.Duration) (*CACli
 	}
 	bundle, err := util.NewVerifiedKeyCertBundleFromFile(caCertPath, caKeyPath, certChainPath, rootCertPath)
 	if err != nil {
-		return nil, fmt.Errorf("mock ca client creation error: %v", err)
+		return nil, fmt.Errorf("mock ca client creation error: %w", err)
 	}
 	cl.bundle = bundle
 	return &cl, nil
@@ -67,12 +67,12 @@ func (c *CAClient) CsrSend(csrPEM []byte, certValidsec int64, identity string) (
 	signingCert, signingKey, certChain, rootCert := c.bundle.GetAll()
 	csr, err := util.ParsePemEncodedCSR(csrPEM)
 	if err != nil {
-		return nil, fmt.Errorf("csr sign error: %v", err)
+		return nil, fmt.Errorf("csr sign error: %w", err)
 	}
 	subjectIDs := []string{"test"}
 	certBytes, err := util.GenCertFromCSR(csr, signingCert, csr.PublicKey, *signingKey, subjectIDs, c.certLifetime, false)
 	if err != nil {
-		return nil, fmt.Errorf("csr sign error: %v", err)
+		return nil, fmt.Errorf("csr sign error: %w", err)
 	}
 
 	block := &pem.Block{
@@ -110,14 +110,14 @@ func (c *CAClient) FetchCert(identity string) (*security.SecretItem, error) {
 	}
 	certChainPEM, err := c.CsrSend(csrPEM, int64(c.opts.SecretTTL.Seconds()), identity)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get certChainPEM due to %v", err)
+		return nil, fmt.Errorf("failed to get certChainPEM due to %w", err)
 	}
 
 	certChain := standardCerts(certChainPEM)
 
 	expireTime, err := nodeagentutil.ParseCertAndGetExpiryTimestamp(certChain)
 	if err != nil {
-		return nil, fmt.Errorf("%s failed to extract expire time from server certificate in CSR response %+v: %v",
+		return nil, fmt.Errorf("%s failed to extract expire time from server certificate in CSR response %+v: %w",
 			identity, certChainPEM, err)
 	}
 

--- a/pkg/controller/telemetry/map_metric.go
+++ b/pkg/controller/telemetry/map_metric.go
@@ -149,7 +149,7 @@ func getMapEntryCountFallback(m *ebpf.Map) (uint32, error) {
 		entryCount++
 	}
 	if err := iterator.Err(); err != nil {
-		return 0, fmt.Errorf("failed during map iteration: %v", err)
+		return 0, fmt.Errorf("failed during map iteration: %w", err)
 	}
 	return entryCount, nil
 }

--- a/pkg/controller/workload/workload_controller.go
+++ b/pkg/controller/workload/workload_controller.go
@@ -126,7 +126,7 @@ func (c *Controller) WorkloadStreamCreateAndSend(client discoveryv3.AggregatedDi
 
 	c.Stream, err = client.DeltaAggregatedResources(ctx)
 	if err != nil {
-		return fmt.Errorf("DeltaAggregatedResources failed, %s", err)
+		return fmt.Errorf("DeltaAggregatedResources failed, %w", err)
 	}
 
 	if c.Processor != nil {
@@ -146,13 +146,13 @@ func (c *Controller) WorkloadStreamCreateAndSend(client discoveryv3.AggregatedDi
 
 	log.Debugf("send initial request with address resources: %v", initialResourceVersions)
 	if err := c.Stream.Send(newDeltaRequest(AddressType, nil, initialResourceVersions)); err != nil {
-		return fmt.Errorf("send request failed, %s", err)
+		return fmt.Errorf("send request failed, %w", err)
 	}
 
 	initialResourceVersions = c.Rbac.GetAllPolicies()
 	log.Debugf("send initial request with authorization resources: %v", initialResourceVersions)
 	if err = c.Stream.Send(newDeltaRequest(AuthorizationType, nil, initialResourceVersions)); err != nil {
-		return fmt.Errorf("authorization subscribe failed, %s", err)
+		return fmt.Errorf("authorization subscribe failed, %w", err)
 	}
 
 	return nil
@@ -166,18 +166,18 @@ func (c *Controller) HandleWorkloadStream() error {
 
 	if rspDelta, err = c.Stream.Recv(); err != nil {
 		_ = c.Stream.CloseSend()
-		return fmt.Errorf("stream recv failed, %s", err)
+		return fmt.Errorf("stream recv failed, %w", err)
 	}
 
 	c.Processor.processWorkloadResponse(rspDelta, c.Rbac)
 
 	if err = c.Stream.Send(c.Processor.ack); err != nil {
-		return fmt.Errorf("stream send ack failed, %s", err)
+		return fmt.Errorf("stream send ack failed, %w", err)
 	}
 
 	if c.Processor.req != nil {
 		if err = c.Stream.Send(c.Processor.req); err != nil {
-			return fmt.Errorf("stream send req failed, %s", err)
+			return fmt.Errorf("stream send req failed, %w", err)
 		}
 	}
 

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -144,7 +144,7 @@ func (r *DNSResolver) resolve(domainName string) ([]string, time.Duration, error
 
 	addrs, ttl, err := r.doResolve(domainName)
 	if err != nil {
-		return []string{}, DeRefreshInterval, fmt.Errorf("dns resolve failed: %v", err)
+		return []string{}, DeRefreshInterval, fmt.Errorf("dns resolve failed: %w", err)
 	}
 
 	r.RLock()

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -89,7 +89,7 @@ func newPortForwarder(cliClient *client, podName string, ns string, localAddress
 		localPort, err = getAvailablePort()
 		if err != nil {
 			cancel()
-			return nil, fmt.Errorf("failed to find an available port: %v", err)
+			return nil, fmt.Errorf("failed to find an available port: %w", err)
 		}
 	}
 

--- a/pkg/kube/portforwarder.go
+++ b/pkg/kube/portforwarder.go
@@ -82,12 +82,12 @@ func (p *portForwarder) Start() error {
 
 	f := cmdutil.NewFactory(p.RESTClientGetter)
 	if err := pfOptions.Complete(f, p.cmd, []string{p.podName, ports}); err != nil {
-		return fmt.Errorf("complete failed: %v", err)
+		return fmt.Errorf("complete failed: %w", err)
 	}
 
 	go func() {
 		if err := pfOptions.RunPortForwardContext(p.ctx); err != nil {
-			p.errCh <- fmt.Errorf("error running port forward: %v", err)
+			p.errCh <- fmt.Errorf("error running port forward: %w", err)
 			return
 		}
 	}()
@@ -96,7 +96,7 @@ func (p *portForwarder) Start() error {
 	case <-pfOptions.ReadyChannel:
 		return nil
 	case err := <-p.errCh:
-		return fmt.Errorf("failure running port forward process: %v", err)
+		return fmt.Errorf("failure running port forward process: %w", err)
 	}
 }
 

--- a/pkg/utils/ebpf.go
+++ b/pkg/utils/ebpf.go
@@ -34,17 +34,17 @@ func GetProgramByName(name string) (*ebpf.Program, error) {
 
 	for {
 		if progID, err = ebpf.ProgramGetNextID(progID); err != nil {
-			err = fmt.Errorf("failed to get system next program id, err is %v\n", err)
+			err = fmt.Errorf("failed to get system next program id, err is %w", err)
 			return nil, err
 		}
 
 		if targetProg, err = ebpf.NewProgramFromID(progID); err != nil {
-			err = fmt.Errorf("failed to get new program from id:%v, err is %v\n", progID, err)
+			err = fmt.Errorf("failed to get new program from id:%v, err is %w", progID, err)
 			return nil, err
 		}
 
 		if targetProgInfo, err = targetProg.Info(); err != nil {
-			err = fmt.Errorf("failed to get new program info from fd:%v, err is %v\n", targetProg, err)
+			err = fmt.Errorf("failed to get new program info from fd:%d, err is %w", targetProg.FD(), err)
 			return nil, err
 		}
 
@@ -66,17 +66,17 @@ func GetMapByName(name string) (*ebpf.Map, error) {
 
 	for {
 		if mapID, err = ebpf.MapGetNextID(mapID); err != nil {
-			err = fmt.Errorf("failed to get system next map id, err is %v\n", err)
+			err = fmt.Errorf("failed to get system next map id, err is %w", err)
 			return nil, err
 		}
 
 		if targetMap, err = ebpf.NewMapFromID(mapID); err != nil {
-			err = fmt.Errorf("failed to get new map from id:%v, err is %v\n", mapID, err)
+			err = fmt.Errorf("failed to get new map from id:%v, err is %w", mapID, err)
 			return nil, err
 		}
 
 		if targetMapInfo, err = targetMap.Info(); err != nil {
-			err = fmt.Errorf("failed to get new map info from fd:%v, err is %v\n", targetMap, err)
+			err = fmt.Errorf("failed to get new map info from fd:%d, err is %w", targetMap.FD(), err)
 			return nil, err
 		}
 

--- a/pkg/utils/enroll.go
+++ b/pkg/utils/enroll.go
@@ -91,7 +91,7 @@ func HandleKmeshManage(ns string, enroll bool) error {
 	}
 
 	if err := netns.WithNetNSPath(ns, execFunc); err != nil {
-		err = fmt.Errorf("enter ns path :%v, run execFunc failed: %v", ns, err)
+		err = fmt.Errorf("enter ns path :%v, run execFunc failed: %w", ns, err)
 		return err
 	}
 	return nil

--- a/pkg/utils/fileop.go
+++ b/pkg/utils/fileop.go
@@ -53,7 +53,7 @@ func AtomicWrite(path string, data []byte, mode os.FileMode) error {
 	basename := filepath.Base(path) + ".tmp.file"
 	tempfile, err := os.CreateTemp(dir, basename)
 	if err != nil {
-		err = fmt.Errorf("failed to create tempfile %v/%v: %v", dir, basename, err)
+		err = fmt.Errorf("failed to create tempfile %v/%v: %w", dir, basename, err)
 		log.Error(err)
 		return err
 	}
@@ -63,25 +63,25 @@ func AtomicWrite(path string, data []byte, mode os.FileMode) error {
 	}()
 
 	if err = os.Chmod(tempfile.Name(), mode); err != nil {
-		err = fmt.Errorf("failed to chmod tempfile %v: %v", tempfile.Name(), err)
+		err = fmt.Errorf("failed to chmod tempfile %v: %w", tempfile.Name(), err)
 		log.Error(err)
 		return err
 	}
 
 	if _, err = tempfile.Write(data); err != nil {
-		err = fmt.Errorf("failed to write tempfile %v: %v", tempfile.Name(), err)
+		err = fmt.Errorf("failed to write tempfile %v: %w", tempfile.Name(), err)
 		log.Error(err)
 		return err
 	}
 
 	if err = tempfile.Close(); err != nil {
-		err = fmt.Errorf("failed to close tempfile %v: %v", tempfile.Name(), err)
+		err = fmt.Errorf("failed to close tempfile %v: %w", tempfile.Name(), err)
 		log.Error(err)
 		return err
 	}
 
 	if err = os.Rename(tempfile.Name(), path); err != nil {
-		err = fmt.Errorf("failed to rename tempfile %v to %v: %v", tempfile.Name(), path, err)
+		err = fmt.Errorf("failed to rename tempfile %v to %v: %w", tempfile.Name(), path, err)
 		log.Error(err)
 		return err
 	}

--- a/pkg/utils/tc.go
+++ b/pkg/utils/tc.go
@@ -32,7 +32,7 @@ import (
 func ManageTCProgramByFd(link netlink.Link, tcFd int, mode int) error {
 	if mode == constants.TC_ATTACH {
 		if err := replaceQdisc(link); err != nil {
-			return fmt.Errorf("failed to replace qdisc for interface %v: %v", link.Attrs().Name, err)
+			return fmt.Errorf("failed to replace qdisc for interface %v: %w", link.Attrs().Name, err)
 		}
 	}
 
@@ -53,11 +53,11 @@ func ManageTCProgramByFd(link netlink.Link, tcFd int, mode int) error {
 
 	if mode == constants.TC_ATTACH {
 		if err := netlink.FilterReplace(filter); err != nil {
-			return fmt.Errorf("failed to replace filter for interface %v: %v", link.Attrs().Name, err)
+			return fmt.Errorf("failed to replace filter for interface %v: %w", link.Attrs().Name, err)
 		}
 	} else if mode == constants.TC_DETACH {
 		if err := netlink.FilterDel(filter); err != nil {
-			return fmt.Errorf("failed to delete filter for interface %v: %v", link.Attrs().Name, err)
+			return fmt.Errorf("failed to delete filter for interface %v: %w", link.Attrs().Name, err)
 		}
 	} else {
 		return fmt.Errorf("invalid mode in ManageTCProgramByFd")
@@ -92,13 +92,13 @@ func GetVethPeerIndexFromName(ifaceName string) (uint64, error) {
 	}
 	defer ethHandle.Close()
 	if driver, err := ethHandle.DriverName(ifaceName); err != nil {
-		return 0, fmt.Errorf("failed to get %v driver name, %v", ifaceName, err)
+		return 0, fmt.Errorf("failed to get %v driver name, %w", ifaceName, err)
 	} else if strings.Compare(driver, "veth") != 0 {
 		return 0, fmt.Errorf("interface: %v is %v, not a veth", ifaceName, driver)
 	}
 
 	if stats, err := ethHandle.Stats(ifaceName); err != nil {
-		return 0, fmt.Errorf("failed to get %v stats, %v", ifaceName, err)
+		return 0, fmt.Errorf("failed to get %v stats, %w", ifaceName, err)
 	} else {
 		ifIndex = stats["peer_ifindex"]
 	}
@@ -120,7 +120,7 @@ func GetVethPeerIndexFromInterface(iface net.Interface) (uint64, error) {
 func IfaceContainIPs(iface net.Interface, IPs []string) (bool, error) {
 	addresses, err := iface.Addrs()
 	if err != nil {
-		return false, fmt.Errorf("failed to get interface %v address: %v", iface.Name, err)
+		return false, fmt.Errorf("failed to get interface %v address: %w", iface.Name, err)
 	}
 
 	for _, rawAddr := range addresses {

--- a/test/bpf_ut/bpftest/tlv_utils.go
+++ b/test/bpf_ut/bpftest/tlv_utils.go
@@ -95,7 +95,7 @@ func ParseTLVMessage(data []byte) (*TLVData, error) {
 func ValidateTLVMessage(t *testing.T, data []byte, expectedIP net.IP, expectedPort uint16) error {
 	tlvData, err := ParseTLVMessage(data)
 	if err != nil {
-		return fmt.Errorf("failed to parse TLV message: %v", err)
+		return fmt.Errorf("failed to parse TLV message: %w", err)
 	}
 	if !tlvData.IP.Equal(expectedIP) {
 		return fmt.Errorf("unexpected TLV IP: got %v, want %v", tlvData.IP, expectedIP)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Replaces all instances of fmt.Errorf("...: %v", err) and 
fmt.Errorf("...: %s", err) with fmt.Errorf("...: %w", err) across 
the codebase to preserve the original error chain.

Using %v or %s converts errors to plain strings, destroying their 
identity. This prevents callers from using errors.Is() for sentinel 
error matching and errors.As() for type-based error extraction.
With %w, the full error chain is preserved enabling smarter error 
handling across the codebase.

**Which issue(s) this PR fixes**:
Fixes #1608

**Special notes for reviewer**:
This PR extends the scope of existing attempt PR #1629 by:
- Covering ctl/, daemon/, and test/ directories that were 
  completely missed in PR #1629
- Carefully skipping non-error %v/%s arguments that would 
  cause build failures if changed to %w (e.g. string args, 
  int args, struct args)
- For lines with multiple format specifiers, only the last 
  argument (the actual error) was changed to %w
- Total: 32 files changed, 120 replacements across pkg/, 
  ctl/, daemon/ and test/ directories
- go build ./... and go vet ./... both pass cleanly

AI tools were used to assist in identifying the scope of changes.
All changes were reviewed and verified for correctness before submission.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```