### PR TITLE
Fix : E2E startup race condition

### DIFF
--- a/pkg/controller/client.go
+++ b/pkg/controller/client.go
@@ -108,9 +108,20 @@ func (c *XdsClient) recoverConnection() {
 			return
 		}
 
+		if c.ctx.Err() != nil {
+			log.Infof("stopping reconnection: %v", c.ctx.Err())
+			return
+		}
+
 		log.Errorf("grpc reconnect failed, %s", err)
-		time.Sleep(interval + nets.CalculateRandTime(RandTimeSed))
-		interval = nets.CalculateInterval(interval)
+		timer := time.NewTimer(interval + nets.CalculateRandTime(RandTimeSed))
+		select {
+		case <-c.ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+			interval = nets.CalculateInterval(interval)
+		}
 	}
 }
 
@@ -147,18 +158,46 @@ func (c *XdsClient) handleUpstream(ctx context.Context) {
 }
 
 func (c *XdsClient) Run(stopCh <-chan struct{}) error {
-	if err := c.createGrpcStreamClient(); err != nil {
-		return fmt.Errorf("create client and stream failed, %s", err)
-	}
-
-	go c.handleUpstream(c.ctx)
-
+	// Cancel c.ctx immediately when stopCh is closed.
+	// This unblocks any blocking call inside createGrpcStreamClient()
+	// that respects c.ctx.
 	go func() {
 		<-stopCh
 		c.closeStreamClient()
 		if c.cancel != nil {
 			c.cancel()
 		}
+	}()
+
+	go func() {
+		var (
+			err      error
+			interval = time.Second
+		)
+
+		for {
+			if err = c.createGrpcStreamClient(); err == nil {
+				break
+			}
+
+			// If the context was already cancelled (stopCh fired), bail out.
+			if c.ctx.Err() != nil {
+				log.Infof("stopped before establishing connection: %v", c.ctx.Err())
+				return
+			}
+
+			log.Errorf("initial grpc connection failed, retrying: %s", err)
+			timer := time.NewTimer(interval + nets.CalculateRandTime(RandTimeSed))
+			select {
+			case <-c.ctx.Done():
+				timer.Stop()
+				return
+			case <-timer.C:
+				interval = nets.CalculateInterval(interval)
+			}
+		}
+
+		go c.handleUpstream(c.ctx)
 	}()
 
 	return nil

--- a/test/e2e/run_test.sh
+++ b/test/e2e/run_test.sh
@@ -118,24 +118,9 @@ function setup_istio() {
 
 	helm install istio-ingressgateway istio/gateway -n istio-system --create-namespace
 
-	while true; do
-		pod_info=$(kubectl get pods -n istio-system -l app=istiod -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.phase}{"\n"}{end}')
-
-		if [ -z "$pod_info" ]; then
-			echo "No istiod pod found yet, waiting..."
-			sleep 1
-			continue
-		fi
-
-		read -r pod_name pod_status <<<"$pod_info"
-		if [ "$pod_status" = "Running" ]; then
-			echo "Istiod pod $pod_name is in Running state."
-			break
-		fi
-
-		echo "Waiting for pods of Kmesh daemon to enter Running state..."
-		sleep 1
-	done
+	echo "Waiting for Istiod to be ready..."
+	kubectl rollout status deployment/istiod -n istio-system --timeout=120s
+	echo "Istiod is ready."
 }
 
 function setup_kmesh() {
@@ -157,28 +142,11 @@ function setup_kmesh() {
 		--set deploy.kmesh.containers.kmeshDaemonArgs="--mode=dual-engine --enable-bypass=false --monitoring=true --enable-ipsec=true" \
 		$extra_args
 
-	# Wait for all Kmesh pods to be ready.
-	while true; do
-		pod_statuses=$(kubectl get pods -n kmesh-system -l app=kmesh -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.phase}{"\n"}{end}')
+	echo "Waiting for Kmesh daemon to be ready..."
+	kubectl rollout status daemonset/kmesh -n kmesh-system --timeout=120s
 
-		running_pods=0
-		total_pods=0
-
-		while read -r pod_name pod_status; do
-			total_pods=$((total_pods + 1))
-			if [ "$pod_status" = "Running" ]; then
-				running_pods=$((running_pods + 1))
-			fi
-		done <<<"$pod_statuses"
-
-		if [ "$running_pods" -eq "$total_pods" ]; then
-			echo "All pods of Kmesh daemon are in Running state."
-			break
-		fi
-
-		echo "Waiting for pods of Kmesh daemon to enter Running state..."
-		sleep 1
-	done
+	echo "Allowing Kmesh daemon to fully initialize (BPF load, admin server startup)..."
+	sleep 5
 
 	# Set log of each Kmesh pods.
 	PODS=$(kubectl get pods -n kmesh-system -l app=kmesh -o jsonpath='{.items[*].metadata.name}')


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR addresses startup race conditions observed during e2e test execution and improves daemon resilience during Istio initialization.

Changes

- Wait for Istiod readiness using `kubectl wait --for=condition=ready` instead of only checking the pod Running state.
- Add a short post-start initialization delay for Kmesh DaemonSet pods before running kmeshctl log and port-forward operations.
- Add retry and backoff logic to `XdsClient.Run()` so the daemon can recover from temporary `Istiod` unavailability instead of exiting on the first connection failure.

