### PR TITLE
refactor(ctl): replace context.TODO() with context.Background() in ku…

### DIFF
--- a/ctl/authz/authz.go
+++ b/ctl/authz/authz.go
@@ -154,7 +154,7 @@ func SetAuthzForPods(podNames []string, info string) {
 
 	if len(podNames) == 0 {
 		// Apply to all kmesh daemon pods.
-		podList, err := cli.PodsForSelector(cmd.Context(), utils.KmeshNamespace, utils.KmeshLabel)
+		podList, err := cli.PodsForSelector(context.Background(), utils.KmeshNamespace, utils.KmeshLabel)
 		if err != nil {
 			log.Errorf("failed to get kmesh podList: %v", err)
 			os.Exit(1)

--- a/ctl/authz/authz.go
+++ b/ctl/authz/authz.go
@@ -100,7 +100,7 @@ func NewStatusCmd() *cobra.Command {
 			// Determine which pods to query.
 			var podNames []string
 			if len(args) == 0 {
-				podList, err := cli.PodsForSelector(context.Background(), utils.KmeshNamespace, utils.KmeshLabel)
+				podList, err := cli.PodsForSelector(cmd.Context(), utils.KmeshNamespace, utils.KmeshLabel)
 				if err != nil {
 					log.Errorf("failed to get kmesh podList: %v", err)
 					os.Exit(1)
@@ -154,7 +154,7 @@ func SetAuthzForPods(podNames []string, info string) {
 
 	if len(podNames) == 0 {
 		// Apply to all kmesh daemon pods.
-		podList, err := cli.PodsForSelector(context.Background(), utils.KmeshNamespace, utils.KmeshLabel)
+		podList, err := cli.PodsForSelector(cmd.Context(), utils.KmeshNamespace, utils.KmeshLabel)
 		if err != nil {
 			log.Errorf("failed to get kmesh podList: %v", err)
 			os.Exit(1)

--- a/ctl/authz/authz.go
+++ b/ctl/authz/authz.go
@@ -100,7 +100,7 @@ func NewStatusCmd() *cobra.Command {
 			// Determine which pods to query.
 			var podNames []string
 			if len(args) == 0 {
-				podList, err := cli.PodsForSelector(context.TODO(), utils.KmeshNamespace, utils.KmeshLabel)
+				podList, err := cli.PodsForSelector(context.Background(), utils.KmeshNamespace, utils.KmeshLabel)
 				if err != nil {
 					log.Errorf("failed to get kmesh podList: %v", err)
 					os.Exit(1)
@@ -154,7 +154,7 @@ func SetAuthzForPods(podNames []string, info string) {
 
 	if len(podNames) == 0 {
 		// Apply to all kmesh daemon pods.
-		podList, err := cli.PodsForSelector(context.TODO(), utils.KmeshNamespace, utils.KmeshLabel)
+		podList, err := cli.PodsForSelector(context.Background(), utils.KmeshNamespace, utils.KmeshLabel)
 		if err != nil {
 			log.Errorf("failed to get kmesh podList: %v", err)
 			os.Exit(1)

--- a/ctl/secret/secret.go
+++ b/ctl/secret/secret.go
@@ -151,7 +151,7 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 
 	ipSecKey.Length = AeadAlgoICVLength
 
-	secretOld, err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Get(context.Background(), SecretName, metav1.GetOptions{})
+	secretOld, err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Get(cmd.Context(), SecretName, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			log.Errorf("failed to get secret: %v, %v", SecretName, err)
@@ -184,13 +184,13 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 	}
 
 	if ipSecKey.Spi == 1 {
-		_, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Create(context.Background(), secret, metav1.CreateOptions{})
+		_, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Create(cmd.Context(), secret, metav1.CreateOptions{})
 		if err != nil {
 			log.Errorf("failed to create %v secret, %v", SecretName, err)
 			os.Exit(1)
 		}
 	} else {
-		_, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Update(context.Background(), secret, metav1.UpdateOptions{})
+		_, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Update(cmd.Context(), secret, metav1.UpdateOptions{})
 		if err != nil {
 			log.Errorf("failed to update %v secret, %v", SecretName, err)
 			os.Exit(1)

--- a/ctl/secret/secret.go
+++ b/ctl/secret/secret.go
@@ -151,7 +151,7 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 
 	ipSecKey.Length = AeadAlgoICVLength
 
-	secretOld, err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Get(context.TODO(), SecretName, metav1.GetOptions{})
+	secretOld, err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Get(context.Background(), SecretName, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
 			log.Errorf("failed to get secret: %v, %v", SecretName, err)
@@ -184,13 +184,13 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 	}
 
 	if ipSecKey.Spi == 1 {
-		_, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+		_, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Create(context.Background(), secret, metav1.CreateOptions{})
 		if err != nil {
 			log.Errorf("failed to create %v secret, %v", SecretName, err)
 			os.Exit(1)
 		}
 	} else {
-		_, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
+		_, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Update(context.Background(), secret, metav1.UpdateOptions{})
 		if err != nil {
 			log.Errorf("failed to update %v secret, %v", SecretName, err)
 			os.Exit(1)
@@ -199,7 +199,7 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 }
 
 func GetSecret() {
-	secret, err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Get(context.TODO(), SecretName, metav1.GetOptions{})
+	secret, err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Get(context.Background(), SecretName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Errorf("secret %s not found", SecretName)
@@ -248,7 +248,7 @@ func GetSecret() {
 }
 
 func DeleteSecret() {
-	err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Delete(context.TODO(), SecretName, metav1.DeleteOptions{})
+	err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Delete(context.Background(), SecretName, metav1.DeleteOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Errorf("secret %s not found", SecretName)

--- a/ctl/version/version.go
+++ b/ctl/version/version.go
@@ -17,7 +17,6 @@
 package version
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"

--- a/ctl/version/version.go
+++ b/ctl/version/version.go
@@ -68,7 +68,7 @@ func runVersion(cmd *cobra.Command, args []string) {
 			cmd.Printf("client version: %s-%s\n", v.GitVersion, v.GitCommit)
 		}
 
-		podList, err := cli.PodsForSelector(context.Background(), utils.KmeshNamespace, utils.KmeshLabel)
+		podList, err := cli.PodsForSelector(cmd.Context(), utils.KmeshNamespace, utils.KmeshLabel)
 		if err != nil {
 			log.Errorf("failed to get kmesh daemon pods: %v", err)
 			os.Exit(1)

--- a/ctl/version/version.go
+++ b/ctl/version/version.go
@@ -68,7 +68,7 @@ func runVersion(cmd *cobra.Command, args []string) {
 			cmd.Printf("client version: %s-%s\n", v.GitVersion, v.GitCommit)
 		}
 
-		podList, err := cli.PodsForSelector(context.TODO(), utils.KmeshNamespace, utils.KmeshLabel)
+		podList, err := cli.PodsForSelector(context.Background(), utils.KmeshNamespace, utils.KmeshLabel)
 		if err != nil {
 			log.Errorf("failed to get kmesh daemon pods: %v", err)
 			os.Exit(1)


### PR DESCRIPTION
Removed placeholder context.TODO() and replaced it with context.Background() in the ctl package's Kubernetes client calls to follow Go context best practices.