### PR TITLE
fix: prevent nil pointer panic when IPsec is disabled and improve E2E log readiness polling

### DIFF
--- a/pkg/bpf/workload/loader.go
+++ b/pkg/bpf/workload/loader.go
@@ -144,8 +144,10 @@ func (w *BpfWorkload) Load() error {
 		return err
 	}
 
-	if err := w.Tc.LoadTC(); err != nil {
-		return err
+	if w.Tc != nil {
+		if err := w.Tc.LoadTC(); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -191,8 +193,10 @@ func (w *BpfWorkload) Detach() error {
 		return err
 	}
 
-	if err := w.Tc.Close(); err != nil {
-		return err
+	if w.Tc != nil {
+		if err := w.Tc.Close(); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/test/e2e/run_test.sh
+++ b/test/e2e/run_test.sh
@@ -186,28 +186,28 @@ function setup_kmesh() {
 	for POD in $PODS; do
 		echo "turn on the debug mode of the log for pod $POD"
 		# Set BPF debug log
-		for i in {1..5}; do
-			echo "Attempt $i of 5: kmeshctl log $POD --set bpf:debug"
+		for i in {1..30}; do
+			echo "Attempt $i of 30: kmeshctl log $POD --set bpf:debug"
 			output=$(kmeshctl log $POD --set bpf:debug 2>&1)
 			if echo "$output" | grep -q "set BPF Log Level: 3"; then
 				echo "BPF debug log set successfully"
 				break
 			fi
 			echo "Failed to set BPF debug log. Output: $output"
-			[ $i -eq 5 ] && echo "Failed to set BPF debug log after 5 attempts" && exit 1
+			[ $i -eq 30 ] && echo "Failed to set BPF debug log after 30 attempts" && exit 1
 			sleep 2
 		done
 
 		# Set default debug log
-		for i in {1..5}; do
-			echo "Attempt $i of 5: kmeshctl log $POD --set default:debug"
+		for i in {1..30}; do
+			echo "Attempt $i of 30: kmeshctl log $POD --set default:debug"
 			output=$(kmeshctl log $POD --set default:debug 2>&1)
 			if echo "$output" | grep -q "OK"; then
 				echo "Default debug log set successfully"
 				break
 			fi
 			echo "Failed to set default debug log. Output: $output"
-			[ $i -eq 5 ] && echo "Failed to set default debug log after 5 attempts" && exit 1
+			[ $i -eq 30 ] && echo "Failed to set default debug log after 30 attempts" && exit 1
 			sleep 2
 		done
 	done
@@ -220,28 +220,28 @@ function setup_kmesh_log() {
 	for POD in $PODS; do
 		echo "turn on the debug mode of the log for pod $POD"
 		# Set BPF debug log
-		for i in {1..5}; do
-			echo "Attempt $i of 5: kmeshctl log $POD --set bpf:debug"
+		for i in {1..30}; do
+			echo "Attempt $i of 30: kmeshctl log $POD --set bpf:debug"
 			output=$(kmeshctl log $POD --set bpf:debug 2>&1)
 			if echo "$output" | grep -q "set BPF Log Level: 3"; then
 				echo "BPF debug log set successfully"
 				break
 			fi
 			echo "Failed to set BPF debug log. Output: $output"
-			[ $i -eq 5 ] && echo "Failed to set BPF debug log after 5 attempts" && exit 1
+			[ $i -eq 30 ] && echo "Failed to set BPF debug log after 30 attempts" && exit 1
 			sleep 2
 		done
 
 		# Set default debug log
-		for i in {1..5}; do
-			echo "Attempt $i of 5: kmeshctl log $POD --set default:debug"
+		for i in {1..30}; do
+			echo "Attempt $i of 30: kmeshctl log $POD --set default:debug"
 			output=$(kmeshctl log $POD --set default:debug 2>&1)
 			if echo "$output" | grep -q "OK"; then
 				echo "Default debug log set successfully"
 				break
 			fi
 			echo "Failed to set default debug log. Output: $output"
-			[ $i -eq 5 ] && echo "Failed to set default debug log after 5 attempts" && exit 1
+			[ $i -eq 30 ] && echo "Failed to set default debug log after 30 attempts" && exit 1
 			sleep 2
 		done
 	done


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:

This PR contains two independent fixes:

Fix nil pointer dereference in workload loader
NewBpfWorkload() initializes w.Tc only when IPsec is enabled.
Load() and Detach() previously dereferenced w.Tc unconditionally.
Added nil guards before invoking:
w.Tc.LoadTC()
w.Tc.Close()
Prevents startup and shutdown panics when IPsec is disabled.
Improve E2E log configuration stability
Recent E2E failures showed repeated connection refused and EOF errors while executing:
kmeshctl log <pod> --set bpf:debug
Increased retry attempts from 5 to 30 in test/e2e/run_test.sh.
No production behavior is changed.
This change is intended to validate whether CI failures are caused by startup latency before the admin endpoint becomes available.

Which issue(s) this PR fixes:

Fixes #1706

Special notes for your reviewer:

The nil-pointer fix is the primary functional change.
The E2E retry adjustment is limited to test infrastructure.
No BPF programs, controller logic, or workflows were modified.
No assumptions are made about CI success; the retry increase is intended to validate a startup-latency hypothesis.

Does this PR introduce a user-facing change?:

NONE