### PR TITLE
docs: add workload enrollment guide for Kmesh

### DIFF
--- a/docs/cn/zh/add_workloads_zh.md
+++ b/docs/cn/zh/add_workloads_zh.md
@@ -1,0 +1,50 @@
+# 将工作负载添加到 Kmesh
+
+## 如何添加工作负载
+
+Kmesh 根据特定的 Kubernetes 标签管理 Pod 流量。您可以通过为命名空间或单个 Pod 贴标签来注册工作负载。
+
+### 命名空间注册
+
+若要为指定的命名空间启用 Kmesh，请应用 `istio.io/dataplane-mode` 标签并将其值设置为 `kmesh`：
+
+```shell
+kubectl label namespace <namespace> istio.io/dataplane-mode=kmesh
+```
+
+若要为指定的命名空间禁用 Kmesh，请移除该标签：
+
+```shell
+kubectl label namespace <namespace> istio.io/dataplane-mode-
+```
+
+### Pod 注册
+
+您还可以直接为 Pod 应用 `istio.io/dataplane-mode=kmesh` 标签来注册工作负载。
+
+```shell
+kubectl label pod <pod-name> -n <namespace> istio.io/dataplane-mode=kmesh --overwrite
+```
+
+若要显式禁用特定 Pod 的 Kmesh 注册，请将标签值设置为 `none`（`istio.io/dataplane-mode=none`）。这将使该 Pod 排除在 Kmesh 管理之外。
+
+## 排除条件
+
+如果 Pod 满足以下任一条件，Kmesh 将不会对其进行管理：
+
+* Pod 中注入了 Istio sidecar。
+* Pod 使用了主机网络（`hostNetwork`）。
+* Pod 是由 Istio 管理的 waypoint 代理。
+
+## 验证方法
+
+要验证您的工作负载是否已成功注册到 Kmesh，请使用以下方法：
+
+* **注解：** 成功注册后，Pod 将被添加 `kmesh.net/redirection: enabled` 注解。
+* **CNI 插件日志：** 检查记录在 Kubernetes 节点上 `/var/run/kmesh` 目录下的 CNI 插件日志。
+* **Kmesh Daemon 日志：** 检查 Kmesh daemon 的日志。首先获取 Pod 名称，然后查看其日志：
+
+```shell
+kubectl get po -n kmesh-system
+kubectl logs <kmesh-pod-name> -n kmesh-system
+```

--- a/docs/en/add_workloads.md
+++ b/docs/en/add_workloads.md
@@ -1,0 +1,50 @@
+# Adding Workloads to Kmesh
+
+## How to Add Workloads
+
+Kmesh manages pod traffic based on specific Kubernetes labels. Workloads can be enrolled by labeling either the namespace or the individual pod.
+
+### Namespace Enrollment
+
+To enable Kmesh for a specified namespace, apply the `istio.io/dataplane-mode` label with the value `kmesh`:
+
+```shell
+kubectl label namespace <namespace> istio.io/dataplane-mode=kmesh
+```
+
+To disable Kmesh for a specified namespace, remove the label:
+
+```shell
+kubectl label namespace <namespace> istio.io/dataplane-mode-
+```
+
+### Pod Enrollment
+
+You can also enroll a pod by directly applying the `istio.io/dataplane-mode=kmesh` label to it.
+
+```shell
+kubectl label pod <pod-name> -n <namespace> istio.io/dataplane-mode=kmesh --overwrite
+```
+
+To explicitly disable Kmesh enrollment for a specific pod, set the label value to `none` (`istio.io/dataplane-mode=none`). This excludes the pod from being managed by Kmesh.
+
+## Exclusions
+
+Kmesh will not manage a pod if any of the following conditions are met:
+
+* The pod has an Istio sidecar.
+* The pod uses `hostNetwork`.
+* The pod is an Istio managed waypoint proxy.
+
+## Verification Methods
+
+To verify that your workload has been successfully enrolled in Kmesh, use the following methods:
+
+* **Annotation:** Successful enrollment adds the `kmesh.net/redirection: enabled` annotation to the pod.
+* **CNI Plugin Logs:** Check the CNI plugin logs recorded in the `/var/run/kmesh` directory on the Kubernetes node.
+* **Kmesh Daemon Logs:** Check the logs of the Kmesh daemon. First, get the pod name, and then view its logs:
+
+```shell
+kubectl get po -n kmesh-system
+kubectl logs <kmesh-pod-name> -n kmesh-system
+```


### PR DESCRIPTION

What type of PR is this?

/kind documentation

What this PR does / why we need it

This PR adds a new documentation guide explaining how workloads can be managed by Kmesh based on the current repository implementation.

The guide includes:

Namespace-level workload enrollment
Pod-level workload enrollment
Pod exclusion conditions
Verification methods using annotations and logs

The content is derived from the existing Kmesh source code and documentation to provide users with a clear and practical reference for enabling workload management.

Which issue(s) this PR fixes

Fixes #721

Special notes for your reviewer
Documentation-only change.
No functional or code changes.
Technical details were verified against the current Kmesh implementation.
The document follows the existing Kmesh documentation style and conventions.
Does this PR introduce a user-facing change?
Add a documentation guide for workload enrollment and verification in Kmesh.
AI Usage Disclosure

AI was used as a drafting assistant during the preparation of this documentation. All technical details and repository behaviors were manually verified before submission.