### PR TITLE
feat(observability): expose eBPF map capacity, memlock, and utilization metrics

### DIFF
--- a/pkg/controller/telemetry/map_metric.go
+++ b/pkg/controller/telemetry/map_metric.go
@@ -34,13 +34,22 @@ type MapMetricController struct {
 }
 
 type MapInfo struct {
-	mapName    string
-	entryCount uint32
+	mapName      string
+	mapType      string
+	entryCount   uint32
+	maxEntries   uint32
+	memlockBytes uint64
 }
 
 type mapMetricLabels struct {
 	mapName  string
 	nodeName string
+}
+
+type detailedMapMetricLabels struct {
+	mapName  string
+	nodeName string
+	mapType  string
 }
 
 func NewMapMetric() *MapMetricController {
@@ -66,11 +75,18 @@ func (m *MapMetricController) Run(ctx context.Context) {
 }
 
 func buildMapMetricLabel(data *MapInfo) mapMetricLabels {
-	labels := mapMetricLabels{
+	return mapMetricLabels{
 		nodeName: os.Getenv("NODE_NAME"),
 		mapName:  data.mapName,
 	}
-	return labels
+}
+
+func buildMapMetricDetailedLabel(data *MapInfo) detailedMapMetricLabels {
+	return detailedMapMetricLabels{
+		mapName:  data.mapName,
+		nodeName: os.Getenv("NODE_NAME"),
+		mapType:  data.mapType,
+	}
 }
 
 func isKmeshMap(mapName string) bool {
@@ -108,6 +124,14 @@ func (m *MapMetricController) updatePrometheusMetric() {
 		metricLabels := buildMapMetricLabel(&mapData)
 		commonLabels := struct2map(metricLabels)
 		mapEntryCount.With(commonLabels).Set(float64(entryCount))
+
+		detailedLabels := buildMapMetricDetailedLabel(&mapData)
+		detailedLabelsMap := struct2map(detailedLabels)
+		mapMaxEntries.With(detailedLabelsMap).Set(float64(mapData.maxEntries))
+		mapMemlockBytes.With(detailedLabelsMap).Set(float64(mapData.memlockBytes))
+		if mapData.maxEntries > 0 {
+			mapUtilizationRatio.With(detailedLabelsMap).Set(float64(entryCount) / float64(mapData.maxEntries))
+		}
 		mapInfo.Close()
 	}
 	mapCountLabels := map[string]string{"node_name": os.Getenv("NODE_NAME")}
@@ -136,9 +160,13 @@ func getNextMapInfo(startID ebpf.MapID) (ebpf.MapID, *ebpf.Map, *ebpf.MapInfo, e
 }
 
 func buildMapEntrycountMetric(info *ebpf.MapInfo, entryCount uint32) MapInfo {
+	memlock, _ := info.Memlock()
 	return MapInfo{
-		mapName:    info.Name,
-		entryCount: entryCount,
+		mapName:      info.Name,
+		mapType:      info.Type.String(),
+		entryCount:   entryCount,
+		maxEntries:   info.MaxEntries,
+		memlockBytes: memlock,
 	}
 }
 func getMapEntryCountFallback(m *ebpf.Map) (uint32, error) {

--- a/pkg/controller/telemetry/map_metric_test.go
+++ b/pkg/controller/telemetry/map_metric_test.go
@@ -33,7 +33,7 @@ func TestBuildMapMetricLabel(t *testing.T) {
 	}{
 		{
 			name: "valid MapInfo",
-			data: &MapInfo{mapName: "kmesh_map", entryCount: 5},
+			data: &MapInfo{mapName: "kmesh_map", entryCount: 5, maxEntries: 1024, memlockBytes: 4096},
 			expected: mapMetricLabels{
 				mapName:  "kmesh_map",
 				nodeName: "test-node",
@@ -44,6 +44,55 @@ func TestBuildMapMetricLabel(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := buildMapMetricLabel(tt.data)
 			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestBuildMapMetricDetailedLabel(t *testing.T) {
+	os.Setenv("NODE_NAME", "test-node")
+	defer os.Unsetenv("NODE_NAME")
+	tests := []struct {
+		name     string
+		data     *MapInfo
+		expected detailedMapMetricLabels
+	}{
+		{
+			name: "valid MapInfo with type",
+			data: &MapInfo{mapName: "kmesh_map", mapType: "Hash", entryCount: 5, maxEntries: 1024, memlockBytes: 4096},
+			expected: detailedMapMetricLabels{
+				mapName:  "kmesh_map",
+				nodeName: "test-node",
+				mapType:  "Hash",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildMapMetricDetailedLabel(tt.data)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestUtilizationRatio(t *testing.T) {
+	tests := []struct {
+		name      string
+		entryCount uint32
+		maxEntries uint32
+		expected  float64
+	}{
+		{name: "zero entries", entryCount: 0, maxEntries: 1024, expected: 0.0},
+		{name: "half full", entryCount: 512, maxEntries: 1024, expected: 0.5},
+		{name: "full", entryCount: 1024, maxEntries: 1024, expected: 1.0},
+		{name: "empty max entries", entryCount: 10, maxEntries: 0, expected: 0.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ratio float64
+			if tt.maxEntries > 0 {
+				ratio = float64(tt.entryCount) / float64(tt.maxEntries)
+			}
+			assert.Equal(t, tt.expected, ratio)
 		})
 	}
 }

--- a/pkg/controller/telemetry/utils.go
+++ b/pkg/controller/telemetry/utils.go
@@ -169,6 +169,11 @@ var (
 		"node_name",
 		"map_name",
 	}
+	kmeshMapDetailedLabels = []string{
+		"node_name",
+		"map_name",
+		"map_type",
+	}
 	totalMapLabels = []string{
 		"node_name",
 	}
@@ -292,6 +297,24 @@ var (
 			Help: "The total entry used by an eBPF map.",
 		}, kmeshMapLabels,
 	)
+	mapMaxEntries = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kmesh_map_max_entries",
+			Help: "The max capacity of an eBPF map.",
+		}, kmeshMapDetailedLabels,
+	)
+	mapMemlockBytes = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kmesh_map_memlock_bytes",
+			Help: "Kernel locked memory of an eBPF map in bytes.",
+		}, kmeshMapDetailedLabels,
+	)
+	mapUtilizationRatio = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "kmesh_map_entry_utilization_ratio",
+			Help: "Ratio of current entries to max capacity of an eBPF map.",
+		}, kmeshMapDetailedLabels,
+	)
 	mapCountInNode = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "kmesh_map_count_total",
@@ -320,7 +343,7 @@ func runPrometheusClient(registry *prometheus.Registry) {
 	registry.MustRegister(tcpConnectionOpenedInService, tcpConnectionClosedInService, tcpReceivedBytesInService, tcpSentBytesInService)
 	registry.MustRegister(tcpConnectionTotalSendBytes, tcpConnectionTotalReceivedBytes, tcpConnectionTotalPacketLost, tcpConnectionTotalRetrans)
 	registry.MustRegister(bpfProgOpDuration, bpfProgOpCount)
-	registry.MustRegister(mapEntryCount, mapCountInNode)
+	registry.MustRegister(mapEntryCount, mapMaxEntries, mapMemlockBytes, mapUtilizationRatio, mapCountInNode)
 
 	http.Handle("/status/metric", promhttp.HandlerFor(registry, promhttp.HandlerOpts{
 		Registry: registry,

--- a/samples/addons/grafana.yaml
+++ b/samples/addons/grafana.yaml
@@ -716,6 +716,291 @@ data:
           ],
           "title": "Traffc Control Duration",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "kmesh_map_max_entries",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Kmesh Map Max Entries",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 24
+          },
+          "id": 7,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "kmesh_map_memlock_bytes",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Kmesh Map Memlock Bytes",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 32
+          },
+          "id": 8,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "PBFA97CFB590B2093"
+              },
+              "editorMode": "code",
+              "expr": "kmesh_map_entry_utilization_ratio",
+              "instant": false,
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Kmesh Map Utilization Ratio",
+          "type": "timeseries"
         }
       ],
       "refresh": "",

--- a/samples/addons/kmesh_performance-monitoring.json
+++ b/samples/addons/kmesh_performance-monitoring.json
@@ -495,6 +495,291 @@
       ],
       "title": "Traffc Control Duration",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "kmesh_map_max_entries",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Kmesh Map Max Entries",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "kmesh_map_memlock_bytes",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Kmesh Map Memlock Bytes",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "code",
+          "expr": "kmesh_map_entry_utilization_ratio",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Kmesh Map Utilization Ratio",
+      "type": "timeseries"
     }
   ],
   "refresh": "",


### PR DESCRIPTION
**What would you like to be added**: Three new Prometheus gauges for kmesh-owned eBPF maps:

- \kmesh_map_max_entries{node_name, map_name, map_type}\ — map capacity
- \kmesh_map_memlock_bytes{node_name, map_name, map_type}\ — kernel locked memory
- \kmesh_map_entry_utilization_ratio{node_name, map_name, map_type}\ — entry_count / max_entries

**Why is this needed**: Currently \updatePrometheusMetric\ only collects \mapName\ and \entryCount\. Neither \MaxEntries\ (capacity) nor \Memlock\ (locked kernel memory) is exported, leaving operators with no map headroom or memory visibility. This makes scale diagnosis difficult as raised in issue #945; operators cannot tell whether a map is approaching its capacity limit or how much kernel memory it is consuming under load.

**Changes**:

1. Extended \MapInfo\ in \pkg/controller/telemetry/map_metric.go\ to capture \MaxEntries\, \Type\, and \Memlock\
2. Added \map_type\ label to \kmeshMapDetailedLabels\ in \pkg/controller/telemetry/utils.go\
3. Registered three new gauges and expose them on \/status/metric\
4. Updated Grafana dashboards in \samples/addons/\ with panels for capacity, utilization, and memlock
5. Added unit tests for detailed label building and utilization ratio computation

Refs: #1666