### PR TITLE
fix(dns): avoid nil-pointer panic in GetDomainAddress on cache miss

### DIFF
--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -272,7 +272,7 @@ func (r *DNSResolver) GetAllCachedDomains() []string {
 func (r *DNSResolver) GetDomainAddress(domain string) ([]string, bool) {
 	r.RLock()
 	defer r.RUnlock()
-	if entry, ok := r.cache[domain]; ok {
+	if entry, ok := r.cache[domain]; ok && entry != nil {
 		return entry.Addresses, true
 	}
 	return nil, false

--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -271,9 +271,11 @@ func (r *DNSResolver) GetAllCachedDomains() []string {
 
 func (r *DNSResolver) GetDomainAddress(domain string) ([]string, bool) {
 	r.RLock()
-	addresses, ok := r.cache[domain]
-	r.RUnlock()
-	return addresses.Addresses, ok
+	defer r.RUnlock()
+	if entry, ok := r.cache[domain]; ok {
+		return entry.Addresses, true
+	}
+	return nil, false
 }
 
 func (r *DNSResolver) GetBatchAddressesFromCache(domains map[string]struct{}) map[string]*DomainCacheEntry {

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -148,6 +148,7 @@ func TestGetDomainAddress(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer r.refreshQueue.ShutDown()
 
 	// Cached domain: returns its addresses and true.
 	want := []string{"10.0.0.1", "fd00::1"}
@@ -159,7 +160,7 @@ func TestGetDomainAddress(t *testing.T) {
 		t.Errorf("GetDomainAddress(cached) = (%v, %v), want (%v, true)", got, ok, want)
 	}
 
-	// Absent domain: must return (nil, false) without panicking on a nil entry.
+	// Absent domain: must return (nil, false) for a key that was never cached.
 	if got, ok := r.GetDomainAddress("absent.example.com."); ok || got != nil {
 		t.Errorf("GetDomainAddress(absent) = (%v, %v), want (nil, false)", got, ok)
 	}

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -163,4 +163,12 @@ func TestGetDomainAddress(t *testing.T) {
 	if got, ok := r.GetDomainAddress("absent.example.com."); ok || got != nil {
 		t.Errorf("GetDomainAddress(absent) = (%v, %v), want (nil, false)", got, ok)
 	}
+
+	// Present key mapped to a nil entry: must not panic, returns (nil, false).
+	r.Lock()
+	r.cache["nil.example.com."] = nil
+	r.Unlock()
+	if got, ok := r.GetDomainAddress("nil.example.com."); ok || got != nil {
+		t.Errorf("GetDomainAddress(nil entry) = (%v, %v), want (nil, false)", got, ok)
+	}
 }

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -142,3 +142,25 @@ func TestDNS(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+func TestGetDomainAddress(t *testing.T) {
+	r, err := NewDNSResolver()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Cached domain: returns its addresses and true.
+	want := []string{"10.0.0.1", "fd00::1"}
+	r.Lock()
+	r.cache["cached.example.com."] = &DomainCacheEntry{Addresses: want}
+	r.Unlock()
+
+	if got, ok := r.GetDomainAddress("cached.example.com."); !ok || !reflect.DeepEqual(got, want) {
+		t.Errorf("GetDomainAddress(cached) = (%v, %v), want (%v, true)", got, ok, want)
+	}
+
+	// Absent domain: must return (nil, false) without panicking on a nil entry.
+	if got, ok := r.GetDomainAddress("absent.example.com."); ok || got != nil {
+		t.Errorf("GetDomainAddress(absent) = (%v, %v), want (nil, false)", got, ok)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`DNSResolver.GetDomainAddress` (`pkg/dns/dns.go`) dereferenced the map-lookup result before checking whether the domain was present:

```go
addresses, ok := r.cache[domain]
r.RUnlock()
return addresses.Addresses, ok   // panics: addresses is nil when ok == false
```

`r.cache` is a `map[string]*DomainCacheEntry`, so on a cache miss `addresses` is a nil `*DomainCacheEntry` and evaluating `addresses.Addresses` panics with a nil-pointer dereference. The `ok` value was computed but never used to guard the access. This PR checks `ok` before reading the field and returns `(nil, false)` on a miss, matching the pattern already used by the sibling accessor `GetDNSAddresses` (`pkg/dns/utils.go`).

A regression test (`TestGetDomainAddress`) is added covering both the cache-hit path (returns addresses + true) and the cache-miss path (returns nil + false without panicking).

**Which issue(s) this PR fixes**:
Fixes #1798

**Special notes for your reviewer**:

This change was AI-assisted, disclosed per the CONTRIBUTING.md AI Guidance. As the author I have reviewed and verified every line: I confirmed the nil-dereference against the current code, confirmed `GetDomainAddress` is the only accessor in the package missing the `ok` guard (`GetDNSAddresses` at `pkg/dns/utils.go:110` and `getByNamespace` at `pkg/auth/policy_store.go:122` already guard correctly), and ran the changed package under `-race` (`go test -race ./pkg/dns/...`) which passes with the new test. The fix is a scoped, behaviour-preserving change on the cache-miss path only.

Note on CI: the failures on the `build (1.23)` and `E2E` jobs are unrelated to this change — they are pre-existing, environment-dependent failures in eBPF/root-dependent tests (`pkg/auth`, `pkg/bpf`, `pkg/cache/v2`, `pkg/controller/encryption/ipsec`, `pkg/status`) that also fail identically on other code PRs. This PR only touches `pkg/dns`, whose tests pass. Happy to rebase/re-run if that helps trigger a clean CI pass.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
