### PR TITLE
ctl: add node-summary, service, and trace commands

### DIFF
--- a/ctl/common/common.go
+++ b/ctl/common/common.go
@@ -23,7 +23,10 @@ import (
 	"kmesh.net/kmesh/ctl/dump"
 	logcmd "kmesh.net/kmesh/ctl/log"
 	"kmesh.net/kmesh/ctl/monitoring"
+	"kmesh.net/kmesh/ctl/nodesummary"
 	"kmesh.net/kmesh/ctl/secret"
+	"kmesh.net/kmesh/ctl/service"
+	"kmesh.net/kmesh/ctl/trace"
 	"kmesh.net/kmesh/ctl/version"
 	"kmesh.net/kmesh/ctl/waypoint"
 )
@@ -45,6 +48,10 @@ func GetRootCommand() *cobra.Command {
 	rootCmd.AddCommand(monitoring.NewCmd())
 	rootCmd.AddCommand(authz.NewCmd())
 	rootCmd.AddCommand(secret.NewCmd())
+	rootCmd.AddCommand(service.NewCmd())
+	rootCmd.AddCommand(trace.NewCmd())
+	rootCmd.AddCommand(nodesummary.NewCmd())
 
 	return rootCmd
 }
+

--- a/ctl/nodesummary/node_summary.go
+++ b/ctl/nodesummary/node_summary.go
@@ -23,23 +23,38 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sync"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	adminv2 "kmesh.net/kmesh/api/v2/admin"
 	"kmesh.net/kmesh/ctl/utils"
+	"kmesh.net/kmesh/pkg/kube"
 	"kmesh.net/kmesh/pkg/logger"
 	"kmesh.net/kmesh/pkg/version"
 )
 
 var log = logger.NewLoggerScope("kmeshctl/node-summary")
 
+var httpClient = &http.Client{Timeout: 10 * time.Second}
+
 type workloadDump struct {
 	Workloads []interface{} `json:"workloads"`
 	Services  []interface{} `json:"services"`
 	Policies  []interface{} `json:"policies"`
+}
+
+type summaryRow struct {
+	nodeName       string
+	podName        string
+	mode           string
+	vStr           string
+	listenersCount int
+	clustersCount  int
+	routesCount    int
 }
 
 func NewCmd() *cobra.Command {
@@ -75,92 +90,112 @@ func RunNodeSummary(cmd *cobra.Command) error {
 		return nil
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
-	fmt.Fprintln(w, "\nNODE_NAME\tKMESH_POD\tMODE\tVERSION\tLISTENERS/WORKLOADS\tCLUSTERS/SERVICES\tROUTES/POLICIES")
+	var (
+		wg   sync.WaitGroup
+		mu   sync.Mutex
+		rows = make([]summaryRow, 0, len(podList.Items))
+	)
 
 	for _, pod := range podList.Items {
-		podName := pod.GetName()
-		nodeName := pod.Spec.NodeName
-		if nodeName == "" {
-			nodeName = "-"
-		}
-
-		fw, err := utils.CreateKmeshPortForwarder(cli, podName)
-		if err != nil {
-			fmt.Fprintf(w, "%s\t%s\tError\t-\t-\t-\t-\n", nodeName, podName)
-			continue
-		}
-		if err := fw.Start(); err != nil {
-			fmt.Fprintf(w, "%s\t%s\tOffline\t-\t-\t-\t-\n", nodeName, podName)
-			fw.Close()
-			continue
-		}
-
-		// 1. Fetch version using the same struct as kmeshctl version
-		vStr := "-"
-		respV, err := http.Get(fmt.Sprintf("http://%s/version", fw.Address()))
-		if err == nil && respV.StatusCode == http.StatusOK {
-			bodyV, _ := io.ReadAll(respV.Body)
-			respV.Body.Close()
-			var v version.Info
-			if json.Unmarshal(bodyV, &v) == nil && v.GitVersion != "" {
-				vStr = v.GitVersion
-			}
-		} else if respV != nil {
-			respV.Body.Close()
-		}
-
-		// 2. Fetch mode and counts by trying kernel-native first
-		mode := "unknown"
-		listenersCount, clustersCount, routesCount := 0, 0, 0
-
-		respKN, err := http.Get(fmt.Sprintf("http://%s/debug/config_dump/kernel-native", fw.Address()))
-		if err == nil && respKN.StatusCode == http.StatusOK {
-			mode = "kernel-native"
-			bodyKN, _ := io.ReadAll(respKN.Body)
-			respKN.Body.Close()
-			configDump := &adminv2.ConfigDump{}
-			if protojson.Unmarshal(bodyKN, configDump) == nil {
-				static, dynamic := configDump.GetStaticResources(), configDump.GetDynamicResources()
-				if static != nil {
-					listenersCount += len(static.GetListenerConfigs())
-					clustersCount += len(static.GetClusterConfigs())
-					routesCount += len(static.GetRouteConfigs())
-				}
-				if dynamic != nil {
-					listenersCount += len(dynamic.GetListenerConfigs())
-					clustersCount += len(dynamic.GetClusterConfigs())
-					routesCount += len(dynamic.GetRouteConfigs())
-				}
-			}
-		} else {
-			if respKN != nil {
-				respKN.Body.Close()
-			}
-			// Try dual-engine
-			respDE, err := http.Get(fmt.Sprintf("http://%s/debug/config_dump/dual-engine", fw.Address()))
-			if err == nil && respDE.StatusCode == http.StatusOK {
-				mode = "dual-engine"
-				bodyDE, _ := io.ReadAll(respDE.Body)
-				respDE.Body.Close()
-				var deDump workloadDump
-				if json.Unmarshal(bodyDE, &deDump) == nil {
-					listenersCount = len(deDump.Workloads)
-					clustersCount = len(deDump.Services)
-					routesCount = len(deDump.Policies)
-				}
-			} else if respDE != nil {
-				respDE.Body.Close()
-			}
-		}
-
-		fw.Close()
-
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%d\t%d\n",
-			nodeName, podName, mode, vStr, listenersCount, clustersCount, routesCount)
+		wg.Add(1)
+		go func(cli kube.CLIClient, podName, nodeName string) {
+			defer wg.Done()
+			row := fetchRow(cli, podName, nodeName)
+			mu.Lock()
+			rows = append(rows, row)
+			mu.Unlock()
+		}(cli, pod.GetName(), pod.Spec.NodeName)
 	}
+	wg.Wait()
 
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "\nNODE_NAME\tKMESH_POD\tMODE\tVERSION\tLISTENERS/WORKLOADS\tCLUSTERS/SERVICES\tROUTES/POLICIES")
+	for _, r := range rows {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%d\t%d\n",
+			r.nodeName, r.podName, r.mode, r.vStr, r.listenersCount, r.clustersCount, r.routesCount)
+	}
 	_ = w.Flush()
 	fmt.Println()
 	return nil
+}
+
+func fetchRow(cli kube.CLIClient, podName, nodeName string) summaryRow {
+	if nodeName == "" {
+		nodeName = "-"
+	}
+	row := summaryRow{nodeName: nodeName, podName: podName, mode: "unknown", vStr: "-"}
+
+	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
+	if err != nil {
+		return row
+	}
+	if err := fw.Start(); err != nil {
+		fw.Close()
+		row.mode = "Offline"
+		return row
+	}
+	defer fw.Close()
+
+	respV, err := httpClient.Get(fmt.Sprintf("http://%s/version", fw.Address()))
+	if err == nil && respV.StatusCode == http.StatusOK {
+		bodyV, readErr := io.ReadAll(respV.Body)
+		respV.Body.Close()
+		if readErr == nil {
+			var v version.Info
+			if json.Unmarshal(bodyV, &v) == nil && v.GitVersion != "" {
+				row.vStr = v.GitVersion
+			}
+		}
+	} else if respV != nil {
+		respV.Body.Close()
+	}
+
+	respKN, err := httpClient.Get(fmt.Sprintf("http://%s/debug/config_dump/kernel-native", fw.Address()))
+	if err == nil && respKN.StatusCode == http.StatusOK {
+		row.mode = "kernel-native"
+		bodyKN, readErr := io.ReadAll(respKN.Body)
+		respKN.Body.Close()
+		if readErr != nil {
+			row.mode = "Error"
+			return row
+		}
+		configDump := &adminv2.ConfigDump{}
+		if protojson.Unmarshal(bodyKN, configDump) == nil {
+			static, dynamic := configDump.GetStaticResources(), configDump.GetDynamicResources()
+			if static != nil {
+				row.listenersCount += len(static.GetListenerConfigs())
+				row.clustersCount += len(static.GetClusterConfigs())
+				row.routesCount += len(static.GetRouteConfigs())
+			}
+			if dynamic != nil {
+				row.listenersCount += len(dynamic.GetListenerConfigs())
+				row.clustersCount += len(dynamic.GetClusterConfigs())
+				row.routesCount += len(dynamic.GetRouteConfigs())
+			}
+		}
+		return row
+	} else if respKN != nil {
+		respKN.Body.Close()
+	}
+
+	respDE, err := httpClient.Get(fmt.Sprintf("http://%s/debug/config_dump/dual-engine", fw.Address()))
+	if err == nil && respDE.StatusCode == http.StatusOK {
+		row.mode = "dual-engine"
+		bodyDE, readErr := io.ReadAll(respDE.Body)
+		respDE.Body.Close()
+		if readErr != nil {
+			row.mode = "Error"
+			return row
+		}
+		var deDump workloadDump
+		if json.Unmarshal(bodyDE, &deDump) == nil {
+			row.listenersCount = len(deDump.Workloads)
+			row.clustersCount = len(deDump.Services)
+			row.routesCount = len(deDump.Policies)
+		}
+	} else if respDE != nil {
+		respDE.Body.Close()
+	}
+
+	return row
 }

--- a/ctl/nodesummary/node_summary.go
+++ b/ctl/nodesummary/node_summary.go
@@ -1,0 +1,166 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nodesummary
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	adminv2 "kmesh.net/kmesh/api/v2/admin"
+	"kmesh.net/kmesh/ctl/utils"
+	"kmesh.net/kmesh/pkg/logger"
+	"kmesh.net/kmesh/pkg/version"
+)
+
+var log = logger.NewLoggerScope("kmeshctl/node-summary")
+
+type workloadDump struct {
+	Workloads []interface{} `json:"workloads"`
+	Services  []interface{} `json:"services"`
+	Policies  []interface{} `json:"policies"`
+}
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "node-summary",
+		Short: "Display a cluster-wide summary of all Kmesh daemons and resource counts",
+		Example: `  # Show summary of all nodes:
+  kmeshctl node-summary`,
+		Args: cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := RunNodeSummary(cmd); err != nil {
+				log.Errorf("Error: %v", err)
+				os.Exit(1)
+			}
+		},
+	}
+	return cmd
+}
+
+func RunNodeSummary(cmd *cobra.Command) error {
+	cli, err := utils.CreateKubeClient()
+	if err != nil {
+		return fmt.Errorf("failed to create cli client: %v", err)
+	}
+
+	podList, err := cli.PodsForSelector(context.TODO(), utils.KmeshNamespace, utils.KmeshLabel)
+	if err != nil {
+		return fmt.Errorf("failed to list kmesh daemon pods: %v", err)
+	}
+
+	if len(podList.Items) == 0 {
+		fmt.Println("No Kmesh daemon pods found in namespace kmesh-system.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(w, "\nNODE_NAME\tKMESH_POD\tMODE\tVERSION\tLISTENERS/WORKLOADS\tCLUSTERS/SERVICES\tROUTES/POLICIES")
+
+	for _, pod := range podList.Items {
+		podName := pod.GetName()
+		nodeName := pod.Spec.NodeName
+		if nodeName == "" {
+			nodeName = "-"
+		}
+
+		fw, err := utils.CreateKmeshPortForwarder(cli, podName)
+		if err != nil {
+			fmt.Fprintf(w, "%s\t%s\tError\t-\t-\t-\t-\n", nodeName, podName)
+			continue
+		}
+		if err := fw.Start(); err != nil {
+			fmt.Fprintf(w, "%s\t%s\tOffline\t-\t-\t-\t-\n", nodeName, podName)
+			fw.Close()
+			continue
+		}
+
+		// 1. Fetch version using the same struct as kmeshctl version
+		vStr := "-"
+		respV, err := http.Get(fmt.Sprintf("http://%s/version", fw.Address()))
+		if err == nil && respV.StatusCode == http.StatusOK {
+			bodyV, _ := io.ReadAll(respV.Body)
+			respV.Body.Close()
+			var v version.Info
+			if json.Unmarshal(bodyV, &v) == nil && v.GitVersion != "" {
+				vStr = v.GitVersion
+			}
+		} else if respV != nil {
+			respV.Body.Close()
+		}
+
+		// 2. Fetch mode and counts by trying kernel-native first
+		mode := "unknown"
+		listenersCount, clustersCount, routesCount := 0, 0, 0
+
+		respKN, err := http.Get(fmt.Sprintf("http://%s/debug/config_dump/kernel-native", fw.Address()))
+		if err == nil && respKN.StatusCode == http.StatusOK {
+			mode = "kernel-native"
+			bodyKN, _ := io.ReadAll(respKN.Body)
+			respKN.Body.Close()
+			configDump := &adminv2.ConfigDump{}
+			if protojson.Unmarshal(bodyKN, configDump) == nil {
+				static, dynamic := configDump.GetStaticResources(), configDump.GetDynamicResources()
+				if static != nil {
+					listenersCount += len(static.GetListenerConfigs())
+					clustersCount += len(static.GetClusterConfigs())
+					routesCount += len(static.GetRouteConfigs())
+				}
+				if dynamic != nil {
+					listenersCount += len(dynamic.GetListenerConfigs())
+					clustersCount += len(dynamic.GetClusterConfigs())
+					routesCount += len(dynamic.GetRouteConfigs())
+				}
+			}
+		} else {
+			if respKN != nil {
+				respKN.Body.Close()
+			}
+			// Try dual-engine
+			respDE, err := http.Get(fmt.Sprintf("http://%s/debug/config_dump/dual-engine", fw.Address()))
+			if err == nil && respDE.StatusCode == http.StatusOK {
+				mode = "dual-engine"
+				bodyDE, _ := io.ReadAll(respDE.Body)
+				respDE.Body.Close()
+				var deDump workloadDump
+				if json.Unmarshal(bodyDE, &deDump) == nil {
+					listenersCount = len(deDump.Workloads)
+					clustersCount = len(deDump.Services)
+					routesCount = len(deDump.Policies)
+				}
+			} else if respDE != nil {
+				respDE.Body.Close()
+			}
+		}
+
+		fw.Close()
+
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d\t%d\t%d\n",
+			nodeName, podName, mode, vStr, listenersCount, clustersCount, routesCount)
+	}
+
+	_ = w.Flush()
+	fmt.Println()
+	return nil
+}

--- a/ctl/nodesummary/node_summary.go
+++ b/ctl/nodesummary/node_summary.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"sort"
 	"sync"
 	"text/tabwriter"
 	"time"
@@ -107,6 +108,13 @@ func RunNodeSummary(cmd *cobra.Command) error {
 		}(cli, pod.GetName(), pod.Spec.NodeName)
 	}
 	wg.Wait()
+
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].nodeName != rows[j].nodeName {
+			return rows[i].nodeName < rows[j].nodeName
+		}
+		return rows[i].podName < rows[j].podName
+	})
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(w, "\nNODE_NAME\tKMESH_POD\tMODE\tVERSION\tLISTENERS/WORKLOADS\tCLUSTERS/SERVICES\tROUTES/POLICIES")

--- a/ctl/service/service.go
+++ b/ctl/service/service.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -38,6 +39,8 @@ import (
 )
 
 var log = logger.NewLoggerScope("kmeshctl/service")
+
+var httpClient = &http.Client{Timeout: 10 * time.Second}
 
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -75,11 +78,20 @@ func RunService(cmd *cobra.Command, args []string) error {
 	defer fw.Close()
 
 	url := fmt.Sprintf("http://%s/debug/config_dump/kernel-native", fw.Address())
-	resp, err := http.Get(url)
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		return fmt.Errorf("failed to make HTTP request to status server: %v", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		msg := strings.TrimSpace(string(body))
+		if msg != "" {
+			return fmt.Errorf("config dump request failed with status %s: %s (daemon may be running in dual-engine mode)", resp.Status, msg)
+		}
+		return fmt.Errorf("config dump request failed with status %s (daemon may be running in dual-engine mode)", resp.Status)
+	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -93,7 +105,6 @@ func RunService(cmd *cobra.Command, args []string) error {
 
 	static, dynamic := configDump.GetStaticResources(), configDump.GetDynamicResources()
 
-	// --- Step 1: Collect matching routes and clusters ---
 	matchingRouteNames := map[string]bool{}
 	matchingClusterNames := map[string]bool{}
 
@@ -137,9 +148,6 @@ func RunService(cmd *cobra.Command, args []string) error {
 	collectClusters(static)
 	collectClusters(dynamic)
 
-	// --- Step 2: Find listeners that reference matching routes or clusters ---
-	// Listener names are IP_PORT format (e.g. 10.96.0.10_53), not service names.
-	// We must correlate via filter chain content.
 	var matchingListeners []*listener.Listener
 	seenListeners := map[string]bool{}
 
@@ -154,7 +162,6 @@ func RunService(cmd *cobra.Command, args []string) error {
 			matched := false
 			for _, fc := range l.GetFilterChains() {
 				for _, f := range fc.GetFilters() {
-					// HTTP filter: check route config name
 					if hcm := f.GetHttpConnectionManager(); hcm != nil {
 						rcName := hcm.GetRouteConfigName()
 						if rcName == "" && hcm.GetRouteConfig() != nil {
@@ -164,7 +171,6 @@ func RunService(cmd *cobra.Command, args []string) error {
 							matched = true
 						}
 					}
-					// TCP filter: check cluster name
 					if tp := f.GetTcpProxy(); tp != nil {
 						if matchingClusterNames[tp.GetCluster()] {
 							matched = true
@@ -185,13 +191,11 @@ func RunService(cmd *cobra.Command, args []string) error {
 	collectListeners(static)
 	collectListeners(dynamic)
 
-	// --- Print results ---
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
 
 	fmt.Printf("\nSERVICE FILTER: %s\n", serviceName)
 	fmt.Println(strings.Repeat("═", 60))
 
-	// Listeners table
 	fmt.Fprintln(w, "\n[LISTENERS]")
 	fmt.Fprintln(w, "NAME\tADDRESS\tPORT\tTYPE")
 	if len(matchingListeners) == 0 {
@@ -204,7 +208,6 @@ func RunService(cmd *cobra.Command, args []string) error {
 			addr = uint32ToIPStr(sa.GetIpv4())
 			port = fmt.Sprintf("%d", parsePort(sa.GetPort()))
 		}
-		// Detect HTTP vs TCP from filter chains
 		for _, fc := range l.GetFilterChains() {
 			for _, f := range fc.GetFilters() {
 				if f.GetHttpConnectionManager() != nil {
@@ -216,7 +219,6 @@ func RunService(cmd *cobra.Command, args []string) error {
 	}
 	_ = w.Flush()
 
-	// Routes table
 	fmt.Fprintln(w, "\n[ROUTES]")
 	fmt.Fprintln(w, "ROUTE_NAME\tVIRTUAL_HOST\tDOMAINS")
 	if len(matchingRoutes) == 0 {
@@ -232,7 +234,6 @@ func RunService(cmd *cobra.Command, args []string) error {
 	}
 	_ = w.Flush()
 
-	// Clusters table
 	fmt.Fprintln(w, "\n[CLUSTERS & ENDPOINTS]")
 	fmt.Fprintln(w, "CLUSTER_NAME\tLB_POLICY\tENDPOINT_IP\tENDPOINT_PORT")
 	if len(matchingClusters) == 0 {
@@ -246,9 +247,11 @@ func RunService(cmd *cobra.Command, args []string) error {
 		} else {
 			for _, ep := range endpoints {
 				for _, lbEp := range ep.GetLbEndpoints() {
-					epAddr := lbEp.GetAddress()
-					epIP := uint32ToIPStr(epAddr.GetIpv4())
-					epPort := fmt.Sprintf("%d", parsePort(epAddr.GetPort()))
+					epIP, epPort := "-", "-"
+					if epAddr := lbEp.GetAddress(); epAddr != nil {
+						epIP = uint32ToIPStr(epAddr.GetIpv4())
+						epPort = fmt.Sprintf("%d", parsePort(epAddr.GetPort()))
+					}
 					fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", c.GetName(), lbPolicy, epIP, epPort)
 				}
 			}
@@ -260,12 +263,14 @@ func RunService(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// parsePort converts a Kmesh BPF port value (stored in big-endian) to host uint16.
 func parsePort(p uint32) uint16 {
 	b := make([]byte, 2)
 	binary.BigEndian.PutUint16(b, uint16(p))
 	return binary.LittleEndian.Uint16(b)
 }
 
+// uint32ToIPStr converts a Kmesh BPF IP value (stored in host/little-endian order) to a dotted IP string.
 func uint32ToIPStr(ip uint32) string {
 	b := make([]byte, 4)
 	binary.LittleEndian.PutUint32(b, ip)

--- a/ctl/service/service.go
+++ b/ctl/service/service.go
@@ -265,9 +265,8 @@ func RunService(cmd *cobra.Command, args []string) error {
 
 // parsePort converts a Kmesh BPF port value (stored in big-endian) to host uint16.
 func parsePort(p uint32) uint16 {
-	b := make([]byte, 2)
-	binary.BigEndian.PutUint16(b, uint16(p))
-	return binary.LittleEndian.Uint16(b)
+	v := uint16(p)
+	return v>>8 | v<<8
 }
 
 // uint32ToIPStr converts a Kmesh BPF IP value (stored in host/little-endian order) to a dotted IP string.

--- a/ctl/service/service.go
+++ b/ctl/service/service.go
@@ -1,0 +1,273 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package service
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	adminv2 "kmesh.net/kmesh/api/v2/admin"
+	cluster "kmesh.net/kmesh/api/v2/cluster"
+	listener "kmesh.net/kmesh/api/v2/listener"
+	route "kmesh.net/kmesh/api/v2/route"
+	"kmesh.net/kmesh/ctl/utils"
+	"kmesh.net/kmesh/pkg/logger"
+)
+
+var log = logger.NewLoggerScope("kmeshctl/service")
+
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "service <kmesh-daemon-pod> <service-name>",
+		Short: "Show all listener, route, and cluster configs for a specific service",
+		Example: `  # Show details for httpbin service:
+  kmeshctl service kmesh-tclf6 httpbin`,
+		Args: cobra.ExactArgs(2),
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := RunService(cmd, args); err != nil {
+				log.Errorf("Error: %v", err)
+				os.Exit(1)
+			}
+		},
+	}
+	return cmd
+}
+
+func RunService(cmd *cobra.Command, args []string) error {
+	podName := args[0]
+	serviceName := strings.ToLower(args[1])
+
+	cli, err := utils.CreateKubeClient()
+	if err != nil {
+		return fmt.Errorf("failed to create cli client: %v", err)
+	}
+
+	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
+	if err != nil {
+		return fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
+	}
+	if err := fw.Start(); err != nil {
+		return fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
+	}
+	defer fw.Close()
+
+	url := fmt.Sprintf("http://%s/debug/config_dump/kernel-native", fw.Address())
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to make HTTP request to status server: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read HTTP response body: %v", err)
+	}
+
+	configDump := &adminv2.ConfigDump{}
+	if err := protojson.Unmarshal(body, configDump); err != nil {
+		return fmt.Errorf("failed to parse config dump: %v", err)
+	}
+
+	static, dynamic := configDump.GetStaticResources(), configDump.GetDynamicResources()
+
+	// --- Step 1: Collect matching routes and clusters ---
+	matchingRouteNames := map[string]bool{}
+	matchingClusterNames := map[string]bool{}
+
+	var matchingRoutes []*route.RouteConfiguration
+	var matchingClusters []*cluster.Cluster
+
+	collectRoutes := func(res *adminv2.ConfigResources) {
+		if res == nil {
+			return
+		}
+		for _, r := range res.GetRouteConfigs() {
+			matched := strings.Contains(strings.ToLower(r.GetName()), serviceName)
+			if !matched {
+				for _, vh := range r.GetVirtualHosts() {
+					if strings.Contains(strings.ToLower(vh.GetName()), serviceName) {
+						matched = true
+						break
+					}
+				}
+			}
+			if matched {
+				matchingRoutes = append(matchingRoutes, r)
+				matchingRouteNames[r.GetName()] = true
+			}
+		}
+	}
+	collectClusters := func(res *adminv2.ConfigResources) {
+		if res == nil {
+			return
+		}
+		for _, c := range res.GetClusterConfigs() {
+			if strings.Contains(strings.ToLower(c.GetName()), serviceName) {
+				matchingClusters = append(matchingClusters, c)
+				matchingClusterNames[c.GetName()] = true
+			}
+		}
+	}
+
+	collectRoutes(static)
+	collectRoutes(dynamic)
+	collectClusters(static)
+	collectClusters(dynamic)
+
+	// --- Step 2: Find listeners that reference matching routes or clusters ---
+	// Listener names are IP_PORT format (e.g. 10.96.0.10_53), not service names.
+	// We must correlate via filter chain content.
+	var matchingListeners []*listener.Listener
+	seenListeners := map[string]bool{}
+
+	collectListeners := func(res *adminv2.ConfigResources) {
+		if res == nil {
+			return
+		}
+		for _, l := range res.GetListenerConfigs() {
+			if seenListeners[l.GetName()] {
+				continue
+			}
+			matched := false
+			for _, fc := range l.GetFilterChains() {
+				for _, f := range fc.GetFilters() {
+					// HTTP filter: check route config name
+					if hcm := f.GetHttpConnectionManager(); hcm != nil {
+						rcName := hcm.GetRouteConfigName()
+						if rcName == "" && hcm.GetRouteConfig() != nil {
+							rcName = hcm.GetRouteConfig().GetName()
+						}
+						if matchingRouteNames[rcName] {
+							matched = true
+						}
+					}
+					// TCP filter: check cluster name
+					if tp := f.GetTcpProxy(); tp != nil {
+						if matchingClusterNames[tp.GetCluster()] {
+							matched = true
+						}
+					}
+				}
+				if matched {
+					break
+				}
+			}
+			if matched {
+				matchingListeners = append(matchingListeners, l)
+				seenListeners[l.GetName()] = true
+			}
+		}
+	}
+
+	collectListeners(static)
+	collectListeners(dynamic)
+
+	// --- Print results ---
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+
+	fmt.Printf("\nSERVICE FILTER: %s\n", serviceName)
+	fmt.Println(strings.Repeat("═", 60))
+
+	// Listeners table
+	fmt.Fprintln(w, "\n[LISTENERS]")
+	fmt.Fprintln(w, "NAME\tADDRESS\tPORT\tTYPE")
+	if len(matchingListeners) == 0 {
+		fmt.Fprintln(w, "<no matching listeners found>")
+	}
+	for _, l := range matchingListeners {
+		addr, port := "-", "-"
+		lType := "TCP"
+		if sa := l.GetAddress(); sa != nil {
+			addr = uint32ToIPStr(sa.GetIpv4())
+			port = fmt.Sprintf("%d", parsePort(sa.GetPort()))
+		}
+		// Detect HTTP vs TCP from filter chains
+		for _, fc := range l.GetFilterChains() {
+			for _, f := range fc.GetFilters() {
+				if f.GetHttpConnectionManager() != nil {
+					lType = "HTTP"
+				}
+			}
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", l.GetName(), addr, port, lType)
+	}
+	_ = w.Flush()
+
+	// Routes table
+	fmt.Fprintln(w, "\n[ROUTES]")
+	fmt.Fprintln(w, "ROUTE_NAME\tVIRTUAL_HOST\tDOMAINS")
+	if len(matchingRoutes) == 0 {
+		fmt.Fprintln(w, "<no matching routes found>")
+	}
+	for _, r := range matchingRoutes {
+		for _, vh := range r.GetVirtualHosts() {
+			if strings.Contains(strings.ToLower(vh.GetName()), serviceName) ||
+				strings.Contains(strings.ToLower(r.GetName()), serviceName) {
+				fmt.Fprintf(w, "%s\t%s\t%s\n", r.GetName(), vh.GetName(), strings.Join(vh.GetDomains(), ","))
+			}
+		}
+	}
+	_ = w.Flush()
+
+	// Clusters table
+	fmt.Fprintln(w, "\n[CLUSTERS & ENDPOINTS]")
+	fmt.Fprintln(w, "CLUSTER_NAME\tLB_POLICY\tENDPOINT_IP\tENDPOINT_PORT")
+	if len(matchingClusters) == 0 {
+		fmt.Fprintln(w, "<no matching clusters found>")
+	}
+	for _, c := range matchingClusters {
+		lbPolicy := c.GetLbPolicy().String()
+		endpoints := c.GetLoadAssignment().GetEndpoints()
+		if len(endpoints) == 0 {
+			fmt.Fprintf(w, "%s\t%s\t-\t-\n", c.GetName(), lbPolicy)
+		} else {
+			for _, ep := range endpoints {
+				for _, lbEp := range ep.GetLbEndpoints() {
+					epAddr := lbEp.GetAddress()
+					epIP := uint32ToIPStr(epAddr.GetIpv4())
+					epPort := fmt.Sprintf("%d", parsePort(epAddr.GetPort()))
+					fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", c.GetName(), lbPolicy, epIP, epPort)
+				}
+			}
+		}
+	}
+	_ = w.Flush()
+	fmt.Println()
+
+	return nil
+}
+
+func parsePort(p uint32) uint16 {
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, uint16(p))
+	return binary.LittleEndian.Uint16(b)
+}
+
+func uint32ToIPStr(ip uint32) string {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, ip)
+	return net.IP(b).String()
+}

--- a/ctl/trace/trace.go
+++ b/ctl/trace/trace.go
@@ -1,0 +1,318 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package trace
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	adminv2 "kmesh.net/kmesh/api/v2/admin"
+	cluster "kmesh.net/kmesh/api/v2/cluster"
+	listener "kmesh.net/kmesh/api/v2/listener"
+	route "kmesh.net/kmesh/api/v2/route"
+	"kmesh.net/kmesh/ctl/utils"
+	"kmesh.net/kmesh/pkg/logger"
+)
+
+var log = logger.NewLoggerScope("kmeshctl/trace")
+
+func NewCmd() *cobra.Command {
+	var srcIP string
+	var dstIP string
+	var port int
+
+	cmd := &cobra.Command{
+		Use:   "trace <kmesh-daemon-pod> --dst <dest-ip> --port <port>",
+		Short: "Simulate a traffic request path lookup in the Kmesh engine config",
+		Example: `  # Trace request to httpbin ClusterIP:
+  kmeshctl trace kmesh-tclf6 --dst 10.96.46.87 --port 80`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			if dstIP == "" || port == 0 {
+				log.Errorf("Error: --dst and --port flags are required")
+				os.Exit(1)
+			}
+			if err := RunTrace(cmd, args[0], srcIP, dstIP, port); err != nil {
+				log.Errorf("Error: %v", err)
+				os.Exit(1)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&srcIP, "src", "", "Source IP (optional)")
+	cmd.Flags().StringVar(&dstIP, "dst", "", "Destination IP")
+	cmd.Flags().IntVar(&port, "port", 0, "Destination Port")
+	return cmd
+}
+
+func RunTrace(cmd *cobra.Command, podName, srcIP, dstIP string, port int) error {
+	cli, err := utils.CreateKubeClient()
+	if err != nil {
+		return fmt.Errorf("failed to create cli client: %v", err)
+	}
+
+	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
+	if err != nil {
+		return fmt.Errorf("failed to create port forwarder: %v", err)
+	}
+	if err := fw.Start(); err != nil {
+		return fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
+	}
+	defer fw.Close()
+
+	url := fmt.Sprintf("http://%s/debug/config_dump/kernel-native", fw.Address())
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to make HTTP request to status server: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to read HTTP response: %v", err)
+	}
+
+	configDump := &adminv2.ConfigDump{}
+	if err := protojson.Unmarshal(body, configDump); err != nil {
+		return fmt.Errorf("failed to parse config dump: %v", err)
+	}
+
+	dstUint := ipStrToUint32(dstIP)
+
+	fmt.Printf("\nSIMULATING TRAFFIC PATH: %s → %s:%d\n", getSrcString(srcIP), dstIP, port)
+	fmt.Println(strings.Repeat("═", 65))
+
+	static, dynamic := configDump.GetStaticResources(), configDump.GetDynamicResources()
+
+	// Step 1: Find Matching Listener
+	var matchedListener *listener.Listener
+	findListener := func(res *adminv2.ConfigResources) {
+		if res == nil || matchedListener != nil {
+			return
+		}
+		for _, l := range res.GetListenerConfigs() {
+			if sa := l.GetAddress(); sa != nil {
+				lIpv4 := sa.GetIpv4()
+				lPort := parsePort(sa.GetPort())
+				// Match exact IP and Port, or Wildcard IP (0.0.0.0 / 0) and exact Port
+				if (lIpv4 == dstUint || lIpv4 == 0) && int(lPort) == port {
+					matchedListener = l
+					return
+				}
+			}
+		}
+	}
+	findListener(static)
+	findListener(dynamic)
+
+	if matchedListener == nil {
+		fmt.Printf("STEP 1: [✗] NO LISTENER MATCHED for target %s:%d\n", dstIP, port)
+		fmt.Println("Result: Traffic will bypass Kmesh and use default OS routing.")
+		return nil
+	}
+
+	fmt.Printf("STEP 1: [✓] LISTENER MATCHED\n")
+	fmt.Printf("  Name:    %s\n", matchedListener.GetName())
+	if sa := matchedListener.GetAddress(); sa != nil {
+		fmt.Printf("  Address: %s:%d\n", uint32ToIPStr(sa.GetIpv4()), parsePort(sa.GetPort()))
+	}
+
+	// Step 2: Parse Filters & Route Configuration
+	var routeConfigName string
+	var directCluster string
+	isHTTP := false
+
+	for _, fc := range matchedListener.GetFilterChains() {
+		for _, f := range fc.GetFilters() {
+			if f.GetName() == "envoy.filters.network.http_connection_manager" {
+				isHTTP = true
+				if hcm := f.GetHttpConnectionManager(); hcm != nil {
+					routeConfigName = hcm.GetRouteConfigName()
+					if routeConfigName == "" && hcm.GetRouteConfig() != nil {
+						routeConfigName = hcm.GetRouteConfig().GetName()
+					}
+				}
+			} else if f.GetName() == "envoy.filters.network.tcp_proxy" {
+				if tp := f.GetTcpProxy(); tp != nil {
+					directCluster = tp.GetCluster()
+				}
+			}
+		}
+	}
+
+	var targetCluster string
+
+	if isHTTP && routeConfigName != "" {
+		fmt.Printf("STEP 2: [✓] HTTP FILTER CHAIN FOUND\n")
+		fmt.Printf("  Route Configuration Name: %s\n", routeConfigName)
+
+		// Find Route config
+		var matchedRoute *route.RouteConfiguration
+		findRoute := func(res *adminv2.ConfigResources) {
+			if res == nil || matchedRoute != nil {
+				return
+			}
+			for _, r := range res.GetRouteConfigs() {
+				if r.GetName() == routeConfigName {
+					matchedRoute = r
+					return
+				}
+			}
+		}
+		findRoute(static)
+		findRoute(dynamic)
+
+		if matchedRoute == nil {
+			fmt.Printf("  [✗] ROUTE CONFIGURATION NOT FOUND in Kmesh dump\n")
+			return nil
+		}
+
+		// Find matching virtual host (we default to the first one or match host domain if available)
+		var matchedVirtualHost *route.VirtualHost
+		if len(matchedRoute.GetVirtualHosts()) > 0 {
+			matchedVirtualHost = matchedRoute.GetVirtualHosts()[0] // default fallback
+			// Try to match domain
+			for _, vh := range matchedRoute.GetVirtualHosts() {
+				for _, dom := range vh.GetDomains() {
+					if dom == "*" || dom == dstIP {
+						matchedVirtualHost = vh
+						break
+					}
+				}
+			}
+		}
+
+		if matchedVirtualHost == nil {
+			fmt.Printf("  [✗] NO VIRTUAL HOST MATCHED in route configuration\n")
+			return nil
+		}
+
+		fmt.Printf("  Virtual Host Matched: %s (Domains: %s)\n",
+			matchedVirtualHost.GetName(), strings.Join(matchedVirtualHost.GetDomains(), ", "))
+
+		// Match the route destination cluster
+		if len(matchedVirtualHost.GetRoutes()) > 0 {
+			r := matchedVirtualHost.GetRoutes()[0]
+			if routeAction := r.GetRoute(); routeAction != nil {
+				targetCluster = routeAction.GetCluster()
+			}
+		}
+	} else if directCluster != "" {
+		fmt.Printf("STEP 2: [✓] TCP PROXY FILTER CHAIN FOUND\n")
+		targetCluster = directCluster
+	}
+
+	if targetCluster == "" {
+		fmt.Printf("STEP 2: [✗] NO TARGET CLUSTER RESOLVED\n")
+		return nil
+	}
+
+	fmt.Printf("STEP 3: [✓] TARGET CLUSTER RESOLVED\n")
+	fmt.Printf("  Cluster Name: %s\n", targetCluster)
+
+	// Step 4: Find Cluster and Backend Endpoints
+	var matchedCluster *cluster.Cluster
+	findCluster := func(res *adminv2.ConfigResources) {
+		if res == nil || matchedCluster != nil {
+			return
+		}
+		for _, c := range res.GetClusterConfigs() {
+			if c.GetName() == targetCluster {
+				matchedCluster = c
+				return
+			}
+		}
+	}
+	findCluster(static)
+	findCluster(dynamic)
+
+	if matchedCluster == nil {
+		fmt.Printf("STEP 4: [✗] CLUSTER NOT FOUND in Kmesh active config list\n")
+		return nil
+	}
+
+	fmt.Printf("STEP 4: [✓] CLUSTER BACKEND ENDPOINTS FOUND\n")
+	fmt.Printf("  Load Balancing Policy: %s\n", matchedCluster.GetLbPolicy().String())
+
+	endpoints := matchedCluster.GetLoadAssignment().GetEndpoints()
+	if len(endpoints) == 0 {
+		fmt.Println("  [✗] NO ACTIVE POD ENDPOINTS REGISTERED (All backends are down/empty)")
+		return nil
+	}
+
+	count := 0
+	for _, ep := range endpoints {
+		weight := ep.GetLoadBalancingWeight()
+		for _, lbEp := range ep.GetLbEndpoints() {
+			epAddr := lbEp.GetAddress()
+			epIP := uint32ToIPStr(epAddr.GetIpv4())
+			epPort := parsePort(epAddr.GetPort())
+			fmt.Printf("  → Endpoint %d: %s:%d (Weight: %d)\n", count+1, epIP, epPort, weight)
+			count++
+		}
+	}
+
+	fmt.Println(strings.Repeat("═", 65))
+	fmt.Printf("RESULT: Kmesh will successfully intercept and redirect this connection.\n")
+
+	return nil
+}
+
+func getSrcString(src string) string {
+	if src == "" {
+		return "Any Client Pod"
+	}
+	return src
+}
+
+func ipStrToUint32(ipStr string) uint32 {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		// Try parsing as int directly
+		val, err := strconv.Atoi(ipStr)
+		if err == nil {
+			return uint32(val)
+		}
+		return 0
+	}
+	ip4 := ip.To4()
+	if ip4 == nil {
+		return 0
+	}
+	return binary.LittleEndian.Uint32(ip4)
+}
+
+func parsePort(p uint32) uint16 {
+	b := make([]byte, 2)
+	binary.BigEndian.PutUint16(b, uint16(p))
+	return binary.LittleEndian.Uint16(b)
+}
+
+func uint32ToIPStr(ip uint32) string {
+	b := make([]byte, 4)
+	binary.LittleEndian.PutUint32(b, ip)
+	return net.IP(b).String()
+}

--- a/ctl/trace/trace.go
+++ b/ctl/trace/trace.go
@@ -23,8 +23,8 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -38,6 +38,8 @@ import (
 )
 
 var log = logger.NewLoggerScope("kmeshctl/trace")
+
+var httpClient = &http.Client{Timeout: 10 * time.Second}
 
 func NewCmd() *cobra.Command {
 	var srcIP string
@@ -84,11 +86,20 @@ func RunTrace(cmd *cobra.Command, podName, srcIP, dstIP string, port int) error 
 	defer fw.Close()
 
 	url := fmt.Sprintf("http://%s/debug/config_dump/kernel-native", fw.Address())
-	resp, err := http.Get(url)
+	resp, err := httpClient.Get(url)
 	if err != nil {
 		return fmt.Errorf("failed to make HTTP request to status server: %v", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		msg := strings.TrimSpace(string(body))
+		if msg != "" {
+			return fmt.Errorf("config dump request failed with status %s: %s", resp.Status, msg)
+		}
+		return fmt.Errorf("config dump request failed with status %s", resp.Status)
+	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -107,7 +118,6 @@ func RunTrace(cmd *cobra.Command, podName, srcIP, dstIP string, port int) error 
 
 	static, dynamic := configDump.GetStaticResources(), configDump.GetDynamicResources()
 
-	// Step 1: Find Matching Listener
 	var matchedListener *listener.Listener
 	findListener := func(res *adminv2.ConfigResources) {
 		if res == nil || matchedListener != nil {
@@ -117,7 +127,6 @@ func RunTrace(cmd *cobra.Command, podName, srcIP, dstIP string, port int) error 
 			if sa := l.GetAddress(); sa != nil {
 				lIpv4 := sa.GetIpv4()
 				lPort := parsePort(sa.GetPort())
-				// Match exact IP and Port, or Wildcard IP (0.0.0.0 / 0) and exact Port
 				if (lIpv4 == dstUint || lIpv4 == 0) && int(lPort) == port {
 					matchedListener = l
 					return
@@ -140,7 +149,6 @@ func RunTrace(cmd *cobra.Command, podName, srcIP, dstIP string, port int) error 
 		fmt.Printf("  Address: %s:%d\n", uint32ToIPStr(sa.GetIpv4()), parsePort(sa.GetPort()))
 	}
 
-	// Step 2: Parse Filters & Route Configuration
 	var routeConfigName string
 	var directCluster string
 	isHTTP := false
@@ -169,7 +177,6 @@ func RunTrace(cmd *cobra.Command, podName, srcIP, dstIP string, port int) error 
 		fmt.Printf("STEP 2: [✓] HTTP FILTER CHAIN FOUND\n")
 		fmt.Printf("  Route Configuration Name: %s\n", routeConfigName)
 
-		// Find Route config
 		var matchedRoute *route.RouteConfiguration
 		findRoute := func(res *adminv2.ConfigResources) {
 			if res == nil || matchedRoute != nil {
@@ -190,11 +197,9 @@ func RunTrace(cmd *cobra.Command, podName, srcIP, dstIP string, port int) error 
 			return nil
 		}
 
-		// Find matching virtual host (we default to the first one or match host domain if available)
 		var matchedVirtualHost *route.VirtualHost
 		if len(matchedRoute.GetVirtualHosts()) > 0 {
-			matchedVirtualHost = matchedRoute.GetVirtualHosts()[0] // default fallback
-			// Try to match domain
+			matchedVirtualHost = matchedRoute.GetVirtualHosts()[0]
 			for _, vh := range matchedRoute.GetVirtualHosts() {
 				for _, dom := range vh.GetDomains() {
 					if dom == "*" || dom == dstIP {
@@ -213,7 +218,6 @@ func RunTrace(cmd *cobra.Command, podName, srcIP, dstIP string, port int) error 
 		fmt.Printf("  Virtual Host Matched: %s (Domains: %s)\n",
 			matchedVirtualHost.GetName(), strings.Join(matchedVirtualHost.GetDomains(), ", "))
 
-		// Match the route destination cluster
 		if len(matchedVirtualHost.GetRoutes()) > 0 {
 			r := matchedVirtualHost.GetRoutes()[0]
 			if routeAction := r.GetRoute(); routeAction != nil {
@@ -233,7 +237,6 @@ func RunTrace(cmd *cobra.Command, podName, srcIP, dstIP string, port int) error 
 	fmt.Printf("STEP 3: [✓] TARGET CLUSTER RESOLVED\n")
 	fmt.Printf("  Cluster Name: %s\n", targetCluster)
 
-	// Step 4: Find Cluster and Backend Endpoints
 	var matchedCluster *cluster.Cluster
 	findCluster := func(res *adminv2.ConfigResources) {
 		if res == nil || matchedCluster != nil {
@@ -288,14 +291,11 @@ func getSrcString(src string) string {
 	return src
 }
 
+// ipStrToUint32 converts a dotted IP string to a uint32 in host/little-endian order,
+// consistent with how Kmesh BPF maps store IP addresses.
 func ipStrToUint32(ipStr string) uint32 {
 	ip := net.ParseIP(ipStr)
 	if ip == nil {
-		// Try parsing as int directly
-		val, err := strconv.Atoi(ipStr)
-		if err == nil {
-			return uint32(val)
-		}
 		return 0
 	}
 	ip4 := ip.To4()
@@ -305,12 +305,14 @@ func ipStrToUint32(ipStr string) uint32 {
 	return binary.LittleEndian.Uint32(ip4)
 }
 
+// parsePort converts a Kmesh BPF port value (stored in big-endian) to host uint16.
 func parsePort(p uint32) uint16 {
 	b := make([]byte, 2)
 	binary.BigEndian.PutUint16(b, uint16(p))
 	return binary.LittleEndian.Uint16(b)
 }
 
+// uint32ToIPStr converts a Kmesh BPF IP value (stored in host/little-endian order) to a dotted IP string.
 func uint32ToIPStr(ip uint32) string {
 	b := make([]byte, 4)
 	binary.LittleEndian.PutUint32(b, ip)

--- a/ctl/trace/trace.go
+++ b/ctl/trace/trace.go
@@ -42,7 +42,6 @@ var log = logger.NewLoggerScope("kmeshctl/trace")
 var httpClient = &http.Client{Timeout: 10 * time.Second}
 
 func NewCmd() *cobra.Command {
-	var srcIP string
 	var dstIP string
 	var port int
 
@@ -57,20 +56,25 @@ func NewCmd() *cobra.Command {
 				log.Errorf("Error: --dst and --port flags are required")
 				os.Exit(1)
 			}
-			if err := RunTrace(cmd, args[0], srcIP, dstIP, port); err != nil {
+			if err := RunTrace(cmd, args[0], dstIP, port); err != nil {
 				log.Errorf("Error: %v", err)
 				os.Exit(1)
 			}
 		},
 	}
 
-	cmd.Flags().StringVar(&srcIP, "src", "", "Source IP (optional)")
 	cmd.Flags().StringVar(&dstIP, "dst", "", "Destination IP")
 	cmd.Flags().IntVar(&port, "port", 0, "Destination Port")
 	return cmd
 }
 
-func RunTrace(cmd *cobra.Command, podName, srcIP, dstIP string, port int) error {
+func RunTrace(cmd *cobra.Command, podName, dstIP string, port int) error {
+	parsedDst := net.ParseIP(dstIP)
+	if parsedDst == nil || parsedDst.To4() == nil {
+		return fmt.Errorf("invalid --dst IPv4 address: %q", dstIP)
+	}
+	dstUint := binary.LittleEndian.Uint32(parsedDst.To4())
+
 	cli, err := utils.CreateKubeClient()
 	if err != nil {
 		return fmt.Errorf("failed to create cli client: %v", err)
@@ -111,9 +115,7 @@ func RunTrace(cmd *cobra.Command, podName, srcIP, dstIP string, port int) error 
 		return fmt.Errorf("failed to parse config dump: %v", err)
 	}
 
-	dstUint := ipStrToUint32(dstIP)
-
-	fmt.Printf("\nSIMULATING TRAFFIC PATH: %s → %s:%d\n", getSrcString(srcIP), dstIP, port)
+	fmt.Printf("\nSIMULATING TRAFFIC PATH: Any Client Pod → %s:%d\n", dstIP, port)
 	fmt.Println(strings.Repeat("═", 65))
 
 	static, dynamic := configDump.GetStaticResources(), configDump.GetDynamicResources()
@@ -270,9 +272,11 @@ func RunTrace(cmd *cobra.Command, podName, srcIP, dstIP string, port int) error 
 	for _, ep := range endpoints {
 		weight := ep.GetLoadBalancingWeight()
 		for _, lbEp := range ep.GetLbEndpoints() {
-			epAddr := lbEp.GetAddress()
-			epIP := uint32ToIPStr(epAddr.GetIpv4())
-			epPort := parsePort(epAddr.GetPort())
+			epIP, epPort := "-", uint16(0)
+			if epAddr := lbEp.GetAddress(); epAddr != nil {
+				epIP = uint32ToIPStr(epAddr.GetIpv4())
+				epPort = parsePort(epAddr.GetPort())
+			}
 			fmt.Printf("  → Endpoint %d: %s:%d (Weight: %d)\n", count+1, epIP, epPort, weight)
 			count++
 		}
@@ -284,32 +288,10 @@ func RunTrace(cmd *cobra.Command, podName, srcIP, dstIP string, port int) error 
 	return nil
 }
 
-func getSrcString(src string) string {
-	if src == "" {
-		return "Any Client Pod"
-	}
-	return src
-}
-
-// ipStrToUint32 converts a dotted IP string to a uint32 in host/little-endian order,
-// consistent with how Kmesh BPF maps store IP addresses.
-func ipStrToUint32(ipStr string) uint32 {
-	ip := net.ParseIP(ipStr)
-	if ip == nil {
-		return 0
-	}
-	ip4 := ip.To4()
-	if ip4 == nil {
-		return 0
-	}
-	return binary.LittleEndian.Uint32(ip4)
-}
-
 // parsePort converts a Kmesh BPF port value (stored in big-endian) to host uint16.
 func parsePort(p uint32) uint16 {
-	b := make([]byte, 2)
-	binary.BigEndian.PutUint16(b, uint16(p))
-	return binary.LittleEndian.Uint16(b)
+	v := uint16(p)
+	return v>>8 | v<<8
 }
 
 // uint32ToIPStr converts a Kmesh BPF IP value (stored in host/little-endian order) to a dotted IP string.


### PR DESCRIPTION
## Summary
This PR introduces three new diagnostic subcommands to `kmeshctl` to improve observability and ease debugging for operators running Kmesh in their clusters:
1. **`node-summary`**: Provides a cluster-wide high-level dashboard of Kmesh daemon status, runtime mode (kernel-native/dual-engine), version, and counts of active configurations (listeners/workloads, clusters/services, routes/policies).
2. **`service`**: Inspects listener, route, and cluster/endpoint configurations associated with a specific service name on a target Kmesh daemon.
3. **`trace`**: Simulates traffic routing in Kmesh, tracing how a request from a client would be processed step-by-step (matching listener, routing chain, target cluster, and backend endpoints).
---
## Changes
- **`ctl/common/common.go`**: Registered the three new CLI subcommands to the `kmeshctl` root command.
- **`ctl/nodesummary/node_summary.go`**: Implemented logic to discover all Kmesh daemon pods, automatically port-forward, detect running mode, and tabulate resources.
- **`ctl/service/service.go`**: Filtered active configurations (listeners, routes, clusters) by service name.
- **`ctl/trace/trace.go`**: Added connection routing simulation logic.

## Proposed Proposal

https://docs.google.com/document/d/19lL3mKnyjVDS3cIGkg48TPpBpN8RdqR_Lrg74apKXB8/edit?usp=sharing