### PR TITLE
build: support selective binary compilation via BINARIES var

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ git commit -s -m "your commit message"
 
 This automatically appends:
 
-```
+```text
 Signed-off-by: Your Name <your-email@example.com>
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ Welcome to Kmesh!
   - [AI Guidance](#ai-guidance)
   - [Contributor Workflow](#contributor-workflow)
     - [Creating Pull Requests](#creating-pull-requests)
+    - [Developer Certificate of Origin (DCO)]
+    - [Fixing a missing sign-off] 
     - [Code Review](#code-review)
   - [Membership](#membership)
 
@@ -103,6 +105,36 @@ fail of continuous integration.
 - To compile, refer to [Compile and Build Kmesh](https://kmesh.net/docs/setup/develop-with-kind/)
 - To run unit test, refer to [Run Unit Test](https://kmesh.net/docs/developer-guide/tests/unit-test/)
 - To run e2e test, refer to [Run E2E Test](https://kmesh.net/docs/developer-guide/tests/e2e-test/)
+
+### Developer Certificate of Origin (DCO)
+
+Every commit must include a `Signed-off-by` line to certify that you 
+wrote or have the right to submit the code:
+
+```bash
+git commit -s -m "your commit message"
+```
+
+This automatically appends:
+
+```
+Signed-off-by: Your Name <your-email@example.com>
+```
+
+#### Fixing a missing sign-off
+
+If you forgot to sign off your last commit:
+
+```bash
+git commit --amend -s --no-edit
+```
+
+For multiple commits, use an interactive rebase and add `-s` when 
+re-committing, or run:
+
+```bash
+git rebase --signoff HEAD~N   # N = number of commits to fix
+```
 
 ### Code Review
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ Welcome to Kmesh!
   - [AI Guidance](#ai-guidance)
   - [Contributor Workflow](#contributor-workflow)
     - [Creating Pull Requests](#creating-pull-requests)
-    - [Developer Certificate of Origin (DCO)]
-    - [Fixing a missing sign-off] 
+    - [Developer Certificate of Origin (DCO)](#developer-certificate-of-origin-dco)
+    - [Fixing a Missing Sign-off](#fixing-a-missing-sign-off)
     - [Code Review](#code-review)
   - [Membership](#membership)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ fail of continuous integration.
 
 ### Developer Certificate of Origin (DCO)
 
-Every commit must include a `Signed-off-by` line to certify that you 
+Every commit must include a `Signed-off-by` line to certify that you
 wrote or have the right to submit the code:
 
 ```bash
@@ -129,7 +129,7 @@ If you forgot to sign off your last commit:
 git commit --amend -s --no-edit
 ```
 
-For multiple commits, use an interactive rebase and add `-s` when 
+For multiple commits, use an interactive rebase and add `-s` when
 re-committing, or run:
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -107,25 +107,25 @@ kmesh-ko:
 BINARIES ?= $(APPS1) $(APPS2) $(APPS3) $(APPS4)
 
 all-binary:
-        $(QUIET) find $(ROOT_DIR)/mk -name "*.pc" | xargs sed -i "s#^prefix=.*#prefix=${ROOT_DIR}#g"
+	$(QUIET) find $(ROOT_DIR)/mk -name "*.pc" | xargs sed -i "s#^prefix=.*#prefix=${ROOT_DIR}#g"
 ifneq (,$(filter $(APPS1),$(BINARIES)))
-        $(call printlog, BUILD, $(APPS1))
-        $(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-        $(GO) build -ldflags $(LDFLAGS) -tags $(ENHANCED_KERNEL) -o $(APPS1) $(GOFLAGS) ./daemon/main.go)
+	$(call printlog, BUILD, $(APPS1))
+	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
+		$(GO) build -ldflags $(LDFLAGS) -tags $(ENHANCED_KERNEL) -o $(APPS1) $(GOFLAGS) ./daemon/main.go)
 endif
 ifneq (,$(filter $(APPS2),$(BINARIES)))
-        $(call printlog, BUILD, $(APPS2))
-        $(QUIET) cd oncn-mda && cmake . -B build && make -C build
+	$(call printlog, BUILD, $(APPS2))
+	$(QUIET) cd oncn-mda && cmake . -B build && make -C build
 endif
 ifneq (,$(filter $(APPS3),$(BINARIES)))
-        $(call printlog, BUILD, $(APPS3))
-        $(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-        CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS3) $(GOFLAGS) ./cniplugin/main.go)
+	$(call printlog, BUILD, $(APPS3))
+	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
+		CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS3) $(GOFLAGS) ./cniplugin/main.go)
 endif
 ifneq (,$(filter $(APPS4),$(BINARIES)))
-        $(call printlog, BUILD, $(APPS4))
-        $(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-        CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS4) $(GOFLAGS) ./ctl/main.go)
+	$(call printlog, BUILD, $(APPS4))
+	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
+		CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS4) $(GOFLAGS) ./ctl/main.go)
 endif
 
 OUT ?= kmeshctl

--- a/Makefile
+++ b/Makefile
@@ -104,22 +104,29 @@ kmesh-ko:
 	$(call printlog, BUILD, "kernel")
 	$(QUIET) make -C kernel/ko_src
 
+BINARIES ?= $(APPS1) $(APPS2) $(APPS3) $(APPS4)
+
 all-binary:
-	$(QUIET) find $(ROOT_DIR)/mk -name "*.pc" | xargs sed -i "s#^prefix=.*#prefix=${ROOT_DIR}#g"
-	$(call printlog, BUILD, $(APPS1))
-	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-		$(GO) build -ldflags $(LDFLAGS) -tags $(ENHANCED_KERNEL) -o $(APPS1) $(GOFLAGS) ./daemon/main.go)
-	
-	$(call printlog, BUILD, $(APPS2))
-	$(QUIET) cd oncn-mda && cmake . -B build && make -C build
-
-	$(call printlog, BUILD, $(APPS3))
-	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-		CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS3) $(GOFLAGS) ./cniplugin/main.go)
-
-	$(call printlog, BUILD, $(APPS4))
-	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-		CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS4) $(GOFLAGS) ./ctl/main.go)
+        $(QUIET) find $(ROOT_DIR)/mk -name "*.pc" | xargs sed -i "s#^prefix=.*#prefix=${ROOT_DIR}#g"
+ifneq (,$(filter $(APPS1),$(BINARIES)))
+        $(call printlog, BUILD, $(APPS1))
+        $(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
+        $(GO) build -ldflags $(LDFLAGS) -tags $(ENHANCED_KERNEL) -o $(APPS1) $(GOFLAGS) ./daemon/main.go)
+endif
+ifneq (,$(filter $(APPS2),$(BINARIES)))
+        $(call printlog, BUILD, $(APPS2))
+        $(QUIET) cd oncn-mda && cmake . -B build && make -C build
+endif
+ifneq (,$(filter $(APPS3),$(BINARIES)))
+        $(call printlog, BUILD, $(APPS3))
+        $(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
+        CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS3) $(GOFLAGS) ./cniplugin/main.go)
+endif
+ifneq (,$(filter $(APPS4),$(BINARIES)))
+        $(call printlog, BUILD, $(APPS4))
+        $(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
+        CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS4) $(GOFLAGS) ./ctl/main.go)
+endif
 
 OUT ?= kmeshctl
 .PHONY: kmeshctl


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
This PR refactors the Makefile to support selective compilation of Kmesh binaries.

Previously, running make build compiled all binaries:

kmesh-daemon
mdacore
kmesh-cni
kmeshctl

With this change, users can specify which binaries to build by passing the BINARIES variable. For example:
BINARIES=kmeshctl make build
or
BINARIES="kmeshctl kmesh-daemon" make build

This improves development efficiency by avoiding unnecessary compilation and reducing build time when working on a subset of the project.
**Which issue(s) this PR fixes**:
Fixes #892 

**Special notes for your reviewer**:
Refactored the Makefile to support selective binary builds.
The default behavior remains unchanged when BINARIES is not specified, ensuring all binaries are still built.
Please verify both the default build and selective build scenarios.
**Does this PR introduce a user-facing change?**:
```release-note
Added support for selectively building Kmesh binaries by specifying the `BINARIES` variable (for example, `BINARIES=kmeshctl make build`), while preserving the default behavior of building all binaries when no selection is provided.
```
