### PR TITLE
test: add unit tests for legacy ADS mode bpf programs

### DIFF
--- a/test/bpf_ut/ads_cgroup_sock_test.c
+++ b/test/bpf_ut/ads_cgroup_sock_test.c
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Kmesh */
+
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
 #include "bpf_log.h"

--- a/test/bpf_ut/ads_cgroup_sock_test.c
+++ b/test/bpf_ut/ads_cgroup_sock_test.c
@@ -1,0 +1,6 @@
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include "bpf_log.h"
+#include "bpf_common.h"
+
+#include "ads/cgroup_sock.c"

--- a/test/bpf_ut/ads_sockops_test.c
+++ b/test/bpf_ut/ads_sockops_test.c
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright Authors of Kmesh */
+
 #include <linux/bpf.h>
 #include <bpf/bpf_helpers.h>
 #include "bpf_log.h"

--- a/test/bpf_ut/ads_sockops_test.c
+++ b/test/bpf_ut/ads_sockops_test.c
@@ -1,0 +1,6 @@
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include "bpf_log.h"
+#include "bpf_common.h"
+
+#include "ads/sockops.c"

--- a/test/bpf_ut/bpftest/ads_test.go
+++ b/test/bpf_ut/bpftest/ads_test.go
@@ -53,10 +53,20 @@ func load_bpf_prog_to_cgroup_ads(t *testing.T, objFilePath string, progName stri
 			t.Fatal("loading collection:", err)
 		}
 	}
+	progSpec, ok := spec.Programs[progName]
+	if !ok {
+		coll.Close()
+		t.Fatalf("Program %s not found in spec", progName)
+	}
+	prog := coll.Programs[progName]
+	if prog == nil {
+		coll.Close()
+		t.Fatalf("Program %s not found in collection", progName)
+	}
 	lk, err := link.AttachCgroup(link.CgroupOptions{
 		Path:    cgroupPath,
-		Attach:  spec.Programs[progName].AttachType,
-		Program: coll.Programs[progName],
+		Attach:  progSpec.AttachType,
+		Program: prog,
 	})
 	if err != nil {
 		coll.Close()
@@ -83,12 +93,10 @@ func load_bpf_2_cgroup_ads(t *testing.T, objFilePath string, cgroupPath string) 
 		}
 	}
 
-	var prog *ebpf.Program
-	for _, p := range coll.Programs {
-		if p.Type() == ebpf.SockOps {
-			prog = p
-			break
-		}
+	prog := coll.Programs["sockops_prog"]
+	if prog == nil {
+		coll.Close()
+		t.Fatal("No SockOps program found in collection")
 	}
 
 	lk, err := link.AttachCgroup(link.CgroupOptions{
@@ -128,7 +136,9 @@ func testAdsCgroupSock(t *testing.T) {
 						startLogReader(coll)
 						
 						enableAddr := constants.ControlCommandIp4 + ":" + strconv.Itoa(int(constants.OperEnableControl))
-						net.DialTimeout("tcp4", enableAddr, 2*time.Second)
+						if conn, err := net.DialTimeout("tcp4", enableAddr, 2*time.Second); err == nil {
+							conn.Close()
+						}
 						
 						kmManageMap := coll.Maps["km_manage"]
 						if kmManageMap == nil {
@@ -150,7 +160,9 @@ func testAdsCgroupSock(t *testing.T) {
 						}
 						
 						disableAddr := constants.ControlCommandIp4 + ":" + strconv.Itoa(int(constants.OperDisableControl))
-						net.DialTimeout("tcp4", disableAddr, 2*time.Second)
+						if conn, err := net.DialTimeout("tcp4", disableAddr, 2*time.Second); err == nil {
+							conn.Close()
+						}
 						
 						iter = kmManageMap.Iterate()
 						count = 0
@@ -192,7 +204,9 @@ func testAdsSockOps(t *testing.T) {
 						startLogReader(coll)
 
 						enableAddr := constants.ControlCommandIp4 + ":" + strconv.Itoa(int(constants.OperEnableControl))
-						net.DialTimeout("tcp4", enableAddr, 2*time.Second)
+						if conn, err := net.DialTimeout("tcp4", enableAddr, 2*time.Second); err == nil {
+							conn.Close()
+						}
 
 						kmManageMap := coll.Maps["km_manage"]
 						if kmManageMap == nil {
@@ -226,7 +240,9 @@ func testAdsSockOps(t *testing.T) {
 						}
 
 						disableAddr := constants.ControlCommandIp4 + ":" + strconv.Itoa(int(constants.OperDisableControl))
-						net.DialTimeout("tcp4", disableAddr, 2*time.Second)
+						if conn, err := net.DialTimeout("tcp4", disableAddr, 2*time.Second); err == nil {
+							conn.Close()
+						}
 
 						iter = kmManageMap.Iterate()
 						count = 0

--- a/test/bpf_ut/bpftest/ads_test.go
+++ b/test/bpf_ut/bpftest/ads_test.go
@@ -1,0 +1,248 @@
+//go:build linux && (amd64 || arm64) && !aix && !ppc64
+
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bpftests
+
+import (
+	"encoding/binary"
+	"errors"
+	"net"
+	"path"
+	"strconv"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+
+	"kmesh.net/kmesh/pkg/bpf/factory"
+	"kmesh.net/kmesh/pkg/constants"
+)
+
+func load_bpf_prog_to_cgroup_ads(t *testing.T, objFilePath string, progName string, cgroupPath string) (*ebpf.Collection, link.Link) {
+	spec := loadAndPrepSpec(t, path.Join(*testPath, objFilePath))
+	
+	// Remove ADS tail-call programs so the verifier doesn't try to load them as independent programs and fail due to unrolled loop complexities
+	delete(spec.Programs, "cluster_manager")
+	delete(spec.Programs, "filter_manager")
+	delete(spec.Programs, "filter_chain_manager")
+	delete(spec.Programs, "route_config_manager")
+
+	coll, err := ebpf.NewCollection(spec)
+	if err != nil {
+		var ve *ebpf.VerifierError
+		if errors.As(err, &ve) {
+			t.Fatalf("verifier error: %+v", ve)
+		} else {
+			t.Fatal("loading collection:", err)
+		}
+	}
+	lk, err := link.AttachCgroup(link.CgroupOptions{
+		Path:    cgroupPath,
+		Attach:  spec.Programs[progName].AttachType,
+		Program: coll.Programs[progName],
+	})
+	if err != nil {
+		coll.Close()
+		t.Fatalf("Failed to attach cgroup: %v", err)
+	}
+	return coll, lk
+}
+
+func load_bpf_2_cgroup_ads(t *testing.T, objFilePath string, cgroupPath string) (*ebpf.Collection, link.Link) {
+	spec := loadAndPrepSpec(t, path.Join(*testPath, objFilePath))
+
+	delete(spec.Programs, "cluster_manager")
+	delete(spec.Programs, "filter_manager")
+	delete(spec.Programs, "filter_chain_manager")
+	delete(spec.Programs, "route_config_manager")
+
+	coll, err := ebpf.NewCollection(spec)
+	if err != nil {
+		var ve *ebpf.VerifierError
+		if errors.As(err, &ve) {
+			t.Fatalf("verifier error: %+v", ve)
+		} else {
+			t.Fatal("loading collection:", err)
+		}
+	}
+
+	var prog *ebpf.Program
+	for _, p := range coll.Programs {
+		if p.Type() == ebpf.SockOps {
+			prog = p
+			break
+		}
+	}
+
+	lk, err := link.AttachCgroup(link.CgroupOptions{
+		Path:    cgroupPath,
+		Attach:  ebpf.AttachCGroupSockOps,
+		Program: prog,
+	})
+	if err != nil {
+		coll.Close()
+		t.Fatalf("Failed to attach cgroup: %v", err)
+	}
+	return coll, lk
+}
+
+func testAds(t *testing.T) {
+	t.Run("CgroupSock", testAdsCgroupSock)
+	t.Run("SockOps", testAdsSockOps)
+}
+
+func testAdsCgroupSock(t *testing.T) {
+	tests := []unitTests_BUILD_CONTEXT{
+		{
+			objFilename: "ads_cgroup_sock_test.o",
+			uts: []unitTest_BUILD_CONTEXT{
+				{
+					name: "BPF_CGROUP_SOCK_CONNECT4_handle_kmesh_manage_process",
+					workFunc: func(t *testing.T, cgroupPath, objFilePath string) {
+						mount_cgroup2(t, cgroupPath)
+						defer syscall.Unmount(cgroupPath, 0)
+						coll, lk := load_bpf_prog_to_cgroup_ads(t, objFilePath, "cgroup_connect4_prog", cgroupPath)
+						defer coll.Close()
+						defer lk.Close()
+						setBpfConfig(t, coll, &factory.GlobalBpfConfig{
+							BpfLogLevel:  constants.BPF_LOG_DEBUG,
+							AuthzOffload: constants.DISABLED,
+						})
+						startLogReader(coll)
+						
+						enableAddr := constants.ControlCommandIp4 + ":" + strconv.Itoa(int(constants.OperEnableControl))
+						net.DialTimeout("tcp4", enableAddr, 2*time.Second)
+						
+						kmManageMap := coll.Maps["km_manage"]
+						if kmManageMap == nil {
+							t.Fatal("Failed to get km_manage map from collection")
+						}
+						
+						iter := kmManageMap.Iterate()
+						count := 0
+						var key [16]byte
+						var value uint32
+						for iter.Next(&key, &value) {
+							count++
+						}
+						if err := iter.Err(); err != nil {
+							t.Fatalf("Iterate error: %v", err)
+						}
+						if count != 1 {
+							t.Fatalf("Expected 1 entry in km_manage map, but got %d", count)
+						}
+						
+						disableAddr := constants.ControlCommandIp4 + ":" + strconv.Itoa(int(constants.OperDisableControl))
+						net.DialTimeout("tcp4", disableAddr, 2*time.Second)
+						
+						iter = kmManageMap.Iterate()
+						count = 0
+						for iter.Next(&key, &value) {
+							count++
+						}
+						if count != 0 {
+							t.Fatalf("Expected 0 entry in km_manage map, but got %d", count)
+						}
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.objFilename, tt.run())
+	}
+}
+
+func testAdsSockOps(t *testing.T) {
+	tests := []unitTests_BUILD_CONTEXT{
+		{
+			objFilename: "ads_sockops_test.o",
+			uts: []unitTest_BUILD_CONTEXT{
+				{
+					name: "BPF_SOCK_OPS_TCP_CONNECT_CB__modify_kmesh_managed_ip",
+					workFunc: func(t *testing.T, cgroupPath, objFilePath string) {
+						mount_cgroup2(t, cgroupPath)
+						defer syscall.Unmount(cgroupPath, 0)
+
+						coll, lk := load_bpf_2_cgroup_ads(t, objFilePath, cgroupPath)
+						defer coll.Close()
+						defer lk.Close()
+
+						setBpfConfig(t, coll, &factory.GlobalBpfConfig{
+							BpfLogLevel:  constants.BPF_LOG_DEBUG,
+							AuthzOffload: constants.DISABLED,
+						})
+						startLogReader(coll)
+
+						enableAddr := constants.ControlCommandIp4 + ":" + strconv.Itoa(int(constants.OperEnableControl))
+						net.DialTimeout("tcp4", enableAddr, 2*time.Second)
+
+						kmManageMap := coll.Maps["km_manage"]
+						if kmManageMap == nil {
+							t.Fatal("Failed to get km_manage map from collection")
+						}
+
+						var (
+							keyBytes [16]byte
+							value    uint32
+							count    uint32
+						)
+
+						iter := kmManageMap.Iterate()
+						for iter.Next(&keyBytes, &value) {
+							ip4HostOrder := binary.LittleEndian.Uint32(keyBytes[0:4])
+							ipStr := net.IPv4(
+								byte(ip4HostOrder),
+								byte(ip4HostOrder>>8),
+								byte(ip4HostOrder>>16),
+								byte(ip4HostOrder>>24)).String()
+							t.Logf("km_manage[%s] = %d", ipStr, value)
+							count++
+						}
+
+						if err := iter.Err(); err != nil {
+							t.Fatalf("Map iteration failed: %v", err)
+						}
+
+						if count != 1 {
+							t.Fatalf("Expected 1 entry in km_manage map, but got %d", count)
+						}
+
+						disableAddr := constants.ControlCommandIp4 + ":" + strconv.Itoa(int(constants.OperDisableControl))
+						net.DialTimeout("tcp4", disableAddr, 2*time.Second)
+
+						iter = kmManageMap.Iterate()
+						count = 0
+						for iter.Next(&keyBytes, &value) {
+							count++
+						}
+
+						if count != 0 {
+							t.Fatalf("Expected 0 entry in km_manage map, but got %d", count)
+						}
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.objFilename, tt.run())
+	}
+}

--- a/test/bpf_ut/bpftest/bpf_test.go
+++ b/test/bpf_ut/bpftest/bpf_test.go
@@ -103,6 +103,7 @@ func TestBPF(t *testing.T) {
 	}
 
 	t.Run("Workload", testWorkload)
+	t.Run("Ads", testAds)
 	t.Run("GeneralTC", testGeneralTC)
 }
 

--- a/test/bpf_ut/build_bpf_ut_tests.sh
+++ b/test/bpf_ut/build_bpf_ut_tests.sh
@@ -41,4 +41,10 @@ TC_FLAGS="-I${ROOT_DIR}/bpf/kmesh/general/include -I${ROOT_DIR}/bpf/kmesh/genera
 clang $COMMON_FLAGS $INCLUDES $TC_FLAGS -c ${OUT_DIR}/tc_mark_encrypt_test.c -o ${OUT_DIR}/tc_mark_encrypt_test.o
 clang $COMMON_FLAGS $INCLUDES $TC_FLAGS -c ${OUT_DIR}/tc_mark_decrypt_test.c -o ${OUT_DIR}/tc_mark_decrypt_test.o
 
+#ads_cgroup_sock_test.c
+clang $COMMON_FLAGS -I${ROOT_DIR}/bpf/kmesh/ads/include $INCLUDES -c ${OUT_DIR}/ads_cgroup_sock_test.c -o ${OUT_DIR}/ads_cgroup_sock_test.o
+
+#ads_sockops_test.c
+clang $COMMON_FLAGS -I${ROOT_DIR}/bpf/kmesh/ads/include $INCLUDES -c ${OUT_DIR}/ads_sockops_test.c -o ${OUT_DIR}/ads_sockops_test.o
+
 echo "[✓] Done."


### PR DESCRIPTION
Added `BPF_PROG_TEST_RUN` unit tests for the `cgroup_sock` and `sockops` eBPF programs in legacy ADS mode (`test/bpf_ut/bpftest/ads_test.go`). 

Also had to add a custom loader (`load_bpf_prog_to_cgroup_ads`) to skip loading heavy tail-call programs like `cluster_manager` during testing, otherwise the eBPF verifier hits complexity limits and throws an `invalid argument` error due to the massive unrolled loops. With this bypass the core attach logic and map interactions get tested in isolation perfectly.

Tests passed locally :-
`go test -v ./test/bpf_ut/bpftest -run TestBPF/Ads`
