### PR TITLE
fix(logger): split ringbuf reader by platform

### DIFF
--- a/pkg/logger/log_reader_linux.go
+++ b/pkg/logger/log_reader_linux.go
@@ -1,0 +1,67 @@
+//go:build linux
+
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logger
+
+import (
+	"context"
+	"encoding/binary"
+
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/ringbuf"
+)
+
+// print bpf log in kmesh-daemon
+func StartLogReader(ctx context.Context, logMapFd *ebpf.Map) {
+	go handleLogEvents(ctx, logMapFd)
+}
+
+func handleLogEvents(ctx context.Context, rbMap *ebpf.Map) {
+	log := NewLoggerScope("ebpf")
+	events, err := ringbuf.NewReader(rbMap)
+	if err != nil {
+		log.Errorf("ringbuf new reader from rb map failed:%v", err)
+		return
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			record, err := events.Read()
+			if err != nil {
+				return
+			}
+			le, err := decodeRecord(record.RawSample)
+			if err != nil {
+				log.Errorf("ringbuf decode data failed:%v", err)
+			}
+			log.Infof("%v", le.Msg)
+		}
+	}
+}
+
+// 4 is the msg length, -1 is the '\0' terminate character
+func decodeRecord(data []byte) (*LogEvent, error) {
+	le := LogEvent{}
+	lenOfMsg := binary.NativeEndian.Uint32(data[0:4])
+	le.len = uint32(lenOfMsg)
+	le.Msg = string(data[4 : 4+lenOfMsg-1])
+	return &le, nil
+}

--- a/pkg/logger/log_reader_stub.go
+++ b/pkg/logger/log_reader_stub.go
@@ -1,0 +1,32 @@
+//go:build !linux
+
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logger
+
+import (
+	"context"
+
+	"github.com/cilium/ebpf"
+)
+
+// StartLogReader is a no-op on non-Linux platforms because the ring buffer
+// reader depends on Linux-only eBPF APIs.
+func StartLogReader(ctx context.Context, logMapFd *ebpf.Map) {
+	_ = ctx
+	_ = logMapFd
+}

--- a/pkg/logger/log_reader_stub_test.go
+++ b/pkg/logger/log_reader_stub_test.go
@@ -1,0 +1,28 @@
+//go:build !linux
+
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logger
+
+import (
+	"context"
+	"testing"
+)
+
+func TestStartLogReaderStub(t *testing.T) {
+	StartLogReader(context.Background(), nil)
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -17,15 +17,11 @@
 package logger
 
 import (
-	"context"
-	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 
-	"github.com/cilium/ebpf"
-	"github.com/cilium/ebpf/ringbuf"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
@@ -121,44 +117,4 @@ func NewLoggerScope(scope string) *logrus.Entry {
 // NewFileLogger don't output log to stdout
 func NewFileLogger(pkgSubsys string) *logrus.Entry {
 	return fileOnlyLogger.WithField(logSubsys, pkgSubsys)
-}
-
-// print bpf log in kmesh-daemon
-func StartLogReader(ctx context.Context, logMapFd *ebpf.Map) {
-	go handleLogEvents(ctx, logMapFd)
-}
-
-func handleLogEvents(ctx context.Context, rbMap *ebpf.Map) {
-	log := NewLoggerScope("ebpf")
-	events, err := ringbuf.NewReader(rbMap)
-	if err != nil {
-		log.Errorf("ringbuf new reader from rb map failed:%v", err)
-		return
-	}
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-			record, err := events.Read()
-			if err != nil {
-				return
-			}
-			le, err := decodeRecord(record.RawSample)
-			if err != nil {
-				log.Errorf("ringbuf decode data failed:%v", err)
-			}
-			log.Infof("%v", le.Msg)
-		}
-	}
-}
-
-// 4 is the msg length, -1 is the '\0' terminate character
-func decodeRecord(data []byte) (*LogEvent, error) {
-	le := LogEvent{}
-	lenOfMsg := binary.NativeEndian.Uint32(data[0:4])
-	le.len = uint32(lenOfMsg)
-	le.Msg = string(data[4 : 4+lenOfMsg-1])
-	return &le, nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

## Summary
- move the eBPF ring buffer reader into a Linux-only logger file
- add a non-Linux `StartLogReader` stub so packages importing `pkg/logger` compile on macOS and other non-Linux hosts
- add a focused non-Linux logger test and keep the shared logger API unchanged

## Linked Issue
Fixes #1787

## What Changed
- split `pkg/logger` so `ringbuf.NewReader` is only referenced from `pkg/logger/log_reader_linux.go`
- keep the existing Linux log reader and record decoder behavior unchanged
- add `pkg/logger/log_reader_stub.go` and `pkg/logger/log_reader_stub_test.go` for non-Linux builds

## Verification
- `go test ./pkg/logger ./pkg/nets` — passed
- `GOOS=linux GOARCH=amd64 go test ./pkg/logger` — passed
- `go test -gcflags=all=-l -race -v -vet=off ./pkg/logger ./pkg/nets` — passed
- `make copyright-check` — passed
- `make gen-check` — not run successfully: fails on this `darwin/arm64` host in `gen-proto` with `Unsupported architecture: arm64`
- `bash ./build.sh` — not run successfully: Linux-specific build prerequisites are unavailable on this host (`/usr/include/linux/bpf.h`, `/usr/lib64`, GNU `sed`/`grep` assumptions)
- `make ebpf_unit_test V=1` — not run successfully: depends on the same Linux-specific build toolchain and also fails because `nproc` is unavailable on this host

## Scope
- only `pkg/logger` files were changed; no unrelated repository files were modified

**Which issue(s) this PR fixes**:
Fixes #1787

**Special notes for your reviewer**:
Prepared with AI assistance and verified locally on a non-Linux host where the original build failure was reproducible.

**Does this PR introduce a user-facing change?**:
NONE
```release-note
NONE
```
