### PR TITLE
fix: separate IPv4 and IPv6 workload tail call maps

### DIFF
--- a/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkload_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkload_bpfeb.go
@@ -111,6 +111,7 @@ type KmeshCgroupSockWorkloadMapSpecs struct {
 	KmAuthReq     *ebpf.MapSpec `ebpf:"km_auth_req"`
 	KmAuthRes     *ebpf.MapSpec `ebpf:"km_auth_res"`
 	KmBackend     *ebpf.MapSpec `ebpf:"km_backend"`
+	KmCgrTail6    *ebpf.MapSpec `ebpf:"km_cgr_tail6"`
 	KmCgrTailcall *ebpf.MapSpec `ebpf:"km_cgr_tailcall"`
 	KmEndpoint    *ebpf.MapSpec `ebpf:"km_endpoint"`
 	KmFrontend    *ebpf.MapSpec `ebpf:"km_frontend"`
@@ -161,6 +162,7 @@ type KmeshCgroupSockWorkloadMaps struct {
 	KmAuthReq     *ebpf.Map `ebpf:"km_auth_req"`
 	KmAuthRes     *ebpf.Map `ebpf:"km_auth_res"`
 	KmBackend     *ebpf.Map `ebpf:"km_backend"`
+	KmCgrTail6    *ebpf.Map `ebpf:"km_cgr_tail6"`
 	KmCgrTailcall *ebpf.Map `ebpf:"km_cgr_tailcall"`
 	KmEndpoint    *ebpf.Map `ebpf:"km_endpoint"`
 	KmFrontend    *ebpf.Map `ebpf:"km_frontend"`
@@ -185,6 +187,7 @@ func (m *KmeshCgroupSockWorkloadMaps) Close() error {
 		m.KmAuthReq,
 		m.KmAuthRes,
 		m.KmBackend,
+		m.KmCgrTail6,
 		m.KmCgrTailcall,
 		m.KmEndpoint,
 		m.KmFrontend,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkload_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkload_bpfel.go
@@ -111,6 +111,7 @@ type KmeshCgroupSockWorkloadMapSpecs struct {
 	KmAuthReq     *ebpf.MapSpec `ebpf:"km_auth_req"`
 	KmAuthRes     *ebpf.MapSpec `ebpf:"km_auth_res"`
 	KmBackend     *ebpf.MapSpec `ebpf:"km_backend"`
+	KmCgrTail6    *ebpf.MapSpec `ebpf:"km_cgr_tail6"`
 	KmCgrTailcall *ebpf.MapSpec `ebpf:"km_cgr_tailcall"`
 	KmEndpoint    *ebpf.MapSpec `ebpf:"km_endpoint"`
 	KmFrontend    *ebpf.MapSpec `ebpf:"km_frontend"`
@@ -161,6 +162,7 @@ type KmeshCgroupSockWorkloadMaps struct {
 	KmAuthReq     *ebpf.Map `ebpf:"km_auth_req"`
 	KmAuthRes     *ebpf.Map `ebpf:"km_auth_res"`
 	KmBackend     *ebpf.Map `ebpf:"km_backend"`
+	KmCgrTail6    *ebpf.Map `ebpf:"km_cgr_tail6"`
 	KmCgrTailcall *ebpf.Map `ebpf:"km_cgr_tailcall"`
 	KmEndpoint    *ebpf.Map `ebpf:"km_endpoint"`
 	KmFrontend    *ebpf.Map `ebpf:"km_frontend"`
@@ -185,6 +187,7 @@ func (m *KmeshCgroupSockWorkloadMaps) Close() error {
 		m.KmAuthReq,
 		m.KmAuthRes,
 		m.KmBackend,
+		m.KmCgrTail6,
 		m.KmCgrTailcall,
 		m.KmEndpoint,
 		m.KmFrontend,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkloadcompat_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkloadcompat_bpfeb.go
@@ -111,6 +111,7 @@ type KmeshCgroupSockWorkloadCompatMapSpecs struct {
 	KmAuthReq     *ebpf.MapSpec `ebpf:"km_auth_req"`
 	KmAuthRes     *ebpf.MapSpec `ebpf:"km_auth_res"`
 	KmBackend     *ebpf.MapSpec `ebpf:"km_backend"`
+	KmCgrTail6    *ebpf.MapSpec `ebpf:"km_cgr_tail6"`
 	KmCgrTailcall *ebpf.MapSpec `ebpf:"km_cgr_tailcall"`
 	KmEndpoint    *ebpf.MapSpec `ebpf:"km_endpoint"`
 	KmFrontend    *ebpf.MapSpec `ebpf:"km_frontend"`
@@ -161,6 +162,7 @@ type KmeshCgroupSockWorkloadCompatMaps struct {
 	KmAuthReq     *ebpf.Map `ebpf:"km_auth_req"`
 	KmAuthRes     *ebpf.Map `ebpf:"km_auth_res"`
 	KmBackend     *ebpf.Map `ebpf:"km_backend"`
+	KmCgrTail6    *ebpf.Map `ebpf:"km_cgr_tail6"`
 	KmCgrTailcall *ebpf.Map `ebpf:"km_cgr_tailcall"`
 	KmEndpoint    *ebpf.Map `ebpf:"km_endpoint"`
 	KmFrontend    *ebpf.Map `ebpf:"km_frontend"`
@@ -185,6 +187,7 @@ func (m *KmeshCgroupSockWorkloadCompatMaps) Close() error {
 		m.KmAuthReq,
 		m.KmAuthRes,
 		m.KmBackend,
+		m.KmCgrTail6,
 		m.KmCgrTailcall,
 		m.KmEndpoint,
 		m.KmFrontend,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkloadcompat_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshcgroupsockworkloadcompat_bpfel.go
@@ -111,6 +111,7 @@ type KmeshCgroupSockWorkloadCompatMapSpecs struct {
 	KmAuthReq     *ebpf.MapSpec `ebpf:"km_auth_req"`
 	KmAuthRes     *ebpf.MapSpec `ebpf:"km_auth_res"`
 	KmBackend     *ebpf.MapSpec `ebpf:"km_backend"`
+	KmCgrTail6    *ebpf.MapSpec `ebpf:"km_cgr_tail6"`
 	KmCgrTailcall *ebpf.MapSpec `ebpf:"km_cgr_tailcall"`
 	KmEndpoint    *ebpf.MapSpec `ebpf:"km_endpoint"`
 	KmFrontend    *ebpf.MapSpec `ebpf:"km_frontend"`
@@ -161,6 +162,7 @@ type KmeshCgroupSockWorkloadCompatMaps struct {
 	KmAuthReq     *ebpf.Map `ebpf:"km_auth_req"`
 	KmAuthRes     *ebpf.Map `ebpf:"km_auth_res"`
 	KmBackend     *ebpf.Map `ebpf:"km_backend"`
+	KmCgrTail6    *ebpf.Map `ebpf:"km_cgr_tail6"`
 	KmCgrTailcall *ebpf.Map `ebpf:"km_cgr_tailcall"`
 	KmEndpoint    *ebpf.Map `ebpf:"km_endpoint"`
 	KmFrontend    *ebpf.Map `ebpf:"km_frontend"`
@@ -185,6 +187,7 @@ func (m *KmeshCgroupSockWorkloadCompatMaps) Close() error {
 		m.KmAuthReq,
 		m.KmAuthRes,
 		m.KmBackend,
+		m.KmCgrTail6,
 		m.KmCgrTailcall,
 		m.KmEndpoint,
 		m.KmFrontend,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshxdpauth_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshxdpauth_bpfeb.go
@@ -98,6 +98,7 @@ type KmeshXDPAuthMapSpecs struct {
 	KmAuthRes     *ebpf.MapSpec `ebpf:"km_auth_res"`
 	KmAuthzPolicy *ebpf.MapSpec `ebpf:"km_authz_policy"`
 	KmBackend     *ebpf.MapSpec `ebpf:"km_backend"`
+	KmCgrTail6    *ebpf.MapSpec `ebpf:"km_cgr_tail6"`
 	KmCgrTailcall *ebpf.MapSpec `ebpf:"km_cgr_tailcall"`
 	KmEndpoint    *ebpf.MapSpec `ebpf:"km_endpoint"`
 	KmFrontend    *ebpf.MapSpec `ebpf:"km_frontend"`
@@ -147,6 +148,7 @@ type KmeshXDPAuthMaps struct {
 	KmAuthRes     *ebpf.Map `ebpf:"km_auth_res"`
 	KmAuthzPolicy *ebpf.Map `ebpf:"km_authz_policy"`
 	KmBackend     *ebpf.Map `ebpf:"km_backend"`
+	KmCgrTail6    *ebpf.Map `ebpf:"km_cgr_tail6"`
 	KmCgrTailcall *ebpf.Map `ebpf:"km_cgr_tailcall"`
 	KmEndpoint    *ebpf.Map `ebpf:"km_endpoint"`
 	KmFrontend    *ebpf.Map `ebpf:"km_frontend"`
@@ -170,6 +172,7 @@ func (m *KmeshXDPAuthMaps) Close() error {
 		m.KmAuthRes,
 		m.KmAuthzPolicy,
 		m.KmBackend,
+		m.KmCgrTail6,
 		m.KmCgrTailcall,
 		m.KmEndpoint,
 		m.KmFrontend,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshxdpauth_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshxdpauth_bpfel.go
@@ -98,6 +98,7 @@ type KmeshXDPAuthMapSpecs struct {
 	KmAuthRes     *ebpf.MapSpec `ebpf:"km_auth_res"`
 	KmAuthzPolicy *ebpf.MapSpec `ebpf:"km_authz_policy"`
 	KmBackend     *ebpf.MapSpec `ebpf:"km_backend"`
+	KmCgrTail6    *ebpf.MapSpec `ebpf:"km_cgr_tail6"`
 	KmCgrTailcall *ebpf.MapSpec `ebpf:"km_cgr_tailcall"`
 	KmEndpoint    *ebpf.MapSpec `ebpf:"km_endpoint"`
 	KmFrontend    *ebpf.MapSpec `ebpf:"km_frontend"`
@@ -147,6 +148,7 @@ type KmeshXDPAuthMaps struct {
 	KmAuthRes     *ebpf.Map `ebpf:"km_auth_res"`
 	KmAuthzPolicy *ebpf.Map `ebpf:"km_authz_policy"`
 	KmBackend     *ebpf.Map `ebpf:"km_backend"`
+	KmCgrTail6    *ebpf.Map `ebpf:"km_cgr_tail6"`
 	KmCgrTailcall *ebpf.Map `ebpf:"km_cgr_tailcall"`
 	KmEndpoint    *ebpf.Map `ebpf:"km_endpoint"`
 	KmFrontend    *ebpf.Map `ebpf:"km_frontend"`
@@ -170,6 +172,7 @@ func (m *KmeshXDPAuthMaps) Close() error {
 		m.KmAuthRes,
 		m.KmAuthzPolicy,
 		m.KmBackend,
+		m.KmCgrTail6,
 		m.KmCgrTailcall,
 		m.KmEndpoint,
 		m.KmFrontend,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshxdpauthcompat_bpfeb.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshxdpauthcompat_bpfeb.go
@@ -98,6 +98,7 @@ type KmeshXDPAuthCompatMapSpecs struct {
 	KmAuthRes     *ebpf.MapSpec `ebpf:"km_auth_res"`
 	KmAuthzPolicy *ebpf.MapSpec `ebpf:"km_authz_policy"`
 	KmBackend     *ebpf.MapSpec `ebpf:"km_backend"`
+	KmCgrTail6    *ebpf.MapSpec `ebpf:"km_cgr_tail6"`
 	KmCgrTailcall *ebpf.MapSpec `ebpf:"km_cgr_tailcall"`
 	KmEndpoint    *ebpf.MapSpec `ebpf:"km_endpoint"`
 	KmFrontend    *ebpf.MapSpec `ebpf:"km_frontend"`
@@ -147,6 +148,7 @@ type KmeshXDPAuthCompatMaps struct {
 	KmAuthRes     *ebpf.Map `ebpf:"km_auth_res"`
 	KmAuthzPolicy *ebpf.Map `ebpf:"km_authz_policy"`
 	KmBackend     *ebpf.Map `ebpf:"km_backend"`
+	KmCgrTail6    *ebpf.Map `ebpf:"km_cgr_tail6"`
 	KmCgrTailcall *ebpf.Map `ebpf:"km_cgr_tailcall"`
 	KmEndpoint    *ebpf.Map `ebpf:"km_endpoint"`
 	KmFrontend    *ebpf.Map `ebpf:"km_frontend"`
@@ -170,6 +172,7 @@ func (m *KmeshXDPAuthCompatMaps) Close() error {
 		m.KmAuthRes,
 		m.KmAuthzPolicy,
 		m.KmBackend,
+		m.KmCgrTail6,
 		m.KmCgrTailcall,
 		m.KmEndpoint,
 		m.KmFrontend,

--- a/bpf/kmesh/bpf2go/dualengine/kmeshxdpauthcompat_bpfel.go
+++ b/bpf/kmesh/bpf2go/dualengine/kmeshxdpauthcompat_bpfel.go
@@ -98,6 +98,7 @@ type KmeshXDPAuthCompatMapSpecs struct {
 	KmAuthRes     *ebpf.MapSpec `ebpf:"km_auth_res"`
 	KmAuthzPolicy *ebpf.MapSpec `ebpf:"km_authz_policy"`
 	KmBackend     *ebpf.MapSpec `ebpf:"km_backend"`
+	KmCgrTail6    *ebpf.MapSpec `ebpf:"km_cgr_tail6"`
 	KmCgrTailcall *ebpf.MapSpec `ebpf:"km_cgr_tailcall"`
 	KmEndpoint    *ebpf.MapSpec `ebpf:"km_endpoint"`
 	KmFrontend    *ebpf.MapSpec `ebpf:"km_frontend"`
@@ -147,6 +148,7 @@ type KmeshXDPAuthCompatMaps struct {
 	KmAuthRes     *ebpf.Map `ebpf:"km_auth_res"`
 	KmAuthzPolicy *ebpf.Map `ebpf:"km_authz_policy"`
 	KmBackend     *ebpf.Map `ebpf:"km_backend"`
+	KmCgrTail6    *ebpf.Map `ebpf:"km_cgr_tail6"`
 	KmCgrTailcall *ebpf.Map `ebpf:"km_cgr_tailcall"`
 	KmEndpoint    *ebpf.Map `ebpf:"km_endpoint"`
 	KmFrontend    *ebpf.Map `ebpf:"km_frontend"`
@@ -170,6 +172,7 @@ func (m *KmeshXDPAuthCompatMaps) Close() error {
 		m.KmAuthRes,
 		m.KmAuthzPolicy,
 		m.KmBackend,
+		m.KmCgrTail6,
 		m.KmCgrTailcall,
 		m.KmEndpoint,
 		m.KmFrontend,

--- a/bpf/kmesh/workload/cgroup_sock.c
+++ b/bpf/kmesh/workload/cgroup_sock.c
@@ -180,7 +180,7 @@ int cgroup_connect6_prog(struct bpf_sock_addr *ctx)
     SET_CTX_ADDRESS6(ctx, &kmesh_ctx.dnat_ip, kmesh_ctx.dnat_port);
 
     if (kmesh_ctx.via_waypoint) {
-        kmesh_workload_tail_call(ctx, TAIL_CALL_CONNECT6_INDEX);
+        kmesh_workload_tail_call6(ctx, TAIL_CALL_CONNECT6_INDEX);
 
         // if tail call failed will run this code
         BPF_LOG(ERR, KMESH, "workload tail call6 failed, err is %d\n", ret);

--- a/bpf/kmesh/workload/include/config.h
+++ b/bpf/kmesh/workload/include/config.h
@@ -15,20 +15,21 @@
 #define MAP_SIZE_OF_AUTH_POLICY   512
 
 // rename map to avoid truncation when name length exceeds BPF_OBJ_NAME_LEN = 16
-#define map_of_frontend      km_frontend
-#define map_of_service       km_service
-#define map_of_endpoint      km_endpoint
-#define map_of_backend       km_backend
-#define map_of_auth_result   km_auth_res
-#define map_of_auth_req      km_auth_req
-#define map_of_tcp_probe     km_tcp_probe
-#define map_of_authz_policy  km_authz_policy
-#define map_of_cgr_tail_call km_cgr_tailcall
-#define map_of_xdp_tailcall  km_xdp_tailcall
-#define map_of_kmesh_socket  km_socket
-#define kmesh_tc_args        km_tcargs
-#define map_of_wl_policy     km_wlpolicy
-#define kmesh_perf_map       km_perf_map
-#define kmesh_perf_info      km_perf_info
+#define map_of_frontend       km_frontend
+#define map_of_service        km_service
+#define map_of_endpoint       km_endpoint
+#define map_of_backend        km_backend
+#define map_of_auth_result    km_auth_res
+#define map_of_auth_req       km_auth_req
+#define map_of_tcp_probe      km_tcp_probe
+#define map_of_authz_policy   km_authz_policy
+#define map_of_cgr_tail_call  km_cgr_tailcall
+#define map_of_cgr_tail_call6 km_cgr_tail6
+#define map_of_xdp_tailcall   km_xdp_tailcall
+#define map_of_kmesh_socket   km_socket
+#define kmesh_tc_args         km_tcargs
+#define map_of_wl_policy      km_wlpolicy
+#define kmesh_perf_map        km_perf_map
+#define kmesh_perf_info       km_perf_info
 
 #endif // _CONFIG_H_

--- a/bpf/kmesh/workload/include/tail_call.h
+++ b/bpf/kmesh/workload/include/tail_call.h
@@ -31,6 +31,14 @@ struct {
     __uint(map_flags, 0);
 } map_of_cgr_tail_call SEC(".maps");
 
+struct {
+    __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
+    __uint(key_size, sizeof(__u32));
+    __uint(value_size, sizeof(__u32));
+    __uint(max_entries, MAP_SIZE_OF_TAIL_CALL_PROG);
+    __uint(map_flags, 0);
+} map_of_cgr_tail_call6 SEC(".maps");
+
 // map_of_xdp_tailcall is used to store xdp tail call progs
 struct {
     __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
@@ -43,6 +51,11 @@ struct {
 static inline void kmesh_workload_tail_call(ctx_buff_t *ctx, const __u32 index)
 {
     bpf_tail_call(ctx, &map_of_cgr_tail_call, index);
+}
+
+static inline void kmesh_workload_tail_call6(ctx_buff_t *ctx, const __u32 index)
+{
+    bpf_tail_call(ctx, &map_of_cgr_tail_call6, index);
 }
 
 #endif

--- a/pkg/bpf/workload/sock_connection.go
+++ b/pkg/bpf/workload/sock_connection.go
@@ -114,7 +114,7 @@ func (sc *SockConnWorkload) LoadSockConn() error {
 	sc.Info6.Type = prog.Type
 	sc.Info6.AttachType = prog.AttachType
 
-	if err = sc.KmCgrTailcall.Update(
+	if err = sc.KmCgrTail6.Update(
 		uint32(constants.TailCallConnect6Index),
 		uint32(sc.CgroupConnect6Prog.FD()),
 		ebpf.UpdateAny); err != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Uses separate program-array maps for the IPv4 and IPv6 workload tail calls.

Newer kernels track the expected attach type for program arrays. Sharing one map causes the IPv6 program load to fail with `EINVAL`, which prevents Kmesh from starting.

**Which issue(s) this PR fixes**:

Fixes #1806

**Special notes for your reviewer**:

The generated BPF bindings are updated to include the IPv6 tail-call map.

**Does this PR introduce a user-facing change?**:

```release-note
NONE