### PR TITLE
fix(ctl): bound admin HTTP requests with a client timeout

### DIFF
--- a/ctl/dump/dump.go
+++ b/ctl/dump/dump.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"os"
 	"strings"
 	"text/tabwriter"
@@ -90,9 +89,10 @@ func RunDump(cmd *cobra.Command, args []string, outputFormat string) error {
 	}
 
 	url := fmt.Sprintf("http://%s%s/%s", fw.Address(), configDumpPrefix, mode)
-	resp, err := http.Get(url)
+	client := utils.NewAdminHTTPClient()
+	resp, err := client.Get(url)
 	if err != nil {
-		log.Errorf("failed to make HTTP request: %v", err)
+		log.Errorf("failed to make HTTP request(%s): %v", url, err)
 		os.Exit(1)
 	}
 	defer resp.Body.Close()

--- a/ctl/log/log.go
+++ b/ctl/log/log.go
@@ -64,7 +64,8 @@ kmeshctl log <kmesh-daemon-pod> default`,
 }
 
 func GetJson(url string, val any) error {
-	resp, err := http.Get(url)
+	client := utils.NewAdminHTTPClient()
+	resp, err := client.Get(url)
 	if err != nil {
 		return fmt.Errorf("failed making GET request(%s): %v", url, err)
 	}
@@ -136,10 +137,10 @@ func SetLoggerLevel(url string, setFlag string) {
 		return
 	}
 	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{}
+	client := utils.NewAdminHTTPClient()
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Errorf("failed to make HTTP request: %v", err)
+		log.Errorf("failed to make HTTP request(%s): %v", url, err)
 		return
 	}
 	defer resp.Body.Close()

--- a/ctl/log/log_test.go
+++ b/ctl/log/log_test.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logs
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"kmesh.net/kmesh/ctl/utils"
+)
+
+func Test_GetJson_TimesOutOnStalledServer(t *testing.T) {
+	unblock := make(chan struct{})
+	defer close(unblock)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-unblock
+	}))
+	defer server.Close()
+
+	original := utils.AdminRequestTimeout
+	utils.AdminRequestTimeout = 50 * time.Millisecond
+	defer func() { utils.AdminRequestTimeout = original }()
+
+	var loggerNames []string
+	start := time.Now()
+	err := GetJson(server.URL, &loggerNames)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected GetJson against a stalled server to return an error, got nil")
+	}
+	if !strings.Contains(err.Error(), server.URL) {
+		t.Errorf("error %q does not identify the request URL %q", err.Error(), server.URL)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("GetJson took %v to fail, expected it to be bounded by the configured timeout", elapsed)
+	}
+}

--- a/ctl/utils/utils.go
+++ b/ctl/utils/utils.go
@@ -18,6 +18,8 @@ package utils
 
 import (
 	"fmt"
+	"net/http"
+	"time"
 
 	"kmesh.net/kmesh/pkg/kube"
 )
@@ -27,6 +29,19 @@ const (
 	KmeshLabel     = "app=kmesh"
 	KmeshAdminPort = 15200
 )
+
+// AdminRequestTimeout bounds how long kmeshctl waits for a response from a
+// port-forwarded kmesh-daemon admin endpoint before failing the command.
+// It is a var, rather than a const, so tests can shrink it to exercise the
+// timeout path without waiting out the real default.
+var AdminRequestTimeout = 10 * time.Second
+
+// NewAdminHTTPClient returns an http.Client configured with a bounded timeout
+// for requests against a kmesh-daemon admin endpoint, so commands fail
+// instead of hanging indefinitely when the endpoint stops responding.
+func NewAdminHTTPClient() *http.Client {
+	return &http.Client{Timeout: AdminRequestTimeout}
+}
 
 func CreateKubeClient() (kube.CLIClient, error) {
 	cli, err := kube.NewCLIClient()

--- a/ctl/utils/utils_test.go
+++ b/ctl/utils/utils_test.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func Test_NewAdminHTTPClient_UsesAdminRequestTimeout(t *testing.T) {
+	client := NewAdminHTTPClient()
+	if client.Timeout != AdminRequestTimeout {
+		t.Errorf("client.Timeout = %v, want %v", client.Timeout, AdminRequestTimeout)
+	}
+}
+
+func Test_NewAdminHTTPClient_TimesOutOnStalledServer(t *testing.T) {
+	unblock := make(chan struct{})
+	defer close(unblock)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-unblock
+	}))
+	defer server.Close()
+
+	original := AdminRequestTimeout
+	AdminRequestTimeout = 50 * time.Millisecond
+	defer func() { AdminRequestTimeout = original }()
+
+	client := NewAdminHTTPClient()
+	start := time.Now()
+	_, err := client.Get(server.URL)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected request against stalled server to fail with a timeout error, got nil error")
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("request took %v to fail, expected it to be bounded by the configured timeout", elapsed)
+	}
+}

--- a/ctl/version/version.go
+++ b/ctl/version/version.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"regexp"
 	"strings"
@@ -119,9 +118,10 @@ func getVersion(client kube.CLIClient, podName string) (version version.Info) {
 	defer fw.Close()
 
 	url := fmt.Sprintf("http://%s/version", fw.Address())
-	resp, err := http.Get(url)
+	httpClient := utils.NewAdminHTTPClient()
+	resp, err := httpClient.Get(url)
 	if err != nil {
-		log.Errorf("failed to make HTTP request: %v", err)
+		log.Errorf("failed to make HTTP request(%s): %v", url, err)
 		return
 	}
 	defer resp.Body.Close()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`kmeshctl log`, `kmeshctl version`, and `kmeshctl dump` all send admin
requests to a port-forwarded `kmesh-daemon` endpoint using the Go default
`http.Client` (`http.Get`, or `&http.Client{}`), which has no timeout.
A stalled port-forward tunnel or an unresponsive daemon leaves these
commands hanging indefinitely with no feedback to the user.

This adds a shared `utils.NewAdminHTTPClient()` helper that returns an
`http.Client` bounded by a configurable `utils.AdminRequestTimeout`
(10s default), and uses it at every admin HTTP call site instead of the
unbounded default client. Error messages at these call sites now also
include the request URL so the failing endpoint is identifiable.

**Which issue(s) this PR fixes**:
Fixes #1781

**Special notes for your reviewer**:

- `ctl/utils/utils.go`: new `AdminRequestTimeout` var and
  `NewAdminHTTPClient()` helper.
- `ctl/log/log.go`, `ctl/version/version.go`, `ctl/dump/dump.go`: replaced
  unbounded `http.Get`/`&http.Client{}` usage with the shared helper, and
  included the request URL in the wrapped error messages.
- Added unit tests (`ctl/utils/utils_test.go`, `ctl/log/log_test.go`) that
  use a stalled `httptest` server and a shrunk `AdminRequestTimeout` to
  verify requests fail within a bounded time instead of hanging, and that
  the resulting error identifies the request URL.
- This PR was prepared with AI assistance (Claude Code); I reviewed and
  verified the changes and tests before submitting.
- `ctl/dump/dump.go`'s separate `fw.Start()` error-handling bug (tracked
  in #1634) is intentionally left untouched — out of scope for this fix.

**Does this PR introduce a user-facing change?**:

```release-note
`kmeshctl log`, `kmeshctl version`, and `kmeshctl dump` now time out after 10s instead of hanging indefinitely when the admin endpoint stops responding.
```
