### PR TITLE
fix: handle deleted waypoint associations

### DIFF
--- a/pkg/controller/workload/cache/waypoint_cache.go
+++ b/pkg/controller/workload/cache/waypoint_cache.go
@@ -90,7 +90,9 @@ func (w *waypointCache) AddOrUpdateService(svc *workloadapi.Service) bool {
 		// Service may become unassociated with waypoint.
 		if waypoint, ok := w.serviceToWaypoint[resourceName]; ok {
 			delete(w.serviceToWaypoint, resourceName)
-			w.waypointAssociatedObjects[waypoint].deleteService(resourceName)
+			if associated, ok := w.waypointAssociatedObjects[waypoint]; ok {
+				associated.deleteService(resourceName)
+			}
 		}
 		return true
 	}
@@ -104,7 +106,9 @@ func (w *waypointCache) AddOrUpdateService(svc *workloadapi.Service) bool {
 	if waypoint, ok := w.serviceToWaypoint[resourceName]; ok && waypoint != waypointResourceName {
 		// Service updated associated waypoint, delete previous association first.
 		delete(w.serviceToWaypoint, resourceName)
-		w.waypointAssociatedObjects[waypoint].deleteService(resourceName)
+		if associated, ok := w.waypointAssociatedObjects[waypoint]; ok {
+			associated.deleteService(resourceName)
+		}
 	}
 
 	log.Debugf("Update svc %s with waypoint %s", svc.ResourceName(), waypointResourceName)
@@ -159,7 +163,9 @@ func (w *waypointCache) AddOrUpdateWorkload(workload *workloadapi.Workload) bool
 		// Workload may become unassociated with waypoint.
 		if waypoint, ok := w.workloadToWaypoint[uid]; ok {
 			delete(w.workloadToWaypoint, uid)
-			w.waypointAssociatedObjects[waypoint].deleteWorkload(uid)
+			if associated, ok := w.waypointAssociatedObjects[waypoint]; ok {
+				associated.deleteWorkload(uid)
+			}
 		}
 		return true
 	}
@@ -173,7 +179,9 @@ func (w *waypointCache) AddOrUpdateWorkload(workload *workloadapi.Workload) bool
 	if waypoint, ok := w.workloadToWaypoint[uid]; ok && waypoint != waypointResourceName {
 		// Workload updated associated waypoint, delete previous association first.
 		delete(w.workloadToWaypoint, uid)
-		w.waypointAssociatedObjects[waypoint].deleteWorkload(uid)
+		if associated, ok := w.waypointAssociatedObjects[waypoint]; ok {
+			associated.deleteWorkload(uid)
+		}
 	}
 
 	log.Debugf("Update workload %s with waypoint %s", uid, waypointResourceName)

--- a/pkg/controller/workload/cache/waypoint_cache_test.go
+++ b/pkg/controller/workload/cache/waypoint_cache_test.go
@@ -107,3 +107,25 @@ func TestBasic(t *testing.T) {
 	assert.Equal(t, 0, len(cache.workloadToWaypoint))
 	assert.Equal(t, 0, len(cache.waypointAssociatedObjects))
 }
+
+func TestDeleteWaypointBeforeAssociatedResources(t *testing.T) {
+	serviceCache := NewServiceCache()
+	cache := NewWaypointCache(serviceCache)
+
+	waypointHostname := "default/waypoint.default.svc.cluster.local"
+	svc := common.CreateFakeService("svc", "10.240.10.1", waypointHostname, nil)
+	wl := common.CreateFakeWorkload("1.2.3.5", waypointHostname)
+
+	cache.AddOrUpdateService(svc)
+	cache.AddOrUpdateWorkload(wl)
+	cache.DeleteService(waypointHostname)
+
+	svc.Waypoint = nil
+	wl.Waypoint = nil
+	cache.AddOrUpdateService(svc)
+	cache.AddOrUpdateWorkload(wl)
+
+	assert.Equal(t, 0, len(cache.serviceToWaypoint))
+	assert.Equal(t, 0, len(cache.workloadToWaypoint))
+	assert.Equal(t, 0, len(cache.waypointAssociatedObjects))
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Checks that a waypoint association still exists before removing a service or workload from it.

This prevents a nil pointer panic when the waypoint service is deleted before updates for its associated resources arrive.

**Which issue(s) this PR fixes**:

Fixes #1804

**Special notes for your reviewer**:

Added a regression test covering both service and workload updates.

**Does this PR introduce a user-facing change?**:

```release-note
Fix a workload controller panic when a waypoint service is deleted before its associated resources are updated.