### PR TITLE
Eliminate duplicate Endpoint struct

### DIFF
--- a/pkg/controller/workload/cache/endpoint_cache.go
+++ b/pkg/controller/workload/cache/endpoint_cache.go
@@ -18,14 +18,12 @@ package cache
 
 import (
 	"sync"
+
+	"kmesh.net/kmesh/pkg/controller/workload/bpfcache"
 )
 
-// TODO: use `EndpointKey` struct
-type Endpoint struct {
-	ServiceId    uint32
-	Prio         uint32
-	BackendIndex uint32
-}
+// Endpoint is an alias to bpfcache.EndpointKey to avoid duplication.
+type Endpoint = bpfcache.EndpointKey
 
 type EndpointCache interface {
 	List(uint32) map[uint32]Endpoint // Endpoint slice by ServiceId

--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -415,7 +415,7 @@ func (p *Processor) addWorkloadToService(sk *bpf.ServiceKey, sv *bpf.ServiceValu
 		log.Errorf("Update endpoint map failed, err:%s", err)
 		return ek, err
 	}
-	p.EndpointCache.AddEndpointToService(cache.Endpoint{ServiceId: ek.ServiceId, Prio: ek.Prio, BackendIndex: ek.BackendIndex}, ev.BackendUid)
+	p.EndpointCache.AddEndpointToService(ek, ev.BackendUid)
 	if err := p.bpf.ServiceUpdate(sk, sv); err != nil {
 		log.Errorf("Update ServiceUpdate map failed, err:%s", err)
 		return ek, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactored the codebase to eliminate the duplicate `Endpoint` struct definition in the workload cache package, replacing it with a Go type alias to `bpfcache.EndpointKey`. This improves the maintainability of the workload data path and resolves a pending TODO.

**Which issue(s) this PR fixes**:
Fixes #1742 
