### PR TITLE
fix: use correct handler name in workload_metrics and connection_metrics error responses

### DIFF
--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -284,7 +284,7 @@ func (s *Server) workloadMetricHandler(w http.ResponseWriter, r *http.Request) {
 	enabled, err := strconv.ParseBool(info)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(fmt.Sprintf("invalid accesslog enable=%s", info)))
+		_, _ = w.Write([]byte(fmt.Sprintf("invalid workload_metrics enable=%s", info)))
 		return
 	}
 
@@ -307,7 +307,7 @@ func (s *Server) connectionMetricHandler(w http.ResponseWriter, r *http.Request)
 	enabled, err := strconv.ParseBool(info)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(fmt.Sprintf("invalid accesslog enable=%s", info)))
+		_, _ = w.Write([]byte(fmt.Sprintf("invalid connection_metrics enable=%s", info)))
 		return
 	}
 


### PR DESCRIPTION
## What this PR does

`workloadMetricHandler` and `connectionMetricHandler` both returned `"invalid accesslog enable=..."` on a parse error — copy-paste leftover from `accesslogHandler`. This PR updates the error messages so the response matches the handler that produced it.

```
GET POST /workload_metrics?enable=abc
Before: invalid accesslog enable=abc
After:  invalid workload_metrics enable=abc

POST /connection_metrics?enable=abc
Before: invalid accesslog enable=abc
After:  invalid connection_metrics enable=abc
```

`accesslogHandler` itself is untouched.

## Issue(s)

Closes #1660

## How to reproduce

```bash
curl -i -X POST 'http://localhost:15200/workload_metrics?enable=abc'
curl -i -X POST 'http://localhost:15200/connection_metrics?enable=abc'
```

Before this change both endpoints return `invalid accesslog enable=abc`. After this change they return the correct handler name.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] Lint and unit tests pass locally with my changes