### PR TITLE
test: add automated performance smoke benchmark workflow

### DIFF
--- a/.github/performance/smoke-thresholds.json
+++ b/.github/performance/smoke-thresholds.json
@@ -1,0 +1,20 @@
+[
+  {
+    "package": "kmesh.net/kmesh/pkg/cache/v2",
+    "benchmark": "BenchmarkClusterFlush",
+    "max_ns_per_op": 2000000000,
+    "description": "Cluster cache flush smoke guard"
+  },
+  {
+    "package": "kmesh.net/kmesh/pkg/cache/v2",
+    "benchmark": "BenchmarkListenerFlush",
+    "max_ns_per_op": 2000000000,
+    "description": "Listener cache flush smoke guard"
+  },
+  {
+    "package": "kmesh.net/kmesh/pkg/controller/workload",
+    "benchmark": "BenchmarkAddNewServicesWithWorkload",
+    "max_ns_per_op": 1000000000,
+    "description": "Workload-to-service indexing smoke guard"
+  }
+]

--- a/.github/workflows/performance-smoke.yml
+++ b/.github/workflows/performance-smoke.yml
@@ -1,0 +1,53 @@
+name: Performance Smoke
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 1"
+
+jobs:
+  performance-smoke:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        go-version: ["1.23"]
+
+    steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - uses: actions/checkout@v3
+
+      - name: Setup Go
+        uses: actions/setup-go@v4.0.0
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Build Kmesh prerequisites
+        shell: bash
+        run: |
+          sudo env "PATH=$PATH" bash ./build.sh
+
+      - name: Run performance smoke benchmarks
+        shell: bash
+        run: |
+          sudo env \
+            LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib:$GITHUB_WORKSPACE/api/v2-c:$GITHUB_WORKSPACE/bpf/deserialization_to_bpf_map" \
+            PKG_CONFIG_PATH="$GITHUB_WORKSPACE/mk" \
+            PATH="$PATH" \
+            make perf-smoke
+
+      - name: Upload performance smoke artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: performance-smoke-results
+          path: .artifacts/perf-smoke/

--- a/Makefile
+++ b/Makefile
@@ -219,6 +219,10 @@ e2e:
 e2e-ipv6:
 	./test/e2e/run_test.sh --ipv6
 
+.PHONY: perf-smoke
+perf-smoke:
+	./hack/perf-smoke.sh
+
 .PHONY: format
 format:
 	./hack/format.sh

--- a/hack/perf-smoke.sh
+++ b/hack/perf-smoke.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+RESULTS_DIR="${RESULTS_DIR:-$ROOT_DIR/.artifacts/perf-smoke}"
+CONFIG_FILE="${CONFIG_FILE:-$ROOT_DIR/.github/performance/smoke-thresholds.json}"
+
+required_objects=(
+	"$ROOT_DIR/bpf/kmesh/bpf2go/kernelnative/normal/kmeshcgroupsock_bpfel.o"
+	"$ROOT_DIR/bpf/kmesh/bpf2go/general/kmeshtcmarkdecrypt_bpfel.o"
+	"$ROOT_DIR/bpf/kmesh/bpf2go/dualengine/kmeshcgroupskb_bpfel.o"
+)
+
+if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+	echo "performance smoke benchmarks require root to initialize BPF maps" >&2
+	echo "run with: sudo env PATH=\$PATH PKG_CONFIG_PATH=$ROOT_DIR/mk LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:$ROOT_DIR/api/v2-c:$ROOT_DIR/bpf/deserialization_to_bpf_map make perf-smoke" >&2
+	exit 1
+fi
+
+for object_file in "${required_objects[@]}"; do
+	if [[ ! -f "$object_file" ]]; then
+		echo "missing generated benchmark prerequisite: $object_file" >&2
+		echo "run: sudo env PATH=\$PATH bash ./build.sh" >&2
+		exit 1
+	fi
+done
+
+mkdir -p "$RESULTS_DIR"
+
+export PKG_CONFIG_PATH="${PKG_CONFIG_PATH:-$ROOT_DIR/mk}"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}:$ROOT_DIR/api/v2-c:$ROOT_DIR/bpf/deserialization_to_bpf_map"
+
+run_benchmark() {
+	local package_path="$1"
+	local bench_filter="$2"
+	local output_file="$3"
+
+	go test "$package_path" \
+		-run '^$' \
+		-bench "$bench_filter" \
+		-benchtime=1x \
+		-benchmem | tee "$output_file"
+}
+
+run_benchmark ./pkg/cache/v2 '^(BenchmarkClusterFlush|BenchmarkListenerFlush)$' "$RESULTS_DIR/pkg-cache-v2.txt"
+run_benchmark ./pkg/controller/workload '^BenchmarkAddNewServicesWithWorkload$' "$RESULTS_DIR/pkg-controller-workload.txt"
+
+go run ./tools/perfcheck \
+	-config "$CONFIG_FILE" \
+	-input "$RESULTS_DIR/pkg-cache-v2.txt" \
+	-input "$RESULTS_DIR/pkg-controller-workload.txt" | tee "$RESULTS_DIR/summary.txt"

--- a/test/performance/README.md
+++ b/test/performance/README.md
@@ -1,5 +1,44 @@
 # Kmesh performance test
 
+## Automated smoke benchmark
+
+The repository now includes a low-cost performance smoke workflow at `.github/workflows/performance-smoke.yml`.
+It runs on a weekly schedule and on `workflow_dispatch`, and it keeps a conservative regression guard on a few
+existing hot-path Go benchmarks:
+
+- `BenchmarkClusterFlush`
+- `BenchmarkListenerFlush`
+- `BenchmarkAddNewServicesWithWorkload`
+
+This smoke workflow is not a replacement for the Fortio-based cluster scenarios in this directory. Its purpose is to
+surface obvious regressions automatically and to publish benchmark artifacts that contributors can inspect.
+
+### Run the smoke benchmark locally
+
+The smoke benchmark requires a Linux environment with the generated BPF objects present.
+
+1. Build the benchmark prerequisites:
+
+   ```sh
+   sudo env PATH=$PATH bash ./build.sh
+   ```
+
+2. Run the smoke benchmark entrypoint:
+
+   ```sh
+   sudo env \
+     PATH=$PATH \
+     PKG_CONFIG_PATH=$PWD/mk \
+     LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$PWD/api/v2-c:$PWD/bpf/deserialization_to_bpf_map \
+     make perf-smoke
+   ```
+
+3. Review the raw benchmark output and threshold summary under `.artifacts/perf-smoke/`.
+
+Thresholds are defined in `.github/performance/smoke-thresholds.json`. They are intentionally conservative and are
+meant to catch major regressions while the full `test/performance/` Fortio scenarios remain the source of deeper
+cluster-level analysis.
+
 ## Basic test networking
 
 ![perf_network](../../docs/pics/perf_network.png)

--- a/tools/perfcheck/main.go
+++ b/tools/perfcheck/main.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type threshold struct {
+	Package     string `json:"package"`
+	Benchmark   string `json:"benchmark"`
+	MaxNsPerOp  int64  `json:"max_ns_per_op"`
+	Description string `json:"description"`
+}
+
+type benchmarkResult struct {
+	Package   string
+	Benchmark string
+	NsPerOp   int64
+	RawLine   string
+}
+
+var benchmarkLineRE = regexp.MustCompile(`^(Benchmark\S+?)(?:-\d+)?\s+\d+\s+([0-9]+(?:\.[0-9]+)?)\s+ns/op(?:\s+.*)?$`)
+
+func main() {
+	var configPath string
+	var inputFiles multiFlag
+
+	flag.StringVar(&configPath, "config", "", "path to threshold config")
+	flag.Var(&inputFiles, "input", "benchmark output file (repeatable)")
+	flag.Parse()
+
+	if configPath == "" || len(inputFiles) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: perfcheck -config <file> -input <benchmark-output> [-input <benchmark-output>]")
+		os.Exit(2)
+	}
+
+	thresholds, err := loadThresholds(configPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load thresholds: %v\n", err)
+		os.Exit(1)
+	}
+
+	results, err := loadResults(inputFiles)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "load benchmark results: %v\n", err)
+		os.Exit(1)
+	}
+
+	failures := evaluateThresholds(thresholds, results)
+	if len(failures) != 0 {
+		for _, failure := range failures {
+			fmt.Fprintf(os.Stderr, "FAIL: %s\n", failure)
+		}
+		os.Exit(1)
+	}
+
+	keys := make([]string, 0, len(results))
+	for key := range results {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		result := results[key]
+		fmt.Printf("PASS: %s %s = %d ns/op\n", result.Package, result.Benchmark, result.NsPerOp)
+	}
+}
+
+type multiFlag []string
+
+func (m *multiFlag) String() string {
+	return strings.Join(*m, ",")
+}
+
+func (m *multiFlag) Set(value string) error {
+	*m = append(*m, value)
+	return nil
+}
+
+func loadThresholds(path string) ([]threshold, error) {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var thresholds []threshold
+	if err := json.Unmarshal(content, &thresholds); err != nil {
+		return nil, err
+	}
+
+	return thresholds, nil
+}
+
+func loadResults(paths []string) (map[string]benchmarkResult, error) {
+	results := make(map[string]benchmarkResult)
+	for _, path := range paths {
+		fileResults, err := parseBenchmarkOutput(path)
+		if err != nil {
+			return nil, err
+		}
+		for key, result := range fileResults {
+			results[key] = result
+		}
+	}
+	return results, nil
+}
+
+func parseBenchmarkOutput(path string) (map[string]benchmarkResult, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	results := make(map[string]benchmarkResult)
+	scanner := bufio.NewScanner(file)
+	currentPackage := ""
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "pkg: ") {
+			currentPackage = strings.TrimPrefix(line, "pkg: ")
+			continue
+		}
+
+		matches := benchmarkLineRE.FindStringSubmatch(line)
+		if matches == nil {
+			continue
+		}
+		if currentPackage == "" {
+			return nil, fmt.Errorf("%s: benchmark line found before pkg header", path)
+		}
+
+		nsPerOp, err := parseNsPerOp(matches[2])
+		if err != nil {
+			return nil, fmt.Errorf("%s: parse ns/op from %q: %w", path, line, err)
+		}
+
+		result := benchmarkResult{
+			Package:   currentPackage,
+			Benchmark: matches[1],
+			NsPerOp:   nsPerOp,
+			RawLine:   line,
+		}
+		results[resultKey(result.Package, result.Benchmark)] = result
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+func parseNsPerOp(value string) (int64, error) {
+	if !strings.Contains(value, ".") {
+		return strconv.ParseInt(value, 10, 64)
+	}
+
+	floatValue, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0, err
+	}
+	return int64(floatValue), nil
+}
+
+func evaluateThresholds(thresholds []threshold, results map[string]benchmarkResult) []string {
+	var failures []string
+
+	for _, threshold := range thresholds {
+		key := resultKey(threshold.Package, threshold.Benchmark)
+		result, found := results[key]
+		if !found {
+			failures = append(failures, fmt.Sprintf("%s %s missing from benchmark output", threshold.Package, threshold.Benchmark))
+			continue
+		}
+
+		if result.NsPerOp > threshold.MaxNsPerOp {
+			label := threshold.Description
+			if label == "" {
+				label = threshold.Benchmark
+			}
+			failures = append(failures, fmt.Sprintf("%s exceeded threshold: got %d ns/op, want <= %d ns/op", label, result.NsPerOp, threshold.MaxNsPerOp))
+		}
+	}
+
+	return failures
+}
+
+func resultKey(pkg, benchmark string) string {
+	return pkg + "::" + benchmark
+}

--- a/tools/perfcheck/main_test.go
+++ b/tools/perfcheck/main_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseBenchmarkOutput(t *testing.T) {
+	t.Parallel()
+
+	output := `goos: linux
+goarch: amd64
+pkg: kmesh.net/kmesh/pkg/cache/v2
+cpu: Intel(R) Xeon(R)
+BenchmarkClusterFlush-8   	       1	835615271 ns/op	  2048 B/op	      18 allocs/op
+BenchmarkListenerFlush-8  	       1	100000000 ns/op
+PASS
+ok  	kmesh.net/kmesh/pkg/cache/v2	0.123s
+`
+
+	path := filepath.Join(t.TempDir(), "bench.txt")
+	if err := os.WriteFile(path, []byte(output), 0o600); err != nil {
+		t.Fatalf("write benchmark output: %v", err)
+	}
+
+	results, err := parseBenchmarkOutput(path)
+	if err != nil {
+		t.Fatalf("parse benchmark output: %v", err)
+	}
+
+	clusterResult, found := results[resultKey("kmesh.net/kmesh/pkg/cache/v2", "BenchmarkClusterFlush")]
+	if !found {
+		t.Fatalf("cluster benchmark result missing")
+	}
+	if clusterResult.NsPerOp != 835615271 {
+		t.Fatalf("unexpected cluster ns/op: got %d", clusterResult.NsPerOp)
+	}
+
+	listenerResult, found := results[resultKey("kmesh.net/kmesh/pkg/cache/v2", "BenchmarkListenerFlush")]
+	if !found {
+		t.Fatalf("listener benchmark result missing")
+	}
+	if listenerResult.NsPerOp != 100000000 {
+		t.Fatalf("unexpected listener ns/op: got %d", listenerResult.NsPerOp)
+	}
+}
+
+func TestEvaluateThresholds(t *testing.T) {
+	t.Parallel()
+
+	thresholds := []threshold{
+		{
+			Package:    "kmesh.net/kmesh/pkg/cache/v2",
+			Benchmark:  "BenchmarkClusterFlush",
+			MaxNsPerOp: 500,
+		},
+		{
+			Package:    "kmesh.net/kmesh/pkg/cache/v2",
+			Benchmark:  "BenchmarkListenerFlush",
+			MaxNsPerOp: 200,
+		},
+	}
+	results := map[string]benchmarkResult{
+		resultKey("kmesh.net/kmesh/pkg/cache/v2", "BenchmarkClusterFlush"): {
+			Package:   "kmesh.net/kmesh/pkg/cache/v2",
+			Benchmark: "BenchmarkClusterFlush",
+			NsPerOp:   400,
+		},
+	}
+
+	failures := evaluateThresholds(thresholds, results)
+	if len(failures) != 1 {
+		t.Fatalf("unexpected number of failures: got %d, want 1", len(failures))
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

## Summary
- add a scheduled and manually triggered performance smoke workflow
- run a small set of existing hot-path Go benchmarks behind a reusable `make perf-smoke` entrypoint
- compare benchmark output against conservative thresholds and upload artifacts for inspection

## Linked Issue
Fixes #1785

## What Changed
- add `.github/workflows/performance-smoke.yml` for weekly and on-demand benchmark runs
- add `hack/perf-smoke.sh` plus `.github/performance/smoke-thresholds.json`
- add `tools/perfcheck` and unit tests to parse benchmark output and enforce thresholds
- document the smoke benchmark flow in `test/performance/README.md`

## Verification
- `go test ./tools/perfcheck` — passed
- `make gen-check` — failed: `hack/gen-protoc.sh` reports `Unsupported architecture: arm64` on this `darwin/arm64` host
- `bash ./build.sh` — failed: Linux BPF headers/tooling are unavailable on this `darwin/arm64` host
- `make test` — failed: depends on Linux BPF build artifacts and non-Linux package paths fail on this host
- `make ebpf_unit_test` — failed: Linux BPF prerequisites are unavailable and `nproc` is missing on this host
- `make e2e` — failed: local run requires privileged Helm installation via `sudo`, which is unavailable in this non-interactive environment

## Scope
- only adds the performance smoke workflow, its helper tooling, the `perf-smoke` make target, and related contributor documentation

**Special notes for your reviewer**:

This change was prepared with AI assistance. I verified the new parser unit test locally, but the repository's Linux-specific build and test flows could not be completed from this `darwin/arm64` environment.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
