### PR TITLE
fix: cache pending DNS clusters

### DIFF
--- a/pkg/controller/ads/ads_controller.go
+++ b/pkg/controller/ads/ads_controller.go
@@ -97,7 +97,9 @@ func (c *Controller) HandleAdsStream() error {
 
 	// Because Kernel-Native mode is full update.
 	// So the original clusterCache is deleted when a new resp is received.
-	c.dnsResolverController.newClusterCache()
+	if rsp.GetTypeUrl() == resource_v3.ClusterType {
+		c.dnsResolverController.newClusterCache()
+	}
 	c.Processor.processAdsResponse(rsp)
 	c.con.requestsChan.Put(c.Processor.ack)
 	if c.Processor.req != nil {

--- a/pkg/controller/ads/dns.go
+++ b/pkg/controller/ads/dns.go
@@ -89,6 +89,12 @@ func (r *dnsController) processClusters() {
 func (r *dnsController) processDomains(cds []*clusterv3.Cluster) {
 	domains := getPendingResolveDomain(cds)
 
+	r.Lock()
+	for domain, pending := range domains {
+		r.clusterCache[domain] = pending.(*pendingResolveDomain)
+	}
+	r.Unlock()
+
 	// store all pending hostnames of clusters in pendingHostnames
 	for _, cluster := range cds {
 		clusterName := cluster.GetName()

--- a/pkg/controller/ads/dns_test.go
+++ b/pkg/controller/ads/dns_test.go
@@ -235,6 +235,9 @@ func TestHandleCdsResponseWithDns(t *testing.T) {
 			retry.UntilOrFail(t, func() bool {
 				return slices.EqualUnordered(tc.expected, dnsResolver.dnsResolver.GetAllCachedDomains())
 			}, retry.Timeout(1*time.Second))
+			for _, domain := range tc.expected {
+				assert.NotNil(t, dnsResolver.getClustersByDomain(domain))
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Keeps pending DNS clusters in `clusterCache` so the resolver can update them when lookup finishes.

The cache is now reset only for CDS responses. EDS, LDS, and RDS responses should not clear pending DNS state.

**Which issue(s) this PR fixes**:

Fixes #1802

**Special notes for your reviewer**:

Added coverage to the existing DNS controller test.

**Does this PR introduce a user-facing change?**:

```release-note
Fix kernel-native DNS clusters not being updated after initial hostname resolution.