### PR TITLE
auth: add unit tests for xdp connection reset and fix uninitialized prev_key

### DIFF
--- a/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.c
+++ b/bpf/deserialization_to_bpf_map/deserialization_to_bpf_map.c
@@ -1426,7 +1426,7 @@ void deserial_uninit()
 
 int map_restore(int map_fd, struct bpf_map_info *map_info, unsigned char *bitmap, unsigned int *start_pos)
 {
-    void *prev_key;
+    void *prev_key = NULL;
     unsigned int key = 0;
 
     while (!bpf_map_get_next_key(map_fd, prev_key, &key)) {

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.7
-	github.com/stretchr/testify v1.10.0
+	github.com/stretchr/testify v1.11.1
 	github.com/vishvananda/netlink v1.3.1
 	golang.org/x/sys v0.35.0
 	google.golang.org/grpc v1.70.0

--- a/go.sum
+++ b/go.sum
@@ -426,6 +426,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/vbatts/tar-split v0.11.6 h1:4SjTW5+PU11n6fZenf2IPoV8/tz3AaYHMWjf23envGs=

--- a/pkg/auth/xdp_auth_handler_test.go
+++ b/pkg/auth/xdp_auth_handler_test.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package auth
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/rlimit"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"kmesh.net/kmesh/pkg/constants"
+)
+
+func Test_xdpNotifyConnRst(t *testing.T) {
+	err := rlimit.RemoveMemlock()
+	require.NoError(t, err, "failed to remove memlock")
+
+	mapOfAuth, err := ebpf.NewMap(&ebpf.MapSpec{
+		Name:       "test_map_of_auth_result",
+		Type:       ebpf.Hash,
+		KeySize:    uint32(TUPLE_LEN),
+		ValueSize:  uint32(unsafe.Sizeof(uint32(0))),
+		MaxEntries: 4096,
+	})
+	require.NoError(t, err, "failed to create ebpf map")
+	defer mapOfAuth.Close()
+
+	t.Run("nil map", func(t *testing.T) {
+		key := make([]byte, TUPLE_LEN)
+		err := xdpNotifyConnRst(nil, constants.MSG_TYPE_IPV4, key)
+		assert.Error(t, err)
+		assert.Equal(t, "map_of_auth_result is nil", err.Error())
+	})
+
+	t.Run("IPv4 zeros out remainder and inserts", func(t *testing.T) {
+		key := make([]byte, TUPLE_LEN)
+		// fill with some garbage
+		for i := 0; i < len(key); i++ {
+			key[i] = 0xAA
+		}
+
+		err := xdpNotifyConnRst(mapOfAuth, constants.MSG_TYPE_IPV4, key)
+		assert.NoError(t, err)
+
+		// check that remainder is zeroed
+		for i := IPV4_TUPLE_LENGTH; i < len(key); i++ {
+			assert.Equal(t, byte(0), key[i], "byte at index %d should be 0", i)
+		}
+
+		// check that map contains the key
+		var val uint32
+		err = mapOfAuth.Lookup(key, &val)
+		assert.NoError(t, err)
+		assert.Equal(t, uint32(1), val)
+	})
+
+	t.Run("IPv6 does not zero out remainder and inserts", func(t *testing.T) {
+		key := make([]byte, TUPLE_LEN)
+		for i := 0; i < len(key); i++ {
+			key[i] = 0xBB
+		}
+
+		// copy key for assertion later
+		expectedKey := make([]byte, TUPLE_LEN)
+		copy(expectedKey, key)
+
+		err := xdpNotifyConnRst(mapOfAuth, constants.MSG_TYPE_IPV6, key)
+		assert.NoError(t, err)
+
+		// check that key is unmodified
+		assert.Equal(t, expectedKey, key)
+
+		// check that map contains the key
+		var val uint32
+		err = mapOfAuth.Lookup(key, &val)
+		assert.NoError(t, err)
+		assert.Equal(t, uint32(1), val)
+	})
+}


### PR DESCRIPTION
This PR adds unit tests for `xdpNotifyConnRst` to verify the connection reset logic for XDP authorization. It also fixes a compilation error in the deserialization module.

Changes :-
1. Added `pkg/auth/xdp_auth_handler_test.go` to cover `xdpNotifyConnRst` :-
  - Verified nil map safety.
  - Verified that trailing bytes for IPv4 keys are zeroed out (important for correct eBPF map lookups).
  - Verified IPv6 key insertion.
2. Initialized `prev_key` to `NULL` in `map_restore` (`deserialization_to_bpf_map.c`) to fix a compilation failure (`sometimes-uninitialized` warning treated as error under `-Werror`).
3. Refactored test setup to use `rlimit` memory lock adjustments instead of loading the full Kmesh BPF programs, which helps tests run locally on setups like WSL2.

Verification :-
Ran tests locally on WSL2 :-
```bash
go test -v ./pkg/auth -run Test_xdpNotifyConnRst
