### PR TITLE
cleanup: use s == "" instead of len(s) == 0 for string emptiness checks

### DIFF
--- a/pkg/auth/rbac.go
+++ b/pkg/auth/rbac.go
@@ -435,7 +435,7 @@ func internalMatchPrincipal(srcId string, principals []*security.StringMatch) bo
 		} else if len(principal.GetExact()) > 0 {
 			m = srcId == principal.GetExact()
 		} else {
-			m = len(srcId) == 0
+			m = srcId == ""
 		}
 		if m {
 			return true
@@ -454,7 +454,7 @@ func internalMatchNamespace(srcNs string, namespaces []*security.StringMatch) bo
 		} else if len(ns.GetExact()) > 0 {
 			m = srcNs == ns.GetExact()
 		} else {
-			m = len(srcNs) == 0
+			m = srcNs == ""
 		}
 		if m {
 			return true

--- a/pkg/cni/kubeconfig.go
+++ b/pkg/cni/kubeconfig.go
@@ -45,11 +45,11 @@ import (
 
 func createKubeConfig(serviceAccountPath string) (string, error) {
 	k8sServiceHost := os.Getenv("KUBERNETES_SERVICE_HOST")
-	if len(k8sServiceHost) == 0 {
+	if k8sServiceHost == "" {
 		return "", fmt.Errorf("KUBERNETES_SERVICE_HOST not set. Is this not running within a pod?")
 	}
 	k8sServicePort := os.Getenv("KUBERNETES_SERVICE_PORT")
-	if len(k8sServicePort) == 0 {
+	if k8sServicePort == "" {
 		return "", fmt.Errorf("KUBERNETES_SERVICE_PORT not set. Is this not running within a pod?")
 	}
 

--- a/pkg/utils/kernel_version.go
+++ b/pkg/utils/kernel_version.go
@@ -29,7 +29,7 @@ import (
 // and will fallback to less BPF log ability(return true) if error
 func KernelVersionLowerThan5_13() bool {
 	kernelVersion := GetKernelVersion()
-	if len(kernelVersion) == 0 {
+	if kernelVersion == "" {
 		return true
 	}
 	splitVers := strings.Split(kernelVersion, ".")


### PR DESCRIPTION
## What this PR does

Standardizes empty-string checks across `pkg/` to the more idiomatic `s == ""` form, as suggested in the parent issue.

Only string-typed expressions are touched — `len(x) == 0` checks on slices, maps and protobuf-generated lists are left as-is since `len(x) == 0` is the conventional and correct check for those types.

## Sites changed

| File | Identifier | Type |
|---|---|---|
| `pkg/auth/rbac.go` | `srcId` | `string` parameter |
| `pkg/auth/rbac.go` | `srcNs` | `string` parameter |
| `pkg/cni/kubeconfig.go` | `k8sServiceHost` | env var (`string`) |
| `pkg/cni/kubeconfig.go` | `k8sServicePort` | env var (`string`) |
| `pkg/utils/kernel_version.go` | `kernelVersion` | return value of `GetKernelVersion()` (`string`) |

5 lines changed across 3 files. Pure consistency cleanup — no functional change.

## Issue(s)

Closes #1659

## Types of changes

- [x] Refactor (no functional change)

## Checklist

- [x] I have read the CONTRIBUTING doc
- [x] Lint and unit tests pass locally with my changes