### PR TITLE
docs: fix broken user guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Kmesh also provides a Dual-Engine Mode, which makes use of eBPF and waypoint to 
 
 ## Quick Start
 
-Please refer to [quick start](https://kmesh.net/en/docs/setup/quick-start/) and [user guide](docs/kmesh_demo.md) to try Kmesh quickly.
+Please refer to [quick start](https://kmesh.net/en/docs/setup/quick-start/) and [user guide](docs/en/kmesh_demo.md) to try Kmesh quickly.
 
 ### Guided Install
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:
The user guide link in the Quick Start section points to `docs/kmesh_demo.md` which does not exist, resulting in a 404 error. The actual file is located at `docs/en/kmesh_demo.md`.

**Which issue(s) this PR fixes**:
Fixes #1668

**Special notes for your reviewer**:
Simple one-line path fix. Documentation-only change, no functional or code changes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
