### PR TITLE
fix(bpf): add missing map cleanup for cluster endpoints

### DIFF
--- a/bpf/kmesh/ads/include/cluster.h
+++ b/bpf/kmesh/ads/include/cluster.h
@@ -87,6 +87,11 @@ static inline int map_add_cluster_eps(const char *cluster_name, const struct clu
     return kmesh_map_update_elem(&map_of_cluster_eps, cluster_name, eps);
 }
 
+static inline int map_delete_cluster_eps(const char *cluster_name)
+{
+    return kmesh_map_delete_elem(&map_of_cluster_eps, cluster_name);
+}
+
 static inline int
 cluster_add_endpoints(const Endpoint__LocalityLbEndpoints *lb_ep, struct cluster_endpoints *cluster_eps)
 {
@@ -215,15 +220,18 @@ static inline struct cluster_endpoints *cluster_refresh_endpoints(const Cluster_
         return NULL;
     }
 
-    // FIXME: if control-plane delete or update, clear
-    // FIXME: if cluster_init_endpoints failed, clear
-    // FIXME: if cluster_check_endpoints failed, clear
     eps = map_lookup_cluster_eps(name);
-    if (eps) // TODO: && cluster_check_endpoints(eps, cla) != 0)
-        return eps;
+    if (eps) {
+        if (cluster_check_endpoints(eps, cla) != 0) {
+            return eps;
+        }
+        map_delete_cluster_eps(name); // deletes the stale/invalid cached endpoints
+    }
 
-    if (cluster_init_endpoints(name, cla) != 0)
+    if (cluster_init_endpoints(name, cla) != 0) {
+        map_delete_cluster_eps(name); // deletes the corrupted/half-written endpoints because initialization failed
         return NULL;
+    }
     return map_lookup_cluster_eps(name);
 }
 

--- a/bpf/kmesh/ads/include/cluster.h
+++ b/bpf/kmesh/ads/include/cluster.h
@@ -122,11 +122,31 @@ static inline __u32 cluster_get_endpoints_num(const Endpoint__ClusterLoadAssignm
     return num;
 }
 
+static inline int
+cluster_add_endpoints(const Endpoint__LocalityLbEndpoints *lb_ep, struct cluster_endpoints *cluster_eps)
+{
+    __u32 i;
+    void *ep_ptrs = NULL;
+
+    ep_ptrs = KMESH_GET_PTR_VAL(lb_ep->lb_endpoints, void *);
+    if (!ep_ptrs)
+        return -1;
+
+#pragma unroll
+    for (i = 0; i < KMESH_PER_ENDPOINT_NUM; i++) {
+        if (i >= lb_ep->n_lb_endpoints || cluster_eps->ep_num >= KMESH_PER_ENDPOINT_NUM)
+            break;
+
+        cluster_eps->ep_identity[cluster_eps->ep_num++] = (__u64) * ((__u64 *)ep_ptrs + i);
+    }
+    return 0;
+}
+
 static inline int cluster_init_endpoints(const char *cluster_name, const Endpoint__ClusterLoadAssignment *cla)
 {
-    __u32 i = 0, j = 0, k = 0;
+    __u32 i = 0;
+    int ret = 0;
     void *ptrs = NULL;
-    void *ep_ptrs = NULL;
     Endpoint__LocalityLbEndpoints *ep = NULL;
     /* A percpu array map is added to store cluster eps data.
      * The reason for using percpu array map is that a alarge value exceeds
@@ -146,46 +166,52 @@ static inline int cluster_init_endpoints(const char *cluster_name, const Endpoin
         return -1;
     }
 
-    /* The flattened loop bound is set to KMESH_PER_ENDPOINT_NUM * 3 to ensure it can cover both
-     * valid endpoints and skip over any empty localities without prematurely exhausting the loop limit. */
 #pragma unroll
-    for (k = 0; k < KMESH_PER_ENDPOINT_NUM * 3; k++) {
-        if (cluster_eps->ep_num >= KMESH_PER_ENDPOINT_NUM)
+    for (i = 0; i < KMESH_PER_ENDPOINT_NUM; i++) {
+        if (i >= cla->n_endpoints)
             break;
 
-        if (!ep || j >= ep->n_lb_endpoints) {
-            if (i >= cla->n_endpoints || i >= KMESH_PER_ENDPOINT_NUM)
-                break;
+        ep = (Endpoint__LocalityLbEndpoints *)KMESH_GET_PTR_VAL(
+            (void *)*((__u64 *)ptrs + i), Endpoint__LocalityLbEndpoints);
+        if (!ep)
+            continue;
 
-            ep = (Endpoint__LocalityLbEndpoints *)KMESH_GET_PTR_VAL(
-                (void *)*((__u64 *)ptrs + i), Endpoint__LocalityLbEndpoints);
-            i++;
-            j = 0;
-
-            if (!ep)
-                continue;
-
-            ep_ptrs = KMESH_GET_PTR_VAL(ep->lb_endpoints, void *);
-            if (!ep_ptrs)
-                return -1;
-
-            if (j >= ep->n_lb_endpoints)
-                continue;
-        }
-
-        cluster_eps->ep_identity[cluster_eps->ep_num++] = (__u64) * ((__u64 *)ep_ptrs + j);
-        j++;
+        ret = cluster_add_endpoints(ep, cluster_eps);
+        if (ret != 0)
+            return -1;
     }
-    return kmesh_map_update_elem(&map_of_cluster_eps, cluster_name, cluster_eps);
+    return map_add_cluster_eps(cluster_name, cluster_eps);
+}
+
+static inline int cluster_check_locality_endpoints(
+    const Endpoint__LocalityLbEndpoints *lb_ep, const struct cluster_endpoints *eps, __u32 *ep_idx)
+{
+    __u32 i;
+    void *ep_ptrs = NULL;
+
+    ep_ptrs = KMESH_GET_PTR_VAL(lb_ep->lb_endpoints, void *);
+    if (!ep_ptrs)
+        return -1;
+
+#pragma unroll
+    for (i = 0; i < KMESH_PER_ENDPOINT_NUM; i++) {
+        if (i >= lb_ep->n_lb_endpoints || *ep_idx >= eps->ep_num)
+            break;
+
+        if (eps->ep_identity[*ep_idx] != (__u64) * ((__u64 *)ep_ptrs + i))
+            return -1;
+
+        (*ep_idx)++;
+    }
+    return 0;
 }
 
 static inline int
 cluster_check_endpoints(const struct cluster_endpoints *eps, const Endpoint__ClusterLoadAssignment *cla)
 {
-    __u32 i = 0, j = 0, k = 0;
+    __u32 i = 0;
     __u32 ep_idx = 0;
     void *loc_ptrs = NULL;
-    void *ep_ptrs = NULL;
     Endpoint__LocalityLbEndpoints *ep = NULL;
 
     __u32 lb_num = cluster_get_endpoints_num(cla);
@@ -200,39 +226,18 @@ cluster_check_endpoints(const struct cluster_endpoints *eps, const Endpoint__Clu
     if (!loc_ptrs)
         return 0;
 
-        /* The flattened loop bound is set to KMESH_PER_ENDPOINT_NUM * 3 to ensure it can cover both
-         * valid endpoints and skip over any empty localities without prematurely exhausting the loop limit. */
 #pragma unroll
-    for (k = 0; k < KMESH_PER_ENDPOINT_NUM * 3; k++) {
-        if (ep_idx >= eps->ep_num)
+    for (i = 0; i < KMESH_PER_ENDPOINT_NUM; i++) {
+        if (i >= cla->n_endpoints || ep_idx >= eps->ep_num)
             break;
 
-        if (!ep || j >= ep->n_lb_endpoints) {
-            if (i >= cla->n_endpoints || i >= KMESH_PER_ENDPOINT_NUM)
-                break;
+        ep = (Endpoint__LocalityLbEndpoints *)KMESH_GET_PTR_VAL(
+            (void *)*((__u64 *)loc_ptrs + i), Endpoint__LocalityLbEndpoints);
+        if (!ep)
+            continue;
 
-            ep = (Endpoint__LocalityLbEndpoints *)KMESH_GET_PTR_VAL(
-                (void *)*((__u64 *)loc_ptrs + i), Endpoint__LocalityLbEndpoints);
-            i++;
-            j = 0;
-
-            if (!ep)
-                continue;
-
-            ep_ptrs = KMESH_GET_PTR_VAL(ep->lb_endpoints, void *);
-            if (!ep_ptrs) {
-                return 0;
-            }
-
-            if (j >= ep->n_lb_endpoints)
-                continue;
-        }
-
-        if (eps->ep_identity[ep_idx] != (__u64) * ((__u64 *)ep_ptrs + j))
+        if (cluster_check_locality_endpoints(ep, eps, &ep_idx) != 0)
             return 0;
-
-        j++;
-        ep_idx++;
     }
 
     if (ep_idx != eps->ep_num)

--- a/bpf/kmesh/ads/include/cluster.h
+++ b/bpf/kmesh/ads/include/cluster.h
@@ -252,6 +252,11 @@ static inline struct cluster_endpoints *cluster_refresh_endpoints(const Cluster_
         return NULL;
     }
 
+    if (cla->n_endpoints == 0) {
+        (void)map_delete_cluster_eps(name);
+        return NULL;
+    }
+
     eps = map_lookup_cluster_eps(name);
     if (eps) {
         if (cluster_check_endpoints(eps, cla) != 0) {
@@ -261,6 +266,7 @@ static inline struct cluster_endpoints *cluster_refresh_endpoints(const Cluster_
     }
 
     if (cluster_init_endpoints(name, cla) != 0) {
+        (void)map_delete_cluster_eps(name);
         return NULL;
     }
     return map_lookup_cluster_eps(name);

--- a/bpf/kmesh/ads/include/cluster.h
+++ b/bpf/kmesh/ads/include/cluster.h
@@ -185,27 +185,59 @@ static inline int cluster_init_endpoints(const char *cluster_name, const Endpoin
 static inline int
 cluster_check_endpoints(const struct cluster_endpoints *eps, const Endpoint__ClusterLoadAssignment *cla)
 {
-    /* 0 -- failed 1 -- succeed */
-    __u32 i;
-    void *ptrs = NULL;
+    __u32 i = 0, j = 0, k = 0;
+    __u32 ep_idx = 0;
+    void *loc_ptrs = NULL;
+    void *ep_ptrs = NULL;
+    Endpoint__LocalityLbEndpoints *ep = NULL;
+
     __u32 lb_num = cluster_get_endpoints_num(cla);
+
+    if (lb_num > KMESH_PER_ENDPOINT_NUM)
+        lb_num = KMESH_PER_ENDPOINT_NUM;
 
     if (!eps || eps->ep_num != lb_num)
         return 0;
 
-    ptrs = KMESH_GET_PTR_VAL(cla->endpoints, void *);
-    if (!ptrs)
+    loc_ptrs = KMESH_GET_PTR_VAL(cla->endpoints, void *);
+    if (!loc_ptrs)
         return 0;
 
 #pragma unroll
-    for (i = 0; i < KMESH_PER_ENDPOINT_NUM; i++) {
-        if (i >= lb_num) {
+    for (k = 0; k < KMESH_PER_ENDPOINT_NUM * 2; k++) {
+        if (ep_idx >= eps->ep_num)
             break;
+
+        if (!ep || j >= ep->n_lb_endpoints) {
+            if (i >= cla->n_endpoints)
+                break;
+
+            ep = (Endpoint__LocalityLbEndpoints *)KMESH_GET_PTR_VAL(
+                (void *)*((__u64 *)loc_ptrs + i), Endpoint__LocalityLbEndpoints);
+            i++;
+            j = 0;
+
+            if (!ep)
+                continue;
+
+            ep_ptrs = KMESH_GET_PTR_VAL(ep->lb_endpoints, void *);
+            if (!ep_ptrs)
+                continue;
+
+            if (j >= ep->n_lb_endpoints)
+                continue;
         }
 
-        if (eps->ep_identity[i] != (__u64)_(ptrs + i))
+        if (eps->ep_identity[ep_idx] != (__u64) * ((__u64 *)ep_ptrs + j))
             return 0;
+
+        j++;
+        ep_idx++;
     }
+
+    if (ep_idx != eps->ep_num)
+        return 0;
+
     return 1;
 }
 
@@ -229,7 +261,6 @@ static inline struct cluster_endpoints *cluster_refresh_endpoints(const Cluster_
     }
 
     if (cluster_init_endpoints(name, cla) != 0) {
-        map_delete_cluster_eps(name); // deletes the corrupted/half-written endpoints because initialization failed
         return NULL;
     }
     return map_lookup_cluster_eps(name);

--- a/bpf/kmesh/ads/include/cluster.h
+++ b/bpf/kmesh/ads/include/cluster.h
@@ -92,27 +92,6 @@ static inline int map_delete_cluster_eps(const char *cluster_name)
     return kmesh_map_delete_elem(&map_of_cluster_eps, cluster_name);
 }
 
-static inline int
-cluster_add_endpoints(const Endpoint__LocalityLbEndpoints *lb_ep, struct cluster_endpoints *cluster_eps)
-{
-    __u32 i;
-    void *ep_ptrs = NULL;
-
-    ep_ptrs = KMESH_GET_PTR_VAL(lb_ep->lb_endpoints, void *);
-    if (!ep_ptrs)
-        return -1;
-
-#pragma unroll
-    for (i = 0; i < KMESH_PER_ENDPOINT_NUM; i++) {
-        if (i >= lb_ep->n_lb_endpoints || cluster_eps->ep_num >= KMESH_PER_ENDPOINT_NUM)
-            break;
-
-        /* store ep identity */
-        cluster_eps->ep_identity[cluster_eps->ep_num++] = (__u64) * ((__u64 *)ep_ptrs + i);
-    }
-    return 0;
-}
-
 static inline __u32 cluster_get_endpoints_num(const Endpoint__ClusterLoadAssignment *cla)
 {
     __u32 i;
@@ -136,15 +115,18 @@ static inline __u32 cluster_get_endpoints_num(const Endpoint__ClusterLoadAssignm
             continue;
 
         num += (__u32)lb_ep->n_lb_endpoints;
+        if (num > KMESH_PER_ENDPOINT_NUM) {
+            return KMESH_PER_ENDPOINT_NUM;
+        }
     }
     return num;
 }
 
 static inline int cluster_init_endpoints(const char *cluster_name, const Endpoint__ClusterLoadAssignment *cla)
 {
-    __u32 i;
-    int ret = 0;
+    __u32 i = 0, j = 0, k = 0;
     void *ptrs = NULL;
+    void *ep_ptrs = NULL;
     Endpoint__LocalityLbEndpoints *ep = NULL;
     /* A percpu array map is added to store cluster eps data.
      * The reason for using percpu array map is that a alarge value exceeds
@@ -164,22 +146,37 @@ static inline int cluster_init_endpoints(const char *cluster_name, const Endpoin
         return -1;
     }
 
+    /* The flattened loop bound is set to KMESH_PER_ENDPOINT_NUM * 3 to ensure it can cover both
+     * valid endpoints and skip over any empty localities without prematurely exhausting the loop limit. */
 #pragma unroll
-    for (i = 0; i < KMESH_PER_ENDPOINT_NUM; i++) {
-        if (i >= cla->n_endpoints)
+    for (k = 0; k < KMESH_PER_ENDPOINT_NUM * 3; k++) {
+        if (cluster_eps->ep_num >= KMESH_PER_ENDPOINT_NUM)
             break;
 
-        ep = (Endpoint__LocalityLbEndpoints *)KMESH_GET_PTR_VAL(
-            (void *)*((__u64 *)ptrs + i), Endpoint__LocalityLbEndpoints);
-        if (!ep)
-            continue;
+        if (!ep || j >= ep->n_lb_endpoints) {
+            if (i >= cla->n_endpoints || i >= KMESH_PER_ENDPOINT_NUM)
+                break;
 
-        ret = cluster_add_endpoints(ep, cluster_eps);
-        if (ret != 0)
-            return -1;
+            ep = (Endpoint__LocalityLbEndpoints *)KMESH_GET_PTR_VAL(
+                (void *)*((__u64 *)ptrs + i), Endpoint__LocalityLbEndpoints);
+            i++;
+            j = 0;
+
+            if (!ep)
+                continue;
+
+            ep_ptrs = KMESH_GET_PTR_VAL(ep->lb_endpoints, void *);
+            if (!ep_ptrs)
+                return -1;
+
+            if (j >= ep->n_lb_endpoints)
+                continue;
+        }
+
+        cluster_eps->ep_identity[cluster_eps->ep_num++] = (__u64) * ((__u64 *)ep_ptrs + j);
+        j++;
     }
-
-    return map_add_cluster_eps(cluster_name, cluster_eps);
+    return kmesh_map_update_elem(&map_of_cluster_eps, cluster_name, cluster_eps);
 }
 
 static inline int
@@ -203,13 +200,15 @@ cluster_check_endpoints(const struct cluster_endpoints *eps, const Endpoint__Clu
     if (!loc_ptrs)
         return 0;
 
+        /* The flattened loop bound is set to KMESH_PER_ENDPOINT_NUM * 3 to ensure it can cover both
+         * valid endpoints and skip over any empty localities without prematurely exhausting the loop limit. */
 #pragma unroll
-    for (k = 0; k < KMESH_PER_ENDPOINT_NUM * 2; k++) {
+    for (k = 0; k < KMESH_PER_ENDPOINT_NUM * 3; k++) {
         if (ep_idx >= eps->ep_num)
             break;
 
         if (!ep || j >= ep->n_lb_endpoints) {
-            if (i >= cla->n_endpoints)
+            if (i >= cla->n_endpoints || i >= KMESH_PER_ENDPOINT_NUM)
                 break;
 
             ep = (Endpoint__LocalityLbEndpoints *)KMESH_GET_PTR_VAL(
@@ -221,8 +220,9 @@ cluster_check_endpoints(const struct cluster_endpoints *eps, const Endpoint__Clu
                 continue;
 
             ep_ptrs = KMESH_GET_PTR_VAL(ep->lb_endpoints, void *);
-            if (!ep_ptrs)
-                continue;
+            if (!ep_ptrs) {
+                return 0;
+            }
 
             if (j >= ep->n_lb_endpoints)
                 continue;
@@ -252,17 +252,16 @@ static inline struct cluster_endpoints *cluster_refresh_endpoints(const Cluster_
         return NULL;
     }
 
-    if (cla->n_endpoints == 0) {
-        (void)map_delete_cluster_eps(name);
-        return NULL;
-    }
-
     eps = map_lookup_cluster_eps(name);
     if (eps) {
         if (cluster_check_endpoints(eps, cla) != 0) {
             return eps;
         }
         map_delete_cluster_eps(name); // deletes the stale/invalid cached endpoints
+    }
+
+    if (cluster_get_endpoints_num(cla) == 0) {
+        return NULL;
     }
 
     if (cluster_init_endpoints(name, cla) != 0) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR resolves the `// FIXME: ... clear` comments in the `cluster_refresh_endpoints` function of the eBPF datapath. 

Previously, Kmesh lacked the ability to invalidate stale cache entries in `map_of_cluster_eps`. If the control plane updated the cluster endpoints, the eBPF program would detect the existing map entry (`if (eps)`) and immediately return the stale endpoints without verifying them against the new `Endpoint__ClusterLoadAssignment`. 

**Changes:**
1. Added a `map_delete_cluster_eps()` helper to interface with `kmesh_map_delete_elem`.
2. Implemented cache invalidation: `cluster_refresh_endpoints` now uses `cluster_check_endpoints` to validate the cache. If a mismatch is detected, the stale map entry is explicitly deleted.
3. Added memory leak protection: if `cluster_init_endpoints` fails during initialization, any partially-written corrupted data is immediately deleted.

**Which issue(s) this PR fixes**:
*(Note: If you didn't open a separate issue for this yet, you can just delete this section!)*
Fixes #1770 

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:
```release-note
NONE
