### PR TITLE
fix(config): fail fast when INSTANCE_IP is missing

### DIFF
--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -18,6 +18,8 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
+	"net"
 	"strings"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -40,7 +42,6 @@ import (
 const (
 	sidecarNodeRole           = "sidecar"
 	ztunnelNodeRole           = "ztunnel"
-	localHostIPv4             = "127.0.0.1"
 	serviceNodeSeparator      = "~"
 	defaultClusterLocalDomain = "cluster.local"
 )
@@ -57,11 +58,10 @@ type XdsConfig struct {
 	Node             *corev3.Node
 }
 
-func NewXDSConfig(mode string) *XdsConfig {
+func NewXDSConfig(mode string) (*XdsConfig, error) {
 	c := &XdsConfig{
 		Metadata: &model.BootstrapNodeMetadata{},
 	}
-	podIP := env.Register("INSTANCE_IP", "", "").Get()
 	podName := env.Register("POD_NAME", "", "").Get()
 	podNamespace := env.Register("POD_NAMESPACE", "", "").Get()
 	c.DiscoveryAddress = env.Register("XDS_ADDRESS", "istiod.istio-system.svc:15012", "").Get()
@@ -71,10 +71,9 @@ func NewXDSConfig(mode string) *XdsConfig {
 	meshID := env.Register("MESH_ID", "cluster.local", "").Get()
 	nw := env.Register("ISTIO_META_NETWORK", "", "The network of the proxy.").Get()
 
-	// TODO: fix it once we want to support VM application
-	ip := localHostIPv4
-	if podIP != "" {
-		ip = podIP
+	ip, err := getInstanceIP()
+	if err != nil {
+		return nil, err
 	}
 	id := podName + "." + podNamespace
 	dnsDomain := podNamespace + ".svc." + defaultClusterLocalDomain
@@ -93,15 +92,39 @@ func NewXDSConfig(mode string) *XdsConfig {
 	c.Metadata.NodeName = nodeName
 	c.Metadata.NodeMetadata.ServiceAccount = sa
 
-	return c
+	return c, nil
 }
 
 func GetConfig(mode string) *XdsConfig {
 	if config != nil {
 		return config
 	}
-	config = NewXDSConfig(mode)
+
+	var err error
+	config, err = NewXDSConfig(mode)
+	if err != nil {
+		log.Fatalf("failed to initialize XDS config: %v", err)
+	}
+
 	return config
+}
+
+func getInstanceIP() (string, error) {
+	podIP := strings.TrimSpace(env.Register("INSTANCE_IP", "", "").Get())
+	if podIP == "" {
+		return "", fmt.Errorf("INSTANCE_IP must be set for XDS bootstrap")
+	}
+
+	ip := net.ParseIP(podIP)
+	if ip == nil {
+		return "", fmt.Errorf("INSTANCE_IP %q is not a valid IP address", podIP)
+	}
+
+	if ip.IsLoopback() || ip.IsUnspecified() {
+		return "", fmt.Errorf("INSTANCE_IP %q must not be loopback or unspecified", podIP)
+	}
+
+	return ip.String(), nil
 }
 
 func (c *XdsConfig) GetNode() *corev3.Node {

--- a/pkg/controller/config/config_test.go
+++ b/pkg/controller/config/config_test.go
@@ -17,18 +17,32 @@
 package config
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestInit(t *testing.T) {
-	os.Setenv("INSTANCE_IP", "10.244.0.81")
-	os.Setenv("POD_NAME", "test")
-	os.Setenv("POD_NAMESPACE", "testNs")
-	os.Setenv("XDS_ADDRESS", "istiod.istio-system.svc:15012")
-	config := GetConfig("ads")
+func TestNewXDSConfig(t *testing.T) {
+	t.Setenv("INSTANCE_IP", "10.244.0.81")
+	t.Setenv("POD_NAME", "test")
+	t.Setenv("POD_NAMESPACE", "testNs")
+	t.Setenv("XDS_ADDRESS", "istiod.istio-system.svc:15012")
+
+	config, err := NewXDSConfig("ads")
+	require.NoError(t, err)
 	assert.Equal(t, "sidecar~10.244.0.81~test.testNs~testNs.svc.cluster.local", config.ServiceNode)
 	assert.Equal(t, "istiod.istio-system.svc:15012", config.DiscoveryAddress)
+	assert.Equal(t, []string{"10.244.0.81"}, config.Metadata.InstanceIPs)
+}
+
+func TestNewXDSConfigRequiresInstanceIP(t *testing.T) {
+	t.Setenv("INSTANCE_IP", "")
+	t.Setenv("POD_NAME", "test")
+	t.Setenv("POD_NAMESPACE", "testNs")
+
+	config, err := NewXDSConfig("ads")
+	require.Error(t, err)
+	assert.Nil(t, config)
+	assert.EqualError(t, err, "INSTANCE_IP must be set for XDS bootstrap")
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

## Summary
- stop `pkg/controller/config` from silently advertising `127.0.0.1` when `INSTANCE_IP` is unset
- make `NewXDSConfig` return an explicit error and keep `GetConfig` fail-fast at runtime
- add focused tests for the configured-IP path and the missing-IP failure path

## Linked Issue
Fixes #1783

## What Changed
- removed the loopback fallback from XDS bootstrap config construction
- validated `INSTANCE_IP` before building `ServiceNode` and `Metadata.InstanceIPs`
- updated config tests to cover the new behavior

## Verification
- `go test ./pkg/controller/config` — failed: local `darwin/arm64` build stops in `pkg/logger` because `github.com/cilium/ebpf/ringbuf` does not expose `NewReader` for this host environment
- `make gen-check` — failed: `gen-proto` reports `Unsupported architecture: arm64`
- `make copyright-check` — passed
- `bash ./build.sh` — failed: Linux eBPF headers/tooling are unavailable on this `darwin/arm64` host
- `./hack/golangci-lint-prepare.sh` — passed
- `golangci-lint run --config=common/config/.golangci.yaml --out-format colored-line-number` — not run: `golangci-lint` is not installed in this environment
- `env LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:$PWD/api/v2-c:$PWD/bpf/deserialization_to_bpf_map PKG_CONFIG_PATH=$PWD/mk go test -gcflags=all=-l -race -v -vet=off -coverprofile=coverage.out ./pkg/...` — failed: required generated BPF object files are absent and some packages are Linux-only on this host
- `make ebpf_unit_test V=1` — failed: Linux eBPF headers/tooling are unavailable and `nproc` is missing on this host

## Scope
- changes are limited to `pkg/controller/config` and its unit tests; unrelated files were not modified

**Special notes for your reviewer**:

- Prepared with AI assistance; I verified the code changes and kept the diff scoped to the issue.
- Local verification was limited by the current `darwin/arm64` environment, which does not satisfy the repository's Linux/eBPF build prerequisites.

**Does this PR introduce a user-facing change?**:
```release-note
Fix XDS bootstrap so Kmesh fails fast instead of advertising 127.0.0.1 when INSTANCE_IP is missing.
```
