### PR TITLE
docs: fix broken relative links to moved docs in READMEs

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -56,7 +56,7 @@ Kmesh创新性的提出将流量治理下沉OS，在数据路径上无需经过�
 - 前提条件
 
   - Kmesh当前是对接Istio控制面，启动Kmesh前，需要提前安装好Istio的控制面软件；具体安装步骤参考：<https://istio.io/latest/docs/setup/getting-started/#install>
-  - 完整的Kmesh能力依赖对OS的增强，需确认执行环境是否在Kmesh支持的[OS列表](docs/kmesh_support-zh.md)中，对于其他OS环境需要参考[Kmesh编译构建](docs/kmesh_compile-zh.md)；也可以使用[兼容模式的kmesh镜像](build/docker/README.md#兼容模式镜像)在其他OS环境中进行尝试，关于kmesh各种镜像的说明请参考[详细文档](build/docker/README.md)。
+  - 完整的Kmesh能力依赖对OS的增强，需确认执行环境是否在Kmesh支持的[OS列表](docs/cn/zh/kmesh_support-zh.md)中，对于其他OS环境需要参考[Kmesh编译构建](docs/cn/zh/kmesh_compile-zh.md)；也可以使用[兼容模式的kmesh镜像](build/docker/README.md#兼容模式镜像)在其他OS环境中进行尝试，关于kmesh各种镜像的说明请参考[详细文档](build/docker/README.md)。
   
 - Docker镜像：
 
@@ -70,7 +70,7 @@ Kmesh创新性的提出将流量治理下沉OS，在数据路径上无需经过�
 
     为了兼容不同的OS版本，Kmesh提供在线编译并运行的镜像。在Kmesh被部署之后，它会基于宿主机的内核能力自动选择运行的Kmesh特性，从而满足一个镜像在不同OS环境运行的要求。
 
-    考虑到kmesh使用的通用性，我们也发布了用于kmesh编译构建的镜像。用户可以基于此镜像方便的制作出可以在当前OS版本上运行的kmesh镜像。默认命名为ghcr.io/kmesh-net/kmesh:latest，用户可自行调整，参考[Kmesh编译构建](docs/kmesh_compile-zh.md#docker image编译)
+    考虑到kmesh使用的通用性，我们也发布了用于kmesh编译构建的镜像。用户可以基于此镜像方便的制作出可以在当前OS版本上运行的kmesh镜像。默认命名为ghcr.io/kmesh-net/kmesh:latest，用户可自行调整，参考[Kmesh编译构建](docs/cn/zh/kmesh_compile-zh.md#docker image编译)
   
     ```bash
     make docker TAG=latest
@@ -123,7 +123,7 @@ Kmesh创新性的提出将流量治理下沉OS，在数据路径上无需经过�
     time="2024-02-19T10:16:54Z" level=info msg="command Start cni successful" subsys=manager
   ```
   
-  更多Kmesh编译构建方式，请参考[Kmesh编译构建](docs/kmesh_compile-zh.md)
+  更多Kmesh编译构建方式，请参考[Kmesh编译构建](docs/cn/zh/kmesh_compile-zh.md)
 
 - Kmesh L7
 
@@ -186,11 +186,11 @@ Kmesh的主要部件包括：
 
 - Kmesh命令列表
 
-  [Kmesh命令列表](docs/kmesh_commands-zh.md)
+  [Kmesh命令列表](docs/cn/zh/kmesh_commands-zh.md)
 
 - demo演示
 
-  [Kmesh demo演示](docs/kmesh_demo-zh.md)
+  [Kmesh demo演示](docs/cn/zh/kmesh_demo-zh.md)
 
 ## Kmesh能力地图
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -70,7 +70,7 @@ Kmesh创新性的提出将流量治理下沉OS，在数据路径上无需经过�
 
     为了兼容不同的OS版本，Kmesh提供在线编译并运行的镜像。在Kmesh被部署之后，它会基于宿主机的内核能力自动选择运行的Kmesh特性，从而满足一个镜像在不同OS环境运行的要求。
 
-    考虑到kmesh使用的通用性，我们也发布了用于kmesh编译构建的镜像。用户可以基于此镜像方便的制作出可以在当前OS版本上运行的kmesh镜像。默认命名为ghcr.io/kmesh-net/kmesh:latest，用户可自行调整，参考[Kmesh编译构建](docs/cn/zh/kmesh_compile-zh.md#docker image编译)
+    考虑到kmesh使用的通用性，我们也发布了用于kmesh编译构建的镜像。用户可以基于此镜像方便的制作出可以在当前OS版本上运行的kmesh镜像。默认命名为ghcr.io/kmesh-net/kmesh:latest，用户可自行调整，参考[Kmesh编译构建](docs/cn/zh/kmesh_compile-zh.md#docker-image编译)
   
     ```bash
     make docker TAG=latest

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Kmesh also provides a Dual-Engine Mode, which makes use of eBPF and waypoint to 
 
 ## Quick Start
 
-Please refer to [quick start](https://kmesh.net/en/docs/setup/quick-start/) and [user guide](docs/kmesh_demo.md) to try Kmesh quickly.
+Please refer to [quick start](https://kmesh.net/en/docs/setup/quick-start/) and [user guide](docs/en/kmesh_demo.md) to try Kmesh quickly.
 
 ### Guided Install
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Several relative Markdown links in the top-level READMEs pointed to `docs/` paths that no longer exist. The docs were moved under `docs/en/` and `docs/cn/zh/`, but the links were not updated, so they 404 on GitHub.

This PR repoints them at the current locations:

- `README.md`: user guide -> `docs/en/kmesh_demo.md`
- `README-zh.md`:
  - `docs/kmesh_support-zh.md` -> `docs/cn/zh/kmesh_support-zh.md`
  - `docs/kmesh_compile-zh.md` -> `docs/cn/zh/kmesh_compile-zh.md` (3 occurrences)
  - `docs/kmesh_commands-zh.md` -> `docs/cn/zh/kmesh_commands-zh.md`
  - `docs/kmesh_demo-zh.md` -> `docs/cn/zh/kmesh_demo-zh.md`

Every new target was confirmed to exist with `find`, and no old broken `docs/kmesh_*.md` links remain.

**Which issue(s) this PR fixes**:

Fixes #1793 

**Special notes for your reviewer**:

Docs-only change. Kmesh's `main.yml` CI ignores `**.md`, so the code CI jobs (gen-check, build, golangci-lint, go test, ebpf_unit_test) do not run for this PR; the gating checks are Codespell and markdownlint, both of which pass locally (`markdownlint-cli2 "**/*.md" "!docs/ctl"` -> 0 errors).

Scope note: `README-zh.md` line 67 also contains a stale absolute link (`https://github.com/kmesh-net/kmesh/blob/main/docs/kmesh_support.md`; the file is now at `docs/en/kmesh_support.md`). It is left untouched here to keep this PR scoped to the relative-link issue as filed - happy to fix it in a follow-up if desired.

This is  the fix  and each broken path and its correct location was verified with `find`/`grep` against the current tree. 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
