### PR TITLE
fix: take write lock in SetApiRouteConfig to prevent data race

### DIFF
--- a/pkg/cache/v2/route.go
+++ b/pkg/cache/v2/route.go
@@ -59,8 +59,8 @@ func newApiRouteConfigurationCache() ApiRouteConfigurationCache {
 }
 
 func (cache *RouteConfigCache) SetApiRouteConfig(key string, value *route_v2.RouteConfiguration) {
-	cache.mutex.RLock()
-	defer cache.mutex.RUnlock()
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
 	cache.apiRouteConfigCache[key] = value
 }
 


### PR DESCRIPTION
`RouteConfigCache.SetApiRouteConfig` (`pkg/cache/v2/route.go`) mutates `apiRouteConfigCache[key]` while holding only a read lock (`RLock`/`RUnlock`), which races with concurrent readers. Take the write lock (`Lock`/`Unlock`) instead.