### PR TITLE
fix: typos in documentation

### DIFF
--- a/docs/cn/zh/kmesh_commands-zh.md
+++ b/docs/cn/zh/kmesh_commands-zh.md
@@ -16,7 +16,7 @@ Flags:
   -h, --help                   help for kmesh-daemon
       --mode string            controller plane mode, valid values are [kernel-native, dual-engine] (default "dual-engine")
       --monitoring string      enable kmesh traffic monitoring in daemon process(default "true")  
-      --profiliing string      whether to enable profiling or not (default "false")
+      --profiling string      whether to enable profiling or not (default "false")
       --enable-ipsec string    enable ipsec encryption and authentication between nodes(default false)
 
 # example

--- a/docs/en/kmesh_commands.md
+++ b/docs/en/kmesh_commands.md
@@ -16,7 +16,7 @@ Flags:
   -h, --help                   help for kmesh-daemon
       --mode string            controller plane mode, valid values are [kernel-native, dual-engine] (default "dual-engine")
       --monitoring string      enable kmesh traffic monitoring in daemon process(default "true")  
-      --profiliing string      whether to enable profiling or not (default "false")
+      --profiling string      whether to enable profiling or not (default "false")
       --enable-ipsec string    enable ipsec encryption and authentication between nodes(default false)
 
 # example


### PR DESCRIPTION
Fixes:
- `--profiliing` → `--profiling` in docs/en/kmesh_commands.md
- `--profiliing` → `--profiling` in docs/cn/zh/kmesh_commands-zh.md

Closes #1736