### PR TITLE
telemetry: populate response_flags label in workload, service and connection metrics

### DIFF
--- a/pkg/controller/telemetry/metric.go
+++ b/pkg/controller/telemetry/metric.go
@@ -207,8 +207,7 @@ type workloadMetricLabels struct {
 	destinationVersion           string
 	destinationCluster           string
 
-	requestProtocol string
-	// TODO: responseFlags is not used for now
+	requestProtocol          string
 	responseFlags            string
 	connectionSecurityPolicy string
 }
@@ -237,8 +236,7 @@ type serviceMetricLabels struct {
 	destinationVersion           string
 	destinationCluster           string
 
-	requestProtocol string
-	// TODO: responseFlags is not used for now
+	requestProtocol          string
 	responseFlags            string
 	connectionSecurityPolicy string
 }
@@ -273,8 +271,7 @@ type connectionMetricLabels struct {
 	destinationVersion           string
 	destinationCluster           string
 
-	requestProtocol string
-	// TODO: responseFlags is not used for now
+	requestProtocol          string
 	responseFlags            string
 	connectionSecurityPolicy string
 }
@@ -665,6 +662,7 @@ func (m *MetricController) buildWorkloadMetric(reqMetric *requestMetric) workloa
 
 	trafficLabels.destinationPodAddress = dstIP
 	trafficLabels.requestProtocol = "tcp"
+	trafficLabels.responseFlags = buildResponseFlags(reqMetric)
 	trafficLabels.connectionSecurityPolicy = "mutual_tls"
 
 	switch reqMetric.conSrcDstInfo.direction {
@@ -758,6 +756,7 @@ func (m *MetricController) buildServiceMetric(reqMetric *requestMetric) (service
 	trafficLabels := NewServiceMetricLabel()
 	trafficLabels.withSource(srcWorkload).withDestination(dstWorkload).withDestinationService(dstService)
 	trafficLabels.requestProtocol = "tcp"
+	trafficLabels.responseFlags = buildResponseFlags(reqMetric)
 	trafficLabels.connectionSecurityPolicy = "mutual_tls"
 
 	accesslog := NewLogInfo()
@@ -808,6 +807,7 @@ func (m *MetricController) buildConnectionMetric(reqMetric *requestMetric) conne
 	trafficLabels.sourceAddress = srcIP + ":" + fmt.Sprintf("%d", reqMetric.conSrcDstInfo.srcPort)
 	trafficLabels.destinationPodAddress = dstIP
 	trafficLabels.requestProtocol = "tcp"
+	trafficLabels.responseFlags = buildResponseFlags(reqMetric)
 	trafficLabels.connectionSecurityPolicy = "mutual_tls"
 
 	switch reqMetric.conSrcDstInfo.direction {
@@ -832,6 +832,16 @@ func (m *MetricController) getWorkloadByAddress(address []byte) (*workloadapi.Wo
 		return nil, networkAddr.Address.String()
 	}
 	return workload, networkAddr.Address.String()
+}
+
+// buildResponseFlags maps connection outcome to an Istio-compatible response_flags value.
+// "UF" (upstream connection failure) is set when the TCP handshake did not succeed;
+// "-" indicates a successfully established connection.
+func buildResponseFlags(reqMetric *requestMetric) string {
+	if reqMetric.success != connection_success {
+		return "UF"
+	}
+	return "-"
 }
 
 func buildPrincipal(workload *workloadapi.Workload) string {

--- a/pkg/controller/telemetry/metric.go
+++ b/pkg/controller/telemetry/metric.go
@@ -207,8 +207,7 @@ type workloadMetricLabels struct {
 	destinationVersion           string
 	destinationCluster           string
 
-	requestProtocol string
-	// TODO: responseFlags is not used for now
+	requestProtocol          string
 	responseFlags            string
 	connectionSecurityPolicy string
 }
@@ -237,8 +236,7 @@ type serviceMetricLabels struct {
 	destinationVersion           string
 	destinationCluster           string
 
-	requestProtocol string
-	// TODO: responseFlags is not used for now
+	requestProtocol          string
 	responseFlags            string
 	connectionSecurityPolicy string
 }
@@ -273,8 +271,7 @@ type connectionMetricLabels struct {
 	destinationVersion           string
 	destinationCluster           string
 
-	requestProtocol string
-	// TODO: responseFlags is not used for now
+	requestProtocol          string
 	responseFlags            string
 	connectionSecurityPolicy string
 }
@@ -665,6 +662,7 @@ func (m *MetricController) buildWorkloadMetric(reqMetric *requestMetric) workloa
 
 	trafficLabels.destinationPodAddress = dstIP
 	trafficLabels.requestProtocol = "tcp"
+	trafficLabels.responseFlags = buildResponseFlags(reqMetric)
 	trafficLabels.connectionSecurityPolicy = "mutual_tls"
 
 	switch reqMetric.conSrcDstInfo.direction {
@@ -758,6 +756,7 @@ func (m *MetricController) buildServiceMetric(reqMetric *requestMetric) (service
 	trafficLabels := NewServiceMetricLabel()
 	trafficLabels.withSource(srcWorkload).withDestination(dstWorkload).withDestinationService(dstService)
 	trafficLabels.requestProtocol = "tcp"
+	trafficLabels.responseFlags = buildResponseFlags(reqMetric)
 	trafficLabels.connectionSecurityPolicy = "mutual_tls"
 
 	accesslog := NewLogInfo()
@@ -808,6 +807,7 @@ func (m *MetricController) buildConnectionMetric(reqMetric *requestMetric) conne
 	trafficLabels.sourceAddress = srcIP + ":" + fmt.Sprintf("%d", reqMetric.conSrcDstInfo.srcPort)
 	trafficLabels.destinationPodAddress = dstIP
 	trafficLabels.requestProtocol = "tcp"
+	trafficLabels.responseFlags = buildResponseFlags(reqMetric)
 	trafficLabels.connectionSecurityPolicy = "mutual_tls"
 
 	switch reqMetric.conSrcDstInfo.direction {
@@ -832,6 +832,18 @@ func (m *MetricController) getWorkloadByAddress(address []byte) (*workloadapi.Wo
 		return nil, networkAddr.Address.String()
 	}
 	return workload, networkAddr.Address.String()
+}
+
+// buildResponseFlags maps connection outcome to an Istio-compatible response_flags value.
+// success mirrors the eBPF connect_success field, which the ringbuf event reports as a
+// binary flag, so any value other than connection_success means the TCP handshake did not
+// complete and is reported as "UF" (upstream connection failure). "-" indicates a
+// successfully established connection.
+func buildResponseFlags(reqMetric *requestMetric) string {
+	if reqMetric.success != connection_success {
+		return "UF"
+	}
+	return "-"
 }
 
 func buildPrincipal(workload *workloadapi.Workload) string {

--- a/pkg/controller/telemetry/metric_test.go
+++ b/pkg/controller/telemetry/metric_test.go
@@ -741,6 +741,7 @@ func TestBuildworkloadMetric(t *testing.T) {
 					receivedBytes: uint32(1024),
 					packetLost:    uint32(5),
 					totalRetrans:  uint32(120),
+					success:       connection_success,
 				},
 			},
 			want: workloadMetricLabels{
@@ -764,7 +765,7 @@ func TestBuildworkloadMetric(t *testing.T) {
 				destinationVersion:           "dstVersion",
 				destinationCluster:           "Kubernetes",
 				requestProtocol:              "tcp",
-				responseFlags:                "",
+				responseFlags:                "-",
 				connectionSecurityPolicy:     "mutual_tls",
 				reporter:                     "",
 			},
@@ -943,6 +944,7 @@ func TestBuildServiceMetric(t *testing.T) {
 					origDstPort:   uint16(8000),
 					sentBytes:     uint32(156),
 					receivedBytes: uint32(1024),
+					success:       connection_success,
 				},
 			},
 			want: serviceMetricLabels{
@@ -966,7 +968,7 @@ func TestBuildServiceMetric(t *testing.T) {
 				destinationVersion:           "dstVersion",
 				destinationCluster:           "Kubernetes",
 				requestProtocol:              "tcp",
-				responseFlags:                "",
+				responseFlags:                "-",
 				connectionSecurityPolicy:     "mutual_tls",
 				reporter:                     "source",
 			},
@@ -999,6 +1001,7 @@ func TestBuildServiceMetric(t *testing.T) {
 					origDstPort:   uint16(8000),
 					sentBytes:     uint32(156),
 					receivedBytes: uint32(1024),
+					success:       connection_success,
 				},
 			},
 			want: serviceMetricLabels{
@@ -1022,7 +1025,7 @@ func TestBuildServiceMetric(t *testing.T) {
 				destinationVersion:           "dstVersion",
 				destinationCluster:           "Kubernetes",
 				requestProtocol:              "tcp",
-				responseFlags:                "",
+				responseFlags:                "-",
 				connectionSecurityPolicy:     "mutual_tls",
 				reporter:                     "source",
 			},
@@ -1055,6 +1058,7 @@ func TestBuildServiceMetric(t *testing.T) {
 					origDstPort:   uint16(80),
 					sentBytes:     uint32(156),
 					receivedBytes: uint32(1024),
+					success:       connection_success,
 				},
 			},
 			want: serviceMetricLabels{
@@ -1078,7 +1082,7 @@ func TestBuildServiceMetric(t *testing.T) {
 				destinationVersion:           "",
 				destinationCluster:           "",
 				requestProtocol:              "tcp",
-				responseFlags:                "",
+				responseFlags:                "-",
 				connectionSecurityPolicy:     "mutual_tls",
 				reporter:                     "source",
 			},
@@ -1111,6 +1115,7 @@ func TestBuildServiceMetric(t *testing.T) {
 					origDstPort:   uint16(80),
 					sentBytes:     uint32(156),
 					receivedBytes: uint32(1024),
+					success:       connection_success,
 				},
 			},
 			want: serviceMetricLabels{
@@ -1134,7 +1139,7 @@ func TestBuildServiceMetric(t *testing.T) {
 				destinationVersion:           "waypointVersion",
 				destinationCluster:           "Kubernetes",
 				requestProtocol:              "tcp",
-				responseFlags:                "",
+				responseFlags:                "-",
 				connectionSecurityPolicy:     "mutual_tls",
 				reporter:                     "source",
 			},
@@ -1167,6 +1172,7 @@ func TestBuildServiceMetric(t *testing.T) {
 					origDstPort:   uint16(80),
 					sentBytes:     uint32(156),
 					receivedBytes: uint32(1024),
+					success:       connection_success,
 				},
 			},
 			want: serviceMetricLabels{
@@ -1190,7 +1196,7 @@ func TestBuildServiceMetric(t *testing.T) {
 				destinationVersion:           "waypointVersion",
 				destinationCluster:           "Kubernetes",
 				requestProtocol:              "tcp",
-				responseFlags:                "",
+				responseFlags:                "-",
 				connectionSecurityPolicy:     "mutual_tls",
 				reporter:                     "source",
 			},
@@ -1223,6 +1229,7 @@ func TestBuildServiceMetric(t *testing.T) {
 					origDstPort:   uint16(80),
 					sentBytes:     uint32(156),
 					receivedBytes: uint32(1024),
+					success:       connection_success,
 				},
 			},
 			want: serviceMetricLabels{
@@ -1246,7 +1253,7 @@ func TestBuildServiceMetric(t *testing.T) {
 				destinationVersion:           "solelyVersion",
 				destinationCluster:           "Kubernetes",
 				requestProtocol:              "tcp",
-				responseFlags:                "",
+				responseFlags:                "-",
 				connectionSecurityPolicy:     "mutual_tls",
 				reporter:                     "source",
 			},
@@ -1362,6 +1369,7 @@ func TestBuildConnectionMetric(t *testing.T) {
 					origDstPort:   uint16(8000),
 					sentBytes:     uint32(156),
 					receivedBytes: uint32(1024),
+					success:       connection_success,
 				},
 			},
 			want: connectionMetricLabels{
@@ -1394,7 +1402,7 @@ func TestBuildConnectionMetric(t *testing.T) {
 				destinationCluster:           "Kubernetes",
 
 				requestProtocol: "tcp",
-				responseFlags:   "",
+				responseFlags:   "-",
 
 				connectionSecurityPolicy: "mutual_tls",
 			},
@@ -1788,6 +1796,31 @@ func TestBuildV4Metric(t *testing.T) {
 			temp.packetLost = temp.packetLost - prevTcpConns[temp.conSrcDstInfo].packetLost
 			temp.totalRetrans = temp.totalRetrans - prevTcpConns[temp.conSrcDstInfo].totalRetrans
 			assert.Equal(t, temp, got)
+		})
+	}
+}
+
+func TestBuildResponseFlags(t *testing.T) {
+	tests := []struct {
+		name   string
+		metric requestMetric
+		want   string
+	}{
+		{
+			name:   "successful connection returns no flag",
+			metric: requestMetric{success: connection_success},
+			want:   "-",
+		},
+		{
+			name:   "failed connection returns upstream failure flag",
+			metric: requestMetric{success: 0},
+			want:   "UF",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildResponseFlags(&tt.metric)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
## What this PR does

Closes #1756

The `response_flags` label on the three TCP metric label structs (`workloadMetricLabels`, `serviceMetricLabels`, `connectionMetricLabels`) was declared but never populated. This meant every metric emitted by the telemetry controller had an empty `response_flags` value, which then got converted to `"-"` by `struct2map()` regardless of whether the connection succeeded or failed. The field was marked with a `// TODO: responseFlags is not used for now` comment that was never followed up on.

This PR removes those TODOs and properly derives the flag from the `success` field that eBPF already provides in the ring buffer event:

- `"-"` when the connection was established successfully
- `"UF"` (upstream connection failure) when the TCP handshake didn't succeed

`"UF"` is the Istio-standard `response_flags` value for upstream connection failures, matching what Envoy emits. This makes Kmesh's metrics consistent with what users expect when building dashboards or alerts based on `response_flags`.

## Changes

- Added `buildResponseFlags()` helper that maps `requestMetric.success` to an Istio-compatible flag string
- Called it in `buildWorkloadMetric()`, `buildServiceMetric()`, and `buildConnectionMetric()` right after `requestProtocol` is set
- Fixed alignment of `requestProtocol` field in the three label structs (it was narrower than `responseFlags`, causing visual misalignment)
- Updated existing tests to set `success: connection_success` in test data (all 8 cases) and updated expected `responseFlags` from `""` to `"-"`
- Added `TestBuildResponseFlags` with both the success and failure paths

## Test plan

- [ ] `go test ./pkg/controller/telemetry/... -v` passes locally
- [ ] Checked that `"UF"` matches the flag Envoy uses for upstream TCP failures

