### PR TITLE
fix: resolve controller bugs, CNI variable shadowing, and extraneous quote error

### DIFF
--- a/pkg/cni/chained.go
+++ b/pkg/cni/chained.go
@@ -281,7 +281,6 @@ func (i *Installer) removeChainedKmeshCniPlugin() error {
 
 	// remove kubeconfig file
 	if kubeconfigFilepath := filepath.Join(i.CniMountNetEtcDIR, kmeshCniKubeConfig); fileExists(kubeconfigFilepath) {
-		kubeconfigFilepath := filepath.Join(i.CniMountNetEtcDIR, kmeshCniKubeConfig)
 		log.Infof("Removing Kmesh CNI kubeconfig file: %s", kubeconfigFilepath)
 		if err := os.Remove(kubeconfigFilepath); err != nil {
 			return err

--- a/pkg/controller/bypass/bypass_controller.go
+++ b/pkg/controller/bypass/bypass_controller.go
@@ -157,7 +157,7 @@ func addIptables(ns string) error {
 		}
 		for _, args := range iptArgs {
 			if err := utils.Execute("iptables", args); err != nil {
-				return fmt.Errorf("failed to exec command: iptables %v\", err: %v", args, err)
+				return fmt.Errorf("failed to exec command: iptables %v, err: %v", args, err)
 			}
 		}
 		return nil
@@ -178,7 +178,7 @@ func deleteIptables(ns string) error {
 		log.Infof("Running delete iptables rule in namespace:%s", ns)
 		for _, args := range iptArgs {
 			if err := utils.Execute("iptables", args); err != nil {
-				err = fmt.Errorf("failed to exec command: iptables %v\", err: %v", args, err)
+				err = fmt.Errorf("failed to exec command: iptables %v, err: %v", args, err)
 				log.Error(err)
 				return err
 			}

--- a/pkg/controller/security/manager.go
+++ b/pkg/controller/security/manager.go
@@ -237,9 +237,10 @@ func (s *SecretManager) rotateCert(identity string) {
 	}
 	s.certsCache.mu.RUnlock()
 
-	if time.Until(certificate.cert.ExpireTime) >= 1*time.Hour {
+	if certificate.cert != nil && time.Until(certificate.cert.ExpireTime) >= 1*time.Hour {
 		// This can happen when delete a certificate following adding the same one later.
-		log.Debugf("cert %s expire at %T, skip rotate now", identity, certificate.cert.ExpireTime)
+		log.Debugf("cert %s expire at %v, skip rotate now", identity, certificate.cert.ExpireTime)
+		return
 	}
 
 	go s.fetchCert(identity)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:
This PR resolves three issues within the Go controller modules:
1. Fixes a log formatting bug in the security manager where `%T` was used instead of `%v` to print the certificate expiration time.
2. Cleans up a redundant variable declaration of `kubeconfigFilepath` inside the CNI installer block that was shadowing the outer variable.
3. Fixes error formatting in the bypass controller where an escaped quote (`\"`) was printing an extraneous double-quote character in the middle of error messages during `iptables` execution.

**Which issue(s) this PR fixes**:
Fixes #1721 

**Special notes for your reviewer**:
These are low-risk changes aimed at logging correctness, code cleanliness, and string formatting.

**Does this PR introduce a user-facing change?**:
NONE