### PR TITLE
feat: synthesize ServiceEntry VIPs for DNS-captured external hosts

### DIFF
--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -30,6 +30,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"istio.io/istio/pkg/slices"
 	"istio.io/istio/pkg/util/sets"
+	"istio.io/pkg/env"
 
 	"kmesh.net/kmesh/api/v2/workloadapi"
 	security_v2 "kmesh.net/kmesh/api/v2/workloadapi/security"
@@ -42,6 +43,7 @@ import (
 	"kmesh.net/kmesh/pkg/controller/telemetry"
 	bpf "kmesh.net/kmesh/pkg/controller/workload/bpfcache"
 	"kmesh.net/kmesh/pkg/controller/workload/cache"
+	kmeshdns "kmesh.net/kmesh/pkg/dns"
 	"kmesh.net/kmesh/pkg/nets"
 	"kmesh.net/kmesh/pkg/utils"
 )
@@ -51,6 +53,8 @@ const (
 	// dnsResolveTimeout is the timeout used when waiting for DNS resolution for workloads
 	dnsResolveTimeout = 3 * time.Second
 )
+
+var workloadClusterDomain = env.Register("CLUSTER_DOMAIN", "cluster.local", "cluster domain").Get()
 
 type Processor struct {
 	ack *service_discovery_v3.DeltaDiscoveryRequest
@@ -78,6 +82,7 @@ type Processor struct {
 
 	DnsResolverChan       chan *workloadapi.Workload
 	ResolvedDomainChanMap map[string]chan *workloadapi.Workload
+	DomainTable           *kmeshdns.DomainTable
 	// Callback to remove workload from DNS cache when workload is deleted
 	onWorkloadDeleted func(workloadName string)
 }
@@ -97,6 +102,7 @@ func NewProcessor(workloadMap bpf2go.KmeshCgroupSockWorkloadMaps) *Processor {
 		addressDone:   make(chan struct{}, 1),
 		authzDone:     make(chan struct{}, 1),
 		handlers:      map[string][]func(resp *service_discovery_v3.DeltaDiscoveryResponse) error{},
+		DomainTable:   kmeshdns.NewDomainTable(),
 	}
 }
 
@@ -354,6 +360,9 @@ func (p *Processor) removeServiceResources(resources []string) error {
 		p.WaypointCache.DeleteService(name)
 		telemetry.DeleteServiceMetric(name)
 		svc := p.ServiceCache.GetService(name)
+		if svc != nil && p.DomainTable != nil {
+			p.DomainTable.Remove(svc.GetHostname())
+		}
 		p.ServiceCache.DeleteService(name)
 		_ = p.removeServiceResourceFromBpfMap(svc, name)
 	}
@@ -841,6 +850,7 @@ func (p *Processor) updateServiceMap(service, oldService *workloadapi.Service) e
 
 func (p *Processor) handleService(service *workloadapi.Service) error {
 	log.Debugf("handle service resource: %s", service.ResourceName())
+	p.ensureServiceAddressForDNS(service)
 
 	containsPort := func(port uint32) bool {
 		for _, p := range service.GetPorts() {
@@ -880,6 +890,57 @@ func (p *Processor) handleService(service *workloadapi.Service) error {
 	}
 
 	return nil
+}
+
+func (p *Processor) ensureServiceAddressForDNS(service *workloadapi.Service) {
+	if !EnableDNSProxy || service == nil || p.DomainTable == nil || service.GetHostname() == "" {
+		return
+	}
+
+	if isKubernetesService(service) {
+		p.DomainTable.Remove(service.GetHostname())
+		return
+	}
+
+	if hasUsableServiceAddress(service) {
+		p.DomainTable.Remove(service.GetHostname())
+		return
+	}
+
+	syntheticIP := p.DomainTable.Add(service.GetHostname())
+	if !syntheticIP.IsValid() {
+		log.Warnf("failed to allocate synthetic address for service %s", service.ResourceName())
+		return
+	}
+
+	network := ""
+	if len(service.GetAddresses()) > 0 {
+		network = service.GetAddresses()[0].GetNetwork()
+	}
+	service.Addresses = []*workloadapi.NetworkAddress{
+		{
+			Network: network,
+			Address: syntheticIP.AsSlice(),
+		},
+	}
+}
+
+func hasUsableServiceAddress(service *workloadapi.Service) bool {
+	for _, address := range service.GetAddresses() {
+		ip, ok := netip.AddrFromSlice(address.GetAddress())
+		if !ok {
+			continue
+		}
+		if !ip.IsUnspecified() {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isKubernetesService(service *workloadapi.Service) bool {
+	return service.GetHostname() == fmt.Sprintf("%s.%s.svc.%s", service.GetName(), service.GetNamespace(), workloadClusterDomain)
 }
 
 func (p *Processor) handleRemovedAddresses(removed []string) {

--- a/pkg/dns/proxy.go
+++ b/pkg/dns/proxy.go
@@ -1,0 +1,248 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dns
+
+import (
+	"net/netip"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+const (
+	defaultSyntheticPrefixHigh = 240
+	defaultSyntheticPrefixLow  = 240
+	defaultProxyTTL            = uint32(30)
+)
+
+type DomainTable struct {
+	mu       sync.RWMutex
+	hostToIP map[string]netip.Addr
+	ipToHost map[netip.Addr]string
+	nextHost uint16
+}
+
+func NewDomainTable() *DomainTable {
+	return &DomainTable{
+		hostToIP: make(map[string]netip.Addr),
+		ipToHost: make(map[netip.Addr]string),
+		nextHost: 1,
+	}
+}
+
+func (d *DomainTable) Add(host string) netip.Addr {
+	key := normalizeHost(host)
+	if key == "" {
+		return netip.Addr{}
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if ip, ok := d.hostToIP[key]; ok {
+		return ip
+	}
+
+	for i := 0; i < 0xffff; i++ {
+		ip := syntheticIPv4FromHost(d.nextHost)
+		d.nextHost++
+		if d.nextHost == 0 {
+			d.nextHost = 1
+		}
+		if _, used := d.ipToHost[ip]; used {
+			continue
+		}
+		d.hostToIP[key] = ip
+		d.ipToHost[ip] = key
+		return ip
+	}
+
+	return netip.Addr{}
+}
+
+func (d *DomainTable) Lookup(host string) (netip.Addr, bool) {
+	key := normalizeHost(host)
+	if key == "" {
+		return netip.Addr{}, false
+	}
+
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	ip, ok := d.hostToIP[key]
+	return ip, ok
+}
+
+func (d *DomainTable) Remove(host string) {
+	key := normalizeHost(host)
+	if key == "" {
+		return
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	ip, ok := d.hostToIP[key]
+	if !ok {
+		return
+	}
+	delete(d.hostToIP, key)
+	delete(d.ipToHost, ip)
+}
+
+func (d *DomainTable) Snapshot() map[string]netip.Addr {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	out := make(map[string]netip.Addr, len(d.hostToIP))
+	for k, v := range d.hostToIP {
+		out[k] = v
+	}
+	return out
+}
+
+func normalizeHost(host string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	host = strings.TrimSuffix(host, ".")
+	return host
+}
+
+func syntheticIPv4FromHost(host uint16) netip.Addr {
+	return netip.AddrFrom4([4]byte{
+		defaultSyntheticPrefixHigh,
+		defaultSyntheticPrefixLow,
+		byte(host >> 8),
+		byte(host),
+	})
+}
+
+type Proxy struct {
+	server    *dns.Server
+	table     *DomainTable
+	upstreams []string
+	ttl       uint32
+	client    *dns.Client
+}
+
+func NewProxy(addr string, table *DomainTable, upstreams []string) (*Proxy, error) {
+	if table == nil {
+		table = NewDomainTable()
+	}
+
+	if len(upstreams) == 0 {
+		config, err := dns.ClientConfigFromFile("/etc/resolv.conf")
+		if err != nil {
+			return nil, err
+		}
+		upstreams = make([]string, 0, len(config.Servers))
+		for _, server := range config.Servers {
+			upstreams = append(upstreams, netJoinHostPort(server, config.Port))
+		}
+	}
+
+	p := &Proxy{
+		table:     table,
+		upstreams: upstreams,
+		ttl:       defaultProxyTTL,
+		client: &dns.Client{
+			Net:          "udp",
+			DialTimeout:  5 * time.Second,
+			ReadTimeout:  5 * time.Second,
+			WriteTimeout: 5 * time.Second,
+		},
+	}
+	p.server = &dns.Server{
+		Addr:    addr,
+		Net:     "udp",
+		Handler: p,
+	}
+
+	return p, nil
+}
+
+func (p *Proxy) Start() error {
+	return p.server.ListenAndServe()
+}
+
+func (p *Proxy) Close() error {
+	return p.server.Shutdown()
+}
+
+func (p *Proxy) Addr() string {
+	if p.server.PacketConn != nil {
+		return p.server.PacketConn.LocalAddr().String()
+	}
+	return p.server.Addr
+}
+
+func (p *Proxy) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
+	if req == nil {
+		msg := new(dns.Msg)
+		msg.Rcode = dns.RcodeFormatError
+		_ = w.WriteMsg(msg)
+		return
+	}
+
+	if len(req.Question) == 0 {
+		msg := new(dns.Msg)
+		msg.SetReply(req)
+		msg.Rcode = dns.RcodeFormatError
+		_ = w.WriteMsg(msg)
+		return
+	}
+
+	question := req.Question[0]
+	if question.Qtype == dns.TypeA {
+		if ip, ok := p.table.Lookup(question.Name); ok {
+			reply := new(dns.Msg)
+			reply.SetReply(req)
+			reply.Authoritative = true
+			reply.Answer = append(reply.Answer, &dns.A{
+				Hdr: dns.RR_Header{
+					Name:   question.Name,
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    p.ttl,
+				},
+				A: ip.AsSlice(),
+			})
+			_ = w.WriteMsg(reply)
+			return
+		}
+	}
+
+	for _, upstream := range p.upstreams {
+		resp, _, err := p.client.Exchange(req, upstream)
+		if err != nil || resp == nil {
+			continue
+		}
+		_ = w.WriteMsg(resp)
+		return
+	}
+
+	msg := new(dns.Msg)
+	msg.SetReply(req)
+	msg.Rcode = dns.RcodeServerFailure
+	_ = w.WriteMsg(msg)
+}
+
+func netJoinHostPort(host, port string) string {
+	if strings.Contains(host, ":") {
+		return "[" + host + "]:" + port
+	}
+	return host + ":" + port
+}

--- a/pkg/dns/proxy_test.go
+++ b/pkg/dns/proxy_test.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dns
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDomainTableBasicOps(t *testing.T) {
+	table := NewDomainTable()
+
+	ip1 := table.Add("Example.com.")
+	require.True(t, ip1.IsValid())
+
+	ip2 := table.Add("example.com")
+	assert.Equal(t, ip1, ip2, "add should be idempotent")
+
+	got, ok := table.Lookup("EXAMPLE.COM.")
+	require.True(t, ok)
+	assert.Equal(t, ip1, got, "lookup should normalize trailing dot and case")
+
+	ip3 := table.Add("other.example.com")
+	require.True(t, ip3.IsValid())
+	assert.NotEqual(t, ip1, ip3, "different hosts should get different synthetic IPs")
+
+	table.Remove("example.com.")
+	_, ok = table.Lookup("example.com")
+	assert.False(t, ok)
+}
+
+func TestProxyReturnsSyntheticRecord(t *testing.T) {
+	table := NewDomainTable()
+	syntheticIP := table.Add("synthetic.example.com")
+	require.True(t, syntheticIP.IsValid())
+
+	p, err := NewProxy("127.0.0.1:0", table, []string{"127.0.0.1:1"})
+	require.NoError(t, err)
+
+	go func() {
+		_ = p.Start()
+	}()
+	require.Eventually(t, func() bool {
+		return p.server.PacketConn != nil
+	}, time.Second, 10*time.Millisecond)
+	defer func() {
+		_ = p.Close()
+	}()
+
+	req := new(dns.Msg)
+	req.SetQuestion("synthetic.example.com.", dns.TypeA)
+
+	resp, _, err := (&dns.Client{Net: "udp"}).Exchange(req, p.Addr())
+	require.NoError(t, err)
+	require.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	require.Len(t, resp.Answer, 1)
+
+	a, ok := resp.Answer[0].(*dns.A)
+	require.True(t, ok)
+	assert.Equal(t, net.IP(syntheticIP.AsSlice()).String(), a.A.String())
+	assert.Equal(t, uint32(30), a.Hdr.Ttl)
+}
+
+func TestProxyForwardsUnknownHost(t *testing.T) {
+	upstream := NewFakeDNSServer()
+	upstream.SetHosts("forward.example.com", 9)
+	defer func() {
+		_ = upstream.Shutdown()
+	}()
+
+	p, err := NewProxy("127.0.0.1:0", NewDomainTable(), []string{upstream.Server.PacketConn.LocalAddr().String()})
+	require.NoError(t, err)
+
+	go func() {
+		_ = p.Start()
+	}()
+	require.Eventually(t, func() bool {
+		return p.server.PacketConn != nil
+	}, time.Second, 10*time.Millisecond)
+	defer func() {
+		_ = p.Close()
+	}()
+
+	req := new(dns.Msg)
+	req.SetQuestion("forward.example.com.", dns.TypeA)
+
+	resp, _, err := (&dns.Client{Net: "udp"}).Exchange(req, p.Addr())
+	require.NoError(t, err)
+	require.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	require.Len(t, resp.Answer, 1)
+
+	a, ok := resp.Answer[0].(*dns.A)
+	require.True(t, ok)
+	assert.Equal(t, "10.0.0.9", a.A.String())
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

this PR improves ServiceEntry support in workload mode by adding synthetic DNS address handling for hostname-only external services

when `KMESH_ENABLE_DNS_PROXY=true`, if a non-Kubernetes service has a hostname but no usable IP address, Kmesh now allocates a synthetic IPv4 from `240.240.0.0/16` and injects it into the service address path, this allows exitsing service/frontend map flow to match and apply traffic policies for external ServiceEntry hosts that are DNS-based

the change includes:
- a thread-safe `DomainTable` for hostname <-> synthetic IP management
- DNS proxy primitives that can answer known synthetic A records and forward unknown domains upstream
- workload processor integration to allocate/remove synthetic addresses during service add/update/remove
- unit tests for `DomainTable` behavior and DNS proxy response/forwarding behavior

this is needed because external services are commonly defined via ServiceEntry hostnames, and policy enforcement requires deterministic address mapping in the dataplane flow

**Which issue(s) this PR fixes**:
FIXES #1451

**Special notes for your reviewer**:

- existing DNS interception plumbing and `KMESH_ENABLE_DNS_PROXY` gating were already present; this PR focuses on the missing synthetic-address path for hostname-only external services
- build/test failures seen in this environment (`ringbuf.NewReader`, missing generated BPF object files) are pre-existing baseline issues and not introduced by this PR

**Does this PR introduce a user-facing change?**:
```release-note
yeah, when KMESH_ENABLE_DNS_PROXY is enabled, Kmesh now supports hostname-only external ServiceEntry services by assigning synthetic IPv4 addresses from 240.240.0.0/16, enabling workload-mode policy matching for DNS-based external destinations