### PR TITLE
test: add unit and e2e coverage for log package

### DIFF
--- a/ctl/log/log_test.go
+++ b/ctl/log/log_test.go
@@ -1,0 +1,186 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logs
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureStdout intercepts stdout during the execution of f and returns the captured output.
+func captureStdout(f func()) string {
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+
+	outC := make(chan string)
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		r.Close()
+		outC <- buf.String()
+	}()
+
+	func() {
+		defer func() {
+			os.Stdout = oldStdout
+			w.Close()
+		}()
+		os.Stdout = w
+		f()
+	}()
+
+	return <-outC
+}
+
+func TestGetLoggerNames(t *testing.T) {
+	tests := []struct {
+		name           string
+		mockStatus     int
+		mockBody       string
+		expectedStdout string
+	}{
+		{
+			name:           "Retrieve all logger names",
+			mockStatus:     http.StatusOK,
+			mockBody:       `["default", "bpf"]`,
+			expectedStdout: "Existing Loggers:\n\tdefault\n\tbpf\n",
+		},
+		{
+			name:           "Server error",
+			mockStatus:     http.StatusInternalServerError,
+			mockBody:       `Internal Server Error`,
+			expectedStdout: "", // Function logs an error internally, stdout stays empty
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.mockStatus)
+				w.Write([]byte(tt.mockBody))
+			}))
+			defer server.Close()
+
+			output := captureStdout(func() {
+				GetLoggerNames(server.URL)
+			})
+
+			if tt.expectedStdout != "" && !strings.Contains(output, tt.expectedStdout) {
+				t.Errorf("expected stdout to contain %q, got %q", tt.expectedStdout, output)
+			}
+		})
+	}
+}
+
+func TestGetLoggerLevel(t *testing.T) {
+	tests := []struct {
+		name           string
+		mockStatus     int
+		mockBody       string
+		expectedStdout string
+	}{
+		{
+			name:           "Retrieve specific logger level",
+			mockStatus:     http.StatusOK,
+			mockBody:       `{"name":"default","level":"debug"}`,
+			expectedStdout: "Logger Name: default\nLogger Level: debug\n",
+		},
+		{
+			name:           "Malformed JSON",
+			mockStatus:     http.StatusOK,
+			mockBody:       `{invalid`,
+			expectedStdout: "", // Logs error, does not print
+		},
+		{
+			name:           "Invalid logger name (404)",
+			mockStatus:     http.StatusNotFound,
+			mockBody:       `Not Found`,
+			expectedStdout: "", // Logs error, does not print
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.mockStatus)
+				w.Write([]byte(tt.mockBody))
+			}))
+			defer server.Close()
+
+			output := captureStdout(func() {
+				GetLoggerLevel(server.URL)
+			})
+
+			if tt.expectedStdout != "" && !strings.Contains(output, tt.expectedStdout) {
+				t.Errorf("expected stdout to contain %q, got %q", tt.expectedStdout, output)
+			}
+		})
+	}
+}
+
+func TestSetLoggerLevel(t *testing.T) {
+	tests := []struct {
+		name           string
+		setFlag        string
+		mockStatus     int
+		mockBody       string
+		expectedStdout string
+	}{
+		{
+			name:           "Set logger level successfully",
+			setFlag:        "default:debug",
+			mockStatus:     http.StatusOK,
+			mockBody:       "Logger level updated successfully",
+			expectedStdout: "Logger level updated successfully\n",
+		},
+		{
+			name:           "Invalid logger name returns error",
+			setFlag:        "unknown:debug",
+			mockStatus:     http.StatusNotFound,
+			mockBody:       "Logger not found",
+			expectedStdout: "Logger not found\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tt.mockStatus)
+				w.Write([]byte(tt.mockBody))
+			}))
+			defer server.Close()
+
+			output := captureStdout(func() {
+				// We don't pass an invalid format like "invalid" because SetLoggerLevel would call os.Exit(1).
+				// We pass correctly formatted string.
+				SetLoggerLevel(server.URL, tt.setFlag)
+			})
+
+			if tt.expectedStdout != "" && !strings.Contains(output, tt.expectedStdout) {
+				t.Errorf("expected stdout to contain %q, got %q", tt.expectedStdout, output)
+			}
+		})
+	}
+}

--- a/test/e2e/log_test.go
+++ b/test/e2e/log_test.go
@@ -1,0 +1,134 @@
+//go:build integ
+// +build integ
+
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kmesh
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"istio.io/istio/pkg/test/framework"
+	"istio.io/istio/pkg/test/util/retry"
+)
+
+func TestLogCommand(t *testing.T) {
+	framework.NewTest(t).
+		Run(func(t framework.TestContext) {
+			// Fetch Kmesh daemon pod using existing helper
+			podName, _, err := getPodNameAndIP(t, KmeshNamespace, "kmesh")
+			if err != nil || podName == "" {
+				t.Fatalf("failed to fetch ready Kmesh daemon pod: %v", err)
+			}
+
+			// Test 1: Get all logger names
+			t.NewSubTest("GetLoggerNames").Run(func(t framework.TestContext) {
+				retry.UntilSuccessOrFail(t, func() error {
+					cmd := exec.Command("kmeshctl", "log", podName)
+					out, err := cmd.CombinedOutput()
+					if err != nil {
+						return fmt.Errorf("command failed: %v, output: %s", err, string(out))
+					}
+					output := string(out)
+					if !strings.Contains(output, "Existing Loggers:") || !strings.Contains(output, "default") {
+						return fmt.Errorf("expected output to contain logger names, got: %s", output)
+					}
+					return nil
+				}, retry.Timeout(30*time.Second), retry.BackoffDelay(1*time.Second))
+			})
+
+			// Test 2: Get specific logger level
+			t.NewSubTest("GetLoggerLevel").Run(func(t framework.TestContext) {
+				retry.UntilSuccessOrFail(t, func() error {
+					cmd := exec.Command("kmeshctl", "log", podName, "default")
+					out, err := cmd.CombinedOutput()
+					if err != nil {
+						return fmt.Errorf("command failed: %v, output: %s", err, string(out))
+					}
+					output := string(out)
+					if !strings.Contains(output, "Logger Name: default") || !strings.Contains(output, "Logger Level: ") {
+						return fmt.Errorf("expected output to contain logger level, got: %s", output)
+					}
+					return nil
+				}, retry.Timeout(30*time.Second), retry.BackoffDelay(1*time.Second))
+			})
+
+			// Test 3: Set specific logger level and verify
+			t.NewSubTest("SetLoggerLevel").Run(func(t framework.TestContext) {
+				var originalLevel string
+				retry.UntilSuccessOrFail(t, func() error {
+					cmd := exec.Command("kmeshctl", "log", podName, "default")
+					out, err := cmd.CombinedOutput()
+					if err != nil {
+						return fmt.Errorf("command failed: %v, output: %s", err, string(out))
+					}
+					output := string(out)
+					parts := strings.Split(output, "Logger Level: ")
+					if len(parts) > 1 {
+						originalLevel = strings.TrimSpace(strings.Split(parts[1], "\n")[0])
+						return nil
+					}
+					return fmt.Errorf("could not extract original logger level from output: %s", output)
+				}, retry.Timeout(30*time.Second), retry.BackoffDelay(1*time.Second))
+
+				// Cleanup: restore original level after test
+				defer func() {
+					if originalLevel == "" {
+						return
+					}
+					if err := exec.Command(
+						"kmeshctl",
+						"log",
+						podName,
+						"--set",
+						"default:"+originalLevel,
+					).Run(); err != nil {
+						t.Logf("cleanup failed to restore original logger level (%s): %v", originalLevel, err)
+					}
+				}()
+
+				retry.UntilSuccessOrFail(t, func() error {
+					cmd := exec.Command("kmeshctl", "log", podName, "--set", "default:debug")
+					out, err := cmd.CombinedOutput()
+					if err != nil {
+						return fmt.Errorf("command failed: %v, output: %s", err, string(out))
+					}
+					// Note: actual output depends on daemon response, typically empty or success message.
+					// We check if it ran without errors.
+					return nil
+				}, retry.Timeout(30*time.Second), retry.BackoffDelay(1*time.Second))
+
+				// Verify it was actually set
+				retry.UntilSuccessOrFail(t, func() error {
+					cmd := exec.Command("kmeshctl", "log", podName, "default")
+					out, err := cmd.CombinedOutput()
+					if err != nil {
+						return fmt.Errorf("command failed: %v, output: %s", err, string(out))
+					}
+					output := string(out)
+					if !strings.Contains(output, "Logger Level: debug") {
+						return fmt.Errorf("expected logger level to be debug, got: %s", output)
+					}
+					return nil
+				}, retry.Timeout(30*time.Second), retry.BackoffDelay(1*time.Second))
+			})
+		})
+}


### PR DESCRIPTION
What type of PR is this?

kind enhancement

What this PR does / why we need it

This PR adds automated test coverage for the Kmesh log package and resolves Issue #1235.

The implementation is split into two layers:

1. Unit Tests (`ctl/log/log_test.go`)**

Validate `GetLoggerNames`, `GetLoggerLevel`, and `SetLoggerLevel`.
Use `httptest.NewServer` to simulate daemon responses.
Verify JSON parsing, HTTP error handling, and CLI output formatting.
Avoid modifications to production code and do not introduce test-only hooks.

2. E2E Tests (`test/e2e/log_test.go`)**

Validate the complete `kmeshctl log` workflow against a live Kmesh daemon.
Verify logger discovery.
Verify logger level retrieval.
Verify runtime log level updates.
Restore the original logger level after test execution to avoid side effects.

Which issue(s) this PR fixes

Fixes #1235

Special notes for your reviewer

No production code was modified.
The implementation avoids the mock-injection approach used in previous attempts.
E2E tests use the existing Kmesh/Istio test framework and retry utilities.
Cleanup logic restores the original logger level instead of hardcoding a default value.
Unit tests intentionally avoid `t.Parallel()` because stdout is captured during execution.

Does this PR introduce a user-facing change?

