### PR TITLE
bpf/workload: prevent nil pointer panic when IPsec is disabled

### DIFF
--- a/pkg/bpf/workload/loader.go
+++ b/pkg/bpf/workload/loader.go
@@ -144,8 +144,10 @@ func (w *BpfWorkload) Load() error {
 		return err
 	}
 
-	if err := w.Tc.LoadTC(); err != nil {
-		return err
+	if w.Tc != nil {
+		if err := w.Tc.LoadTC(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -191,8 +193,10 @@ func (w *BpfWorkload) Detach() error {
 		return err
 	}
 
-	if err := w.Tc.Close(); err != nil {
-		return err
+	if w.Tc != nil {
+		if err := w.Tc.Close(); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it

The `w.Tc` object is conditionally initialized when IPsec is enabled.

`Load()` and `Detach()` previously accessed `w.Tc` unconditionally, which could result in a nil pointer dereference when IPsec is disabled.

This change adds nil checks before invoking:

- `w.Tc.LoadTC()`
- `w.Tc.Close()`

to prevent runtime panics.

Which issue(s) this PR fixes

Fixes #1706

Special notes for your reviewer

This PR is intentionally scoped to the nil pointer fix only.

No test infrastructure, workflow, or E2E changes are included.

Does this PR introduce a user-facing change?

```release-note
NONE