### PR TITLE
test: add regression test for RouteConfigCache.Flush with empty VirtualHosts

### DIFF
--- a/pkg/cache/v2/route_test.go
+++ b/pkg/cache/v2/route_test.go
@@ -116,6 +116,44 @@ func TestRouteFlush(t *testing.T) {
 		assert.Equal(t, []string{}, deleteRouterName)
 	})
 
+	t.Run("route status is UPDATE with empty virtual hosts", func(t *testing.T) {
+		updateRouterName := []string{}
+		deleteRouterName := []string{}
+
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+
+		patches.ApplyFunc(maps_v2.RouteConfigUpdate, func(key string, value *route_v2.RouteConfiguration) error {
+			updateRouterName = append(updateRouterName, key)
+			return nil
+		})
+
+		patches.ApplyFunc(maps_v2.RouteConfigDelete, func(key string) error {
+			deleteRouterName = append(deleteRouterName, key)
+			return nil
+		})
+
+		cache := NewRouteConfigCache()
+
+		routeConfig := &route_v2.RouteConfiguration{
+			ApiStatus:    core_v2.ApiStatus_UPDATE,
+			Name:         "ut-empty-route",
+			VirtualHosts: []*route_v2.VirtualHost{},
+		}
+
+		cache.SetApiRouteConfig(routeConfig.Name, routeConfig)
+
+		cache.Flush()
+
+		apiRouteConfig := cache.GetApiRouteConfig(routeConfig.Name)
+
+		if assert.NotNil(t, apiRouteConfig) {
+			assert.Equal(t, core_v2.ApiStatus_NONE, apiRouteConfig.ApiStatus)
+		}
+		assert.Equal(t, []string{}, updateRouterName)
+		assert.Equal(t, []string{}, deleteRouterName)
+	})
+
 	t.Run("one route status is UPDATE, one route status is DELETE", func(t *testing.T) {
 		updateRouterName := []string{}
 		deleteRouterName := []string{}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

* Adds a regression test for `RouteConfigCache.Flush` when a route has no `VirtualHosts`.
* Verifies that routes with empty `VirtualHosts` are skipped instead of being passed to `RouteConfigUpdate`.
* Protects the behavior introduced in #1603 from future regressions.

**Which issue(s) this PR fixes**:

Fixes #1775

**Special notes for your reviewer**:

This test covers the regression scenario introduced by the fix in #1603 (`fix: skip empty routes in RouteConfigCache.Flush`). Without that fix, the new test fails because `RouteConfigUpdate` is invoked for a route with no `VirtualHosts`.

**Does this PR introduce a user-facing change?**:

```release-note
NONE