### PR TITLE
feat(ctl): add YAML output support to kmeshctl dump

### DIFF
--- a/ctl/dump/dump.go
+++ b/ctl/dump/dump.go
@@ -112,8 +112,9 @@ func RunDump(cmd *cobra.Command, args []string, outputFormat string) error {
 	if outputFormat == "yaml" {
 		yamlData, err := yaml.JSONToYAML(body)
 		if err != nil {
-			log.Errorf("failed to convert JSON to YAML: %v", err)
-			os.Exit(1)
+			log.Errorf("failed to convert JSON to YAML: %v, falling back to raw output", err)
+			fmt.Println(string(body))
+			return nil
 		}
 		fmt.Println(string(yamlData))
 		return nil

--- a/ctl/dump/dump.go
+++ b/ctl/dump/dump.go
@@ -108,7 +108,7 @@ func RunDump(cmd *cobra.Command, args []string, outputFormat string) error {
 		fmt.Println(string(body))
 		return nil
 	}
-	
+
 	if outputFormat == "yaml" {
 		yamlData, err := yaml.JSONToYAML(body)
 		if err != nil {

--- a/ctl/dump/dump.go
+++ b/ctl/dump/dump.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/encoding/protojson"
+	"sigs.k8s.io/yaml"
 
 	adminv2 "kmesh.net/kmesh/api/v2/admin"
 	"kmesh.net/kmesh/ctl/utils"
@@ -62,7 +63,7 @@ kmeshctl dump <kmesh-daemon-pod> kernel-native -o json`,
 		},
 	}
 
-	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "Output format: table or json")
+	cmd.Flags().StringVarP(&outputFormat, "output", "o", "table", "Output format: table, json, or yaml")
 	return cmd
 }
 
@@ -105,6 +106,16 @@ func RunDump(cmd *cobra.Command, args []string, outputFormat string) error {
 
 	if outputFormat == "json" {
 		fmt.Println(string(body))
+		return nil
+	}
+	
+	if outputFormat == "yaml" {
+		yamlData, err := yaml.JSONToYAML(body)
+		if err != nil {
+			log.Errorf("failed to convert JSON to YAML: %v", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(yamlData))
 		return nil
 	}
 

--- a/docs/ctl/kmeshctl_dump.md
+++ b/docs/ctl/kmeshctl_dump.md
@@ -23,7 +23,7 @@ kmeshctl dump <kmesh-daemon-pod> kernel-native -o json
 
 ```bash
   -h, --help            help for dump
-  -o, --output string   Output format: table or json (default "table")
+  -o, --output string   Output format: table, json, or yaml (default "table")
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

## What this PR does / why we need it

Currently, `kmeshctl dump` supports output in table format or raw JSON only. While JSON is useful for machine processing, it can be difficult to read when inspecting large configurations.

This PR adds support for `-o yaml`, allowing users to view the daemon's configuration in a more human-readable format. The implementation converts the existing JSON output into YAML using `sigs.k8s.io/yaml`, providing an experience consistent with common Kubernetes tooling such as `kubectl`.

## Special notes for your reviewer
The implementation has been tested locally against a Kind cluster, and the output is rendered correctly in YAML format.
Please let me know if any additional changes or tests are needed.

## Does this PR introduce a user-facing change?

```release-note
Added support for the `-o yaml` flag in `kmeshctl dump`, enabling daemon configuration output in YAML format.
```

