### PR TITLE
fix: handle port-forward startup failure in dump command

### DIFF
--- a/ctl/dump/dump.go
+++ b/ctl/dump/dump.go
@@ -87,12 +87,15 @@ func RunDump(cmd *cobra.Command, args []string, outputFormat string) error {
 	}
 	if err := fw.Start(); err != nil {
 		log.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
+		os.Exit(1)
 	}
+	defer fw.Close()
 
 	url := fmt.Sprintf("http://%s%s/%s", fw.Address(), configDumpPrefix, mode)
 	resp, err := http.Get(url)
 	if err != nil {
 		log.Errorf("failed to make HTTP request: %v", err)
+		fw.Close()
 		os.Exit(1)
 	}
 	defer resp.Body.Close()
@@ -100,6 +103,7 @@ func RunDump(cmd *cobra.Command, args []string, outputFormat string) error {
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Errorf("failed to read HTTP response body: %v", err)
+		fw.Close()
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes `kmeshctl dump` port-forward lifecycle handling. The command now stops when port-forward startup fails and closes the forwarder after a successful start, matching other Kmesh CLI commands.

**Which issue(s) this PR fixes**:

Fixes #1795 

**Special notes for your reviewer**:

The change aligns `ctl/dump` with `ctl/log`, `ctl/version`, and `ctl/monitoring`, which already return/exit on `Start()` failure and use `defer fw.Close()`.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed kmeshctl dump to stop on port-forward startup failures and clean up the port-forward session after use.
```
