### PR TITLE
wip(debug): instrument BPF workload loaders to diagnose verifier rejection

### DIFF
--- a/bpf/include/bpf_common.h
+++ b/bpf/include/bpf_common.h
@@ -100,7 +100,7 @@ struct {
  * From v5.4, bpf_get_netns_cookie can be called for bpf cgroup hooks, from v5.15, it can be called for bpf sockops
  * hook. Therefore, ensure that function is correctly used.
  */
-static inline void record_manager_netns_cookie(struct bpf_sock_addr *ctx)
+static inline __attribute__((always_inline)) void record_manager_netns_cookie(struct bpf_sock_addr *ctx)
 {
     int err;
     struct manager_key key = {0};
@@ -116,7 +116,7 @@ static inline void record_manager_netns_cookie(struct bpf_sock_addr *ctx)
  * From v5.4, bpf_get_netns_cookie can be called for bpf cgroup hooks, from v5.15, it can be called for bpf sockops
  * hook. Therefore, ensure that function is correctly used.
  */
-static inline bool is_kmesh_enabled(struct bpf_sock_addr *ctx)
+static inline __attribute__((always_inline)) bool is_kmesh_enabled(struct bpf_sock_addr *ctx)
 {
     struct manager_key key = {0};
     key.netns_cookie = bpf_get_netns_cookie(ctx);
@@ -127,7 +127,7 @@ static inline bool is_kmesh_enabled(struct bpf_sock_addr *ctx)
  * From v5.4, bpf_get_netns_cookie can be called for bpf cgroup hooks, from v5.15, it can be called for bpf sockops
  * hook. Therefore, ensure that function is correctly used.
  */
-static inline void remove_manager_netns_cookie(struct bpf_sock_addr *ctx)
+static inline __attribute__((always_inline)) void remove_manager_netns_cookie(struct bpf_sock_addr *ctx)
 {
     int err;
     struct manager_key key = {0};
@@ -138,7 +138,8 @@ static inline void remove_manager_netns_cookie(struct bpf_sock_addr *ctx)
         BPF_LOG(ERR, KMESH, "remove netcookie failed!, err is %d\n", err);
 }
 
-static inline bool is_control_connect(struct kmesh_context *kmesh_ctx, __u32 ip, __u32 port)
+static inline __attribute__((always_inline)) bool
+is_control_connect(struct kmesh_context *kmesh_ctx, __u32 ip, __u32 port)
 {
     if (bpf_ntohs(kmesh_ctx->ctx->user_port) != port)
         return false;
@@ -151,14 +152,14 @@ static inline bool is_control_connect(struct kmesh_context *kmesh_ctx, __u32 ip,
         && kmesh_ctx->orig_dst_addr.ip6[2] == 0 && bpf_ntohl(kmesh_ctx->orig_dst_addr.ip6[3]) == ip);
 }
 
-static inline bool conn_from_cni_sim_add(struct kmesh_context *kmesh_ctx)
+static inline __attribute__((always_inline)) bool conn_from_cni_sim_add(struct kmesh_context *kmesh_ctx)
 {
     // cni sim connect CONTROL_CMD_IP:929(0x3a1)
     // 0x3a1 is the specific port handled by the cni to enable Kmesh
     return is_control_connect(kmesh_ctx, CONTROL_CMD_IP, ENABLE_KMESH_PORT);
 }
 
-static inline bool conn_from_cni_sim_delete(struct kmesh_context *kmesh_ctx)
+static inline __attribute__((always_inline)) bool conn_from_cni_sim_delete(struct kmesh_context *kmesh_ctx)
 {
     // cni sim connect CONTROL_CMD_IP:930(0x3a2)
     // 0x3a2 is the specific port handled by the cni to disable Kmesh
@@ -169,7 +170,7 @@ static inline bool conn_from_cni_sim_delete(struct kmesh_context *kmesh_ctx)
  * records of pods managed by kmesh. When the record exists
  * and the value is 0, it means it is managed by kmesh.
  */
-static inline bool handle_kmesh_manage_process(struct kmesh_context *kmesh_ctx)
+static inline __attribute__((always_inline)) bool handle_kmesh_manage_process(struct kmesh_context *kmesh_ctx)
 {
     if (conn_from_cni_sim_add(kmesh_ctx)) {
         record_manager_netns_cookie(kmesh_ctx->ctx);
@@ -185,14 +186,14 @@ static inline bool handle_kmesh_manage_process(struct kmesh_context *kmesh_ctx)
     return false;
 }
 
-static inline void kmesh_parse_outer_key(__u32 outer_key, __u8 *type, __u32 *inner_idx)
+static inline __attribute__((always_inline)) void kmesh_parse_outer_key(__u32 outer_key, __u8 *type, __u32 *inner_idx)
 {
     *type = MAP_GET_TYPE(outer_key);
     *inner_idx = MAP_GET_INDEX(outer_key);
     return;
 }
 
-static inline void *get_ptr_val_from_map(void *map, __u8 map_type, const void *ptr)
+static inline __attribute__((always_inline)) void *get_ptr_val_from_map(void *map, __u8 map_type, const void *ptr)
 {
     __u8 type;
     __u32 inner_idx;
@@ -232,7 +233,7 @@ static inline void *get_ptr_val_from_map(void *map, __u8 map_type, const void *p
         val_tmp;                                                                                                       \
     })
 
-static inline void record_kmesh_managed_ip(__u32 family, __u32 ip4, __u32 *ip6)
+static inline __attribute__((always_inline)) void record_kmesh_managed_ip(__u32 family, __u32 ip4, __u32 *ip6)
 {
     int err;
     __u32 value = 0;
@@ -247,7 +248,7 @@ static inline void record_kmesh_managed_ip(__u32 family, __u32 ip4, __u32 *ip6)
         BPF_LOG(ERR, KMESH, "record ip failed, err is %d\n", err);
 }
 
-static inline void remove_kmesh_managed_ip(__u32 family, __u32 ip4, __u32 *ip6)
+static inline __attribute__((always_inline)) void remove_kmesh_managed_ip(__u32 family, __u32 ip4, __u32 *ip6)
 {
     struct manager_key key = {0};
     if (family == AF_INET)
@@ -260,7 +261,7 @@ static inline void remove_kmesh_managed_ip(__u32 family, __u32 ip4, __u32 *ip6)
         BPF_LOG(ERR, KMESH, "remove ip failed, err is %d\n", err);
 }
 
-static inline bool sock_conn_from_sim(struct __sk_buff *skb)
+static inline __attribute__((always_inline)) bool sock_conn_from_sim(struct __sk_buff *skb)
 {
     __u16 dst_port = (__u16)(skb->remote_port >> 16);
     if (bpf_ntohs(dst_port) != ENABLE_KMESH_PORT && bpf_ntohs(dst_port) != DISABLE_KMESH_PORT)
@@ -275,7 +276,7 @@ static inline bool sock_conn_from_sim(struct __sk_buff *skb)
         remote_ip6[0] == 0 && remote_ip6[1] == 0 && remote_ip6[2] == 0 && bpf_ntohl(remote_ip6[3]) == CONTROL_CMD_IP);
 }
 
-static inline bool conn_from_sim(struct bpf_sock_ops *skops, __u32 ip, __u16 port)
+static inline __attribute__((always_inline)) bool conn_from_sim(struct bpf_sock_ops *skops, __u32 ip, __u16 port)
 {
     __u16 remote_port = GET_SKOPS_REMOTE_PORT(skops);
     if (bpf_ntohs(remote_port) != port)
@@ -289,21 +290,21 @@ static inline bool conn_from_sim(struct bpf_sock_ops *skops, __u32 ip, __u16 por
         && bpf_ntohl(skops->remote_ip6[3]) == ip);
 }
 
-static inline bool skops_conn_from_cni_sim_add(struct bpf_sock_ops *skops)
+static inline __attribute__((always_inline)) bool skops_conn_from_cni_sim_add(struct bpf_sock_ops *skops)
 {
     // cni sim connect CONTROL_CMD_IP:929(0x3a1)
     // 0x3a1 is the specific port handled by the cni to enable Kmesh
     return conn_from_sim(skops, CONTROL_CMD_IP, ENABLE_KMESH_PORT);
 }
 
-static inline bool skops_conn_from_cni_sim_delete(struct bpf_sock_ops *skops)
+static inline __attribute__((always_inline)) bool skops_conn_from_cni_sim_delete(struct bpf_sock_ops *skops)
 {
     // cni sim connect CONTROL_CMD_IP:930(0x3a2)
     // 0x3a2 is the specific port handled by the cni to disable Kmesh
     return conn_from_sim(skops, CONTROL_CMD_IP, DISABLE_KMESH_PORT);
 }
 
-static inline void skops_handle_kmesh_managed_process(struct bpf_sock_ops *skops)
+static inline __attribute__((always_inline)) void skops_handle_kmesh_managed_process(struct bpf_sock_ops *skops)
 {
     if (skops_conn_from_cni_sim_add(skops))
         record_kmesh_managed_ip(skops->family, skops->local_ip4, skops->local_ip6);
@@ -311,7 +312,7 @@ static inline void skops_handle_kmesh_managed_process(struct bpf_sock_ops *skops
         remove_kmesh_managed_ip(skops->family, skops->local_ip4, skops->local_ip6);
 }
 
-static inline bool is_managed_by_kmesh(struct bpf_sock_ops *skops)
+static inline __attribute__((always_inline)) bool is_managed_by_kmesh(struct bpf_sock_ops *skops)
 {
     struct manager_key key = {0};
     if (skops->family == AF_INET)
@@ -329,7 +330,7 @@ static inline bool is_managed_by_kmesh(struct bpf_sock_ops *skops)
     return (*value == 0);
 }
 
-static inline bool is_managed_by_kmesh_skb(struct __sk_buff *skb)
+static inline __attribute__((always_inline)) bool is_managed_by_kmesh_skb(struct __sk_buff *skb)
 {
     struct manager_key key = {0};
     if (skb->family == AF_INET)

--- a/bpf/include/common.h
+++ b/bpf/include/common.h
@@ -68,23 +68,23 @@ typedef struct {
     char *data;
 } bytes;
 
-static inline void *kmesh_map_lookup_elem(void *map, const void *key)
+static inline __attribute__((always_inline)) void *kmesh_map_lookup_elem(void *map, const void *key)
 {
     return bpf_map_lookup_elem(map, key);
 }
 
-static inline int kmesh_map_delete_elem(void *map, const void *key)
+static inline __attribute__((always_inline)) int kmesh_map_delete_elem(void *map, const void *key)
 {
     return (int)bpf_map_delete_elem(map, key);
 }
 
-static inline int kmesh_map_update_elem(void *map, const void *key, const void *value)
+static inline __attribute__((always_inline)) int kmesh_map_update_elem(void *map, const void *key, const void *value)
 {
     // TODO: Duplicate element, status update
     return (int)bpf_map_update_elem(map, key, value, BPF_ANY);
 }
 
-static inline bool is_ipv4_mapped_addr(__u32 ip6[4])
+static inline __attribute__((always_inline)) bool is_ipv4_mapped_addr(__u32 ip6[4])
 {
     return ip6[0] == 0 && ip6[1] == 0 && ip6[2] == 0xFFFF0000;
 }
@@ -149,14 +149,14 @@ struct {
  */
 
 #if KERNEL_VERSION_HIGHER_5_13_0
-static inline int convert_v4(char *data, __u32 *ip)
+static inline __attribute__((always_inline)) int convert_v4(char *data, __u32 *ip)
 {
     int ret = 0;
     ret = BPF_SNPRINTF(data, MAX_IP4_LEN, "%pI4h", ip);
     return ret;
 }
 #else
-static inline int convert_v4(char *data, __u32 *ip_ptr)
+static inline __attribute__((always_inline)) int convert_v4(char *data, __u32 *ip_ptr)
 {
     __u32 ip = *ip_ptr;
     __u8 ip1 = (ip >> 24) & 0xFF;
@@ -214,14 +214,14 @@ static inline int convert_v4(char *data, __u32 *ip_ptr)
 #endif
 
 #if KERNEL_VERSION_HIGHER_5_13_0
-static inline int convert_v6(char *data, __u32 *ip6)
+static inline __attribute__((always_inline)) int convert_v6(char *data, __u32 *ip6)
 {
     int ret = 0;
     ret = BPF_SNPRINTF(data, MAX_IP6_LEN, "%pI6", ip6);
     return ret;
 }
 #else
-static inline int convert_v6(char *data, __u32 *ip6)
+static inline __attribute__((always_inline)) int convert_v6(char *data, __u32 *ip6)
 {
     const char hex_digits[16] = "0123456789abcdef";
 #pragma clang loop unroll(full)
@@ -249,7 +249,7 @@ static inline int convert_v6(char *data, __u32 *ip6)
 
 /* 2001:0db8:3333:4444:CCCC:DDDD:EEEE:FFFF */
 /* 192.168.000.001 */
-static inline char *ip2str(__u32 *ip_ptr, bool v4)
+static inline __attribute__((always_inline)) char *ip2str(__u32 *ip_ptr, bool v4)
 {
     struct buf *buf;
     int zero = 0;

--- a/bpf/kmesh/general/include/tc.h
+++ b/bpf/kmesh/general/include/tc.h
@@ -28,17 +28,17 @@ struct tc_info {
 #define PARSER_SUCC          0
 #define IPSEC_DECRYPTED_MARK 0x00d0
 
-static inline bool is_ipv4(struct tc_info *info)
+static inline __attribute__((always_inline)) bool is_ipv4(struct tc_info *info)
 {
     return info->ethh->h_proto == bpf_htons(ETH_P_IP);
 }
 
-static inline bool is_ipv6(struct tc_info *info)
+static inline __attribute__((always_inline)) bool is_ipv6(struct tc_info *info)
 {
     return info->ethh->h_proto == bpf_htons(ETH_P_IPV6);
 }
 
-static inline int parser_tc_info(struct __sk_buff *ctx, struct tc_info *info)
+static inline __attribute__((always_inline)) int parser_tc_info(struct __sk_buff *ctx, struct tc_info *info)
 {
     void *begin = (void *)(long)(ctx->data);
     void *end = (void *)(long)(ctx->data_end);

--- a/bpf/kmesh/probes/performance_probe.h
+++ b/bpf/kmesh/probes/performance_probe.h
@@ -39,7 +39,7 @@ struct {
     __uint(max_entries, RINGBUF_SIZE);
 } kmesh_perf_info SEC(".maps");
 
-static inline void performance_report(struct operation_usage_data *data)
+static inline __attribute__((always_inline)) void performance_report(struct operation_usage_data *data)
 {
     struct operation_usage_data *info = NULL;
     info = bpf_ringbuf_reserve(&kmesh_perf_info, sizeof(struct operation_usage_data), 0);
@@ -54,7 +54,8 @@ static inline void performance_report(struct operation_usage_data *data)
     bpf_ringbuf_submit(info, 0);
 }
 
-static inline void observe_on_operation_start(__u32 operation_type, struct kmesh_context *kmesh_ctx)
+static inline __attribute__((always_inline)) void
+observe_on_operation_start(__u32 operation_type, struct kmesh_context *kmesh_ctx)
 {
 #if PERF_MONITOR
     struct operation_usage_data data = {};
@@ -72,7 +73,8 @@ static inline void observe_on_operation_start(__u32 operation_type, struct kmesh
 #endif
 }
 
-static inline void observe_on_operation_end(__u32 operation_type, struct kmesh_context *kmesh_ctx)
+static inline __attribute__((always_inline)) void
+observe_on_operation_end(__u32 operation_type, struct kmesh_context *kmesh_ctx)
 {
 #if PERF_MONITOR
     struct operation_usage_key key = {};

--- a/bpf/kmesh/probes/probe.h
+++ b/bpf/kmesh/probes/probe.h
@@ -11,12 +11,12 @@
 
 volatile __u32 enable_monitoring = 1;
 
-static inline bool is_monitoring_enable()
+static inline __attribute__((always_inline)) bool is_monitoring_enable()
 {
     return enable_monitoring == 1;
 }
 
-static inline void observe_on_pre_connect(struct bpf_sock *sk)
+static inline __attribute__((always_inline)) void observe_on_pre_connect(struct bpf_sock *sk)
 {
     struct sock_storage_data *storage = NULL;
     if (!sk)
@@ -32,7 +32,7 @@ static inline void observe_on_pre_connect(struct bpf_sock *sk)
     return;
 }
 
-static inline void observe_on_connect_established(struct bpf_sock *sk, __u8 direction)
+static inline __attribute__((always_inline)) void observe_on_connect_established(struct bpf_sock *sk, __u8 direction)
 {
     if (!is_monitoring_enable()) {
         return;
@@ -62,7 +62,7 @@ static inline void observe_on_connect_established(struct bpf_sock *sk, __u8 dire
     tcp_report(sk, tcp_sock, storage, BPF_TCP_ESTABLISHED);
 }
 
-static inline void observe_on_close(struct bpf_sock *sk)
+static inline __attribute__((always_inline)) void observe_on_close(struct bpf_sock *sk)
 {
     if (!is_monitoring_enable()) {
         return;
@@ -84,7 +84,7 @@ static inline void observe_on_close(struct bpf_sock *sk)
     tcp_report(sk, tcp_sock, storage, BPF_TCP_CLOSE);
 }
 
-static inline void observe_on_data(struct bpf_sock *sk)
+static inline __attribute__((always_inline)) void observe_on_data(struct bpf_sock *sk)
 {
     struct bpf_tcp_sock *tcp_sock = NULL;
     struct sock_storage_data *storage = NULL;

--- a/bpf/kmesh/probes/tcp_probe.h
+++ b/bpf/kmesh/probes/tcp_probe.h
@@ -56,7 +56,8 @@ struct {
     __uint(max_entries, 256 * 1024 /* 256 KB */);
 } map_of_tcp_probe SEC(".maps");
 
-static inline void construct_tuple(struct bpf_sock *sk, struct bpf_sock_tuple *tuple, __u8 direction)
+static inline __attribute__((always_inline)) void
+construct_tuple(struct bpf_sock *sk, struct bpf_sock_tuple *tuple, __u8 direction)
 {
     if (direction == OUTBOUND) {
         if (sk->family == AF_INET) {
@@ -97,7 +98,8 @@ static inline void construct_tuple(struct bpf_sock *sk, struct bpf_sock_tuple *t
     return;
 }
 
-static inline void get_tcp_probe_info(struct bpf_tcp_sock *tcp_sock, struct tcp_probe_info *info)
+static inline __attribute__((always_inline)) void
+get_tcp_probe_info(struct bpf_tcp_sock *tcp_sock, struct tcp_probe_info *info)
 {
     info->sent_bytes = tcp_sock->bytes_acked; // bytes_acked means already acked sent bytes
     info->received_bytes = tcp_sock->bytes_received;
@@ -110,7 +112,7 @@ static inline void get_tcp_probe_info(struct bpf_tcp_sock *tcp_sock, struct tcp_
 
 // construct_orig_dst_info try to read the dst_info from map_of_sock_storage first
 // if not found, use the tuple info for orig_dst
-static inline void
+static inline __attribute__((always_inline)) void
 construct_orig_dst_info(struct bpf_sock *sk, struct sock_storage_data *storage, struct tcp_probe_info *info)
 {
     if (sk->family == AF_INET) {
@@ -127,7 +129,7 @@ construct_orig_dst_info(struct bpf_sock *sk, struct sock_storage_data *storage, 
     }
 }
 
-static inline void
+static inline __attribute__((always_inline)) void
 tcp_report(struct bpf_sock *sk, struct bpf_tcp_sock *tcp_sock, struct sock_storage_data *storage, __u32 state)
 {
     struct tcp_probe_info *info = NULL;

--- a/bpf/kmesh/workload/cgroup_skb.c
+++ b/bpf/kmesh/workload/cgroup_skb.c
@@ -13,7 +13,7 @@
 
 volatile __u32 enable_periodic_report = 0;
 
-static inline bool is__periodic_report_enable()
+static inline __attribute__((always_inline)) bool is__periodic_report_enable()
 {
     return enable_periodic_report == 1;
 }

--- a/bpf/kmesh/workload/cgroup_sock.c
+++ b/bpf/kmesh/workload/cgroup_sock.c
@@ -12,7 +12,7 @@
 #include "probe.h"
 #include <bpf/bpf_endian.h>
 
-static inline int sock_traffic_control(struct kmesh_context *kmesh_ctx)
+static inline __attribute__((always_inline)) int sock_traffic_control(struct kmesh_context *kmesh_ctx)
 {
     observe_on_operation_start(SOCK_TRAFFIC_CONTROL, kmesh_ctx);
     int ret;
@@ -57,7 +57,7 @@ static inline int sock_traffic_control(struct kmesh_context *kmesh_ctx)
     return 0;
 }
 
-static inline int set_original_dst_info(struct kmesh_context *kmesh_ctx)
+static inline __attribute__((always_inline)) int set_original_dst_info(struct kmesh_context *kmesh_ctx)
 {
     struct bpf_sock *sk = (struct bpf_sock *)kmesh_ctx->ctx->sk;
     ctx_buff_t *ctx = (ctx_buff_t *)kmesh_ctx->ctx;

--- a/bpf/kmesh/workload/include/authz.h
+++ b/bpf/kmesh/workload/include/authz.h
@@ -69,17 +69,17 @@ struct MatchIpParams {
     int ip_type;
 };
 
-static inline Istio__Security__Authorization *map_lookup_authz(__u32 policyKey)
+static inline __attribute__((always_inline)) Istio__Security__Authorization *map_lookup_authz(__u32 policyKey)
 {
     return (Istio__Security__Authorization *)kmesh_map_lookup_elem(&map_of_authz_policy, &policyKey);
 }
 
-static inline wl_policies_v *get_workload_policies_by_uid(__u32 workload_uid)
+static inline __attribute__((always_inline)) wl_policies_v *get_workload_policies_by_uid(__u32 workload_uid)
 {
     return (wl_policies_v *)kmesh_map_lookup_elem(&map_of_wl_policy, &workload_uid);
 }
 
-static inline int parser_xdp_info(struct xdp_md *ctx, struct xdp_info *info)
+static inline __attribute__((always_inline)) int parser_xdp_info(struct xdp_md *ctx, struct xdp_info *info)
 {
     void *begin = (void *)(long)(ctx->data);
     void *end = (void *)(long)(ctx->data_end);
@@ -112,7 +112,7 @@ static inline int parser_xdp_info(struct xdp_md *ctx, struct xdp_info *info)
     return PARSER_SUCC;
 }
 
-static inline void parser_tuple(struct xdp_info *info, struct bpf_sock_tuple *tuple_info)
+static inline __attribute__((always_inline)) void parser_tuple(struct xdp_info *info, struct bpf_sock_tuple *tuple_info)
 {
     if (info->iph->version == IPV4_VERSION) {
         tuple_info->ipv4.saddr = info->iph->saddr;
@@ -205,7 +205,8 @@ static int match_dst_ports(Istio__Security__Match *match, struct xdp_info *info,
 /* This function is used to convert the IP address
  * from big-endian storage to u32 type data.
  */
-static inline __u32 convert_ipv4_to_u32(const struct ProtobufCBinaryData *ipv4_data, bool is_ipv4_in_ipv6)
+static inline __attribute__((always_inline)) __u32
+convert_ipv4_to_u32(const struct ProtobufCBinaryData *ipv4_data, bool is_ipv4_in_ipv6)
 {
     if (!ipv4_data->data || (ipv4_data->len != 4 && ipv4_data->len != 16)) {
         return 0;
@@ -226,7 +227,8 @@ static inline __u32 convert_ipv4_to_u32(const struct ProtobufCBinaryData *ipv4_d
     return (data[0] << 24) | (data[1] << 16) | (data[2] << 8) | (data[3]);
 }
 
-static inline __u32 convert_ipv6_to_ip6addr(struct ip_addr *rule_addr, const struct ProtobufCBinaryData *ipv6_data)
+static inline __attribute__((always_inline)) __u32
+convert_ipv6_to_ip6addr(struct ip_addr *rule_addr, const struct ProtobufCBinaryData *ipv6_data)
 {
     if (!rule_addr || !ipv6_data)
         return CONVERT_FAILED;
@@ -251,7 +253,7 @@ static inline __u32 convert_ipv6_to_ip6addr(struct ip_addr *rule_addr, const str
 // reference cilium https://github.com/cilium/cilium/blob/main/bpf/lib/ipv6.h#L122
 #define GET_PREFIX(PREFIX) bpf_htonl(PREFIX <= 0 ? 0 : PREFIX < 32 ? ((1 << PREFIX) - 1) << (32 - PREFIX) : 0xFFFFFFFF)
 
-static inline void ipv6_addr_clear_suffix(__u32 ip6[4], int prefix)
+static inline __attribute__((always_inline)) void ipv6_addr_clear_suffix(__u32 ip6[4], int prefix)
 {
     ip6[0] &= GET_PREFIX(prefix);
     prefix -= 32;
@@ -262,7 +264,8 @@ static inline void ipv6_addr_clear_suffix(__u32 ip6[4], int prefix)
     ip6[3] &= GET_PREFIX(prefix);
 }
 
-static inline int match_ipv4_rule(__u32 ruleIp, __u32 preFixLen, struct bpf_sock_tuple *tuple_info, __u8 type)
+static inline __attribute__((always_inline)) int
+match_ipv4_rule(__u32 ruleIp, __u32 preFixLen, struct bpf_sock_tuple *tuple_info, __u8 type)
 {
     __u32 mask = 0;
     __be32 targetIP = (type & TYPE_SRCIP) ? tuple_info->ipv4.saddr : tuple_info->ipv4.daddr;
@@ -278,7 +281,8 @@ static inline int match_ipv4_rule(__u32 ruleIp, __u32 preFixLen, struct bpf_sock
     return UNMATCHED;
 }
 
-static inline int match_ipv6_rule(struct ip_addr *rule_addr, struct ip_addr *target_addr, __u32 prefixLen)
+static inline __attribute__((always_inline)) int
+match_ipv6_rule(struct ip_addr *rule_addr, struct ip_addr *target_addr, __u32 prefixLen)
 {
     if (prefixLen > 128)
         return UNMATCHED;
@@ -292,7 +296,7 @@ static inline int match_ipv6_rule(struct ip_addr *rule_addr, struct ip_addr *tar
     return UNMATCHED;
 }
 
-static inline int
+static inline __attribute__((always_inline)) int
 match_ip_rule(struct ProtobufCBinaryData *addrInfo, __u32 preFixLen, struct bpf_sock_tuple *tuple_info, __u8 type)
 {
     if (!addrInfo || addrInfo->len == 0) {
@@ -327,7 +331,7 @@ match_ip_rule(struct ProtobufCBinaryData *addrInfo, __u32 preFixLen, struct bpf_
     return UNMATCHED;
 }
 
-static inline int match_ip_common(struct MatchIpParams *params)
+static inline __attribute__((always_inline)) int match_ip_common(struct MatchIpParams *params)
 {
     void *ipPtrs = NULL;
     void *notIpPtrs = NULL;
@@ -411,7 +415,8 @@ static inline int match_ip_common(struct MatchIpParams *params)
     return UNMATCHED;
 }
 
-static inline int match_src_ip(Istio__Security__Match *match, struct bpf_sock_tuple *tuple_info)
+static inline __attribute__((always_inline)) int
+match_src_ip(Istio__Security__Match *match, struct bpf_sock_tuple *tuple_info)
 {
     if (!match || !tuple_info) {
         return UNMATCHED;
@@ -428,7 +433,8 @@ static inline int match_src_ip(Istio__Security__Match *match, struct bpf_sock_tu
     return match_ip_common(&params);
 }
 
-static inline int match_dst_ip(Istio__Security__Match *match, struct bpf_sock_tuple *tuple_info)
+static inline __attribute__((always_inline)) int
+match_dst_ip(Istio__Security__Match *match, struct bpf_sock_tuple *tuple_info)
 {
     if (!match || !tuple_info) {
         return UNMATCHED;
@@ -445,7 +451,8 @@ static inline int match_dst_ip(Istio__Security__Match *match, struct bpf_sock_tu
     return match_ip_common(&params);
 }
 
-static inline int match_IPs(Istio__Security__Match *match, struct bpf_sock_tuple *tuple_info)
+static inline __attribute__((always_inline)) int
+match_IPs(Istio__Security__Match *match, struct bpf_sock_tuple *tuple_info)
 {
     return match_src_ip(match, tuple_info) && match_dst_ip(match, tuple_info);
 }

--- a/bpf/kmesh/workload/include/backend.h
+++ b/bpf/kmesh/workload/include/backend.h
@@ -7,12 +7,13 @@
 #include "workload_common.h"
 #include "tail_call.h"
 
-static inline backend_value *map_lookup_backend(const backend_key *key)
+static inline __attribute__((always_inline)) backend_value *map_lookup_backend(const backend_key *key)
 {
     return kmesh_map_lookup_elem(&map_of_backend, key);
 }
 
-static inline int waypoint_manager(struct kmesh_context *kmesh_ctx, struct ip_addr *wp_addr, __u32 port)
+static inline __attribute__((always_inline)) int
+waypoint_manager(struct kmesh_context *kmesh_ctx, struct ip_addr *wp_addr, __u32 port)
 {
     ctx_buff_t *ctx = (ctx_buff_t *)kmesh_ctx->ctx;
 
@@ -25,7 +26,8 @@ static inline int waypoint_manager(struct kmesh_context *kmesh_ctx, struct ip_ad
     return 0;
 }
 
-static inline int svc_dnat(struct kmesh_context *kmesh_ctx, backend_value *backend_v, service_value *service_v)
+static inline __attribute__((always_inline)) int
+svc_dnat(struct kmesh_context *kmesh_ctx, backend_value *backend_v, service_value *service_v)
 {
     int i;
     ctx_buff_t *ctx = (ctx_buff_t *)kmesh_ctx->ctx;
@@ -53,7 +55,7 @@ static inline int svc_dnat(struct kmesh_context *kmesh_ctx, backend_value *backe
     return -ENOENT;
 }
 
-static inline int
+static inline __attribute__((always_inline)) int
 backend_manager(struct kmesh_context *kmesh_ctx, backend_value *backend_v, __u32 service_id, service_value *service_v)
 {
     int ret = -ENOENT;

--- a/bpf/kmesh/workload/include/endpoint.h
+++ b/bpf/kmesh/workload/include/endpoint.h
@@ -7,12 +7,12 @@
 #include "workload_common.h"
 #include "backend.h"
 
-static inline endpoint_value *map_lookup_endpoint(const endpoint_key *key)
+static inline __attribute__((always_inline)) endpoint_value *map_lookup_endpoint(const endpoint_key *key)
 {
     return kmesh_map_lookup_elem(&map_of_endpoint, key);
 }
 
-static inline int endpoint_manager(
+static inline __attribute__((always_inline)) int endpoint_manager(
     struct kmesh_context *kmesh_ctx, endpoint_value *endpoint_v, __u32 service_id, service_value *service_v)
 {
     int ret = 0;

--- a/bpf/kmesh/workload/include/frontend.h
+++ b/bpf/kmesh/workload/include/frontend.h
@@ -8,12 +8,13 @@
 #include "service.h"
 #include "backend.h"
 
-static inline frontend_value *map_lookup_frontend(const frontend_key *key)
+static inline __attribute__((always_inline)) frontend_value *map_lookup_frontend(const frontend_key *key)
 {
     return kmesh_map_lookup_elem(&map_of_frontend, key);
 }
 
-static inline int frontend_manager(struct kmesh_context *kmesh_ctx, frontend_value *frontend_v)
+static inline __attribute__((always_inline)) int
+frontend_manager(struct kmesh_context *kmesh_ctx, frontend_value *frontend_v)
 {
     int ret = 0;
     service_key service_k = {0};

--- a/bpf/kmesh/workload/include/service.h
+++ b/bpf/kmesh/workload/include/service.h
@@ -7,12 +7,13 @@
 #include "workload_common.h"
 #include "endpoint.h"
 
-static inline service_value *map_lookup_service(const service_key *key)
+static inline __attribute__((always_inline)) service_value *map_lookup_service(const service_key *key)
 {
     return kmesh_map_lookup_elem(&map_of_service, key);
 }
 
-static inline int lb_random_handle(struct kmesh_context *kmesh_ctx, __u32 service_id, service_value *service_v)
+static inline __attribute__((always_inline)) int
+lb_random_handle(struct kmesh_context *kmesh_ctx, __u32 service_id, service_value *service_v)
 {
     int ret = 0;
     endpoint_key endpoint_k = {0};
@@ -46,7 +47,8 @@ static inline int lb_random_handle(struct kmesh_context *kmesh_ctx, __u32 servic
 }
 
 // TODO: reuse with lb_random_handle
-static inline int lb_locality_strict_handle(struct kmesh_context *kmesh_ctx, __u32 service_id, service_value *service_v)
+static inline __attribute__((always_inline)) int
+lb_locality_strict_handle(struct kmesh_context *kmesh_ctx, __u32 service_id, service_value *service_v)
 {
     int ret = -ENOENT;
     endpoint_key endpoint_k = {0};
@@ -71,7 +73,7 @@ static inline int lb_locality_strict_handle(struct kmesh_context *kmesh_ctx, __u
     return ret;
 }
 
-static inline int
+static inline __attribute__((always_inline)) int
 lb_locality_failover_handle(struct kmesh_context *kmesh_ctx, __u32 service_id, service_value *service_v)
 {
     int i, ret = -ENOENT;
@@ -103,7 +105,8 @@ lb_locality_failover_handle(struct kmesh_context *kmesh_ctx, __u32 service_id, s
     return ret;
 }
 
-static inline int service_manager(struct kmesh_context *kmesh_ctx, __u32 service_id, service_value *service_v)
+static inline __attribute__((always_inline)) int
+service_manager(struct kmesh_context *kmesh_ctx, __u32 service_id, service_value *service_v)
 {
     int ret = 0;
 

--- a/bpf/kmesh/workload/include/tail_call.h
+++ b/bpf/kmesh/workload/include/tail_call.h
@@ -40,7 +40,7 @@ struct {
     __uint(map_flags, 0);
 } map_of_xdp_tailcall SEC(".maps");
 
-static inline void kmesh_workload_tail_call(ctx_buff_t *ctx, const __u32 index)
+static inline __attribute__((always_inline)) void kmesh_workload_tail_call(ctx_buff_t *ctx, const __u32 index)
 {
     bpf_tail_call(ctx, &map_of_cgr_tail_call, index);
 }

--- a/bpf/kmesh/workload/sendmsg.c
+++ b/bpf/kmesh/workload/sendmsg.c
@@ -78,7 +78,7 @@ enum TLV_TYPE {
     TLV_PAYLOAD = 0xfe,
 };
 
-static inline int check_overflow(struct sk_msg_md *msg, __u8 *begin, __u32 length)
+static inline __attribute__((always_inline)) int check_overflow(struct sk_msg_md *msg, __u8 *begin, __u32 length)
 {
     if (msg->data_end < (void *)(begin + length)) {
         BPF_LOG(ERR, SENDMSG, "msg over flow\n");
@@ -87,7 +87,8 @@ static inline int check_overflow(struct sk_msg_md *msg, __u8 *begin, __u32 lengt
     return 0;
 }
 
-static inline int get_origin_dst(struct sk_msg_md *msg, struct ip_addr *dst_ip, __u16 *dst_port)
+static inline __attribute__((always_inline)) int
+get_origin_dst(struct sk_msg_md *msg, struct ip_addr *dst_ip, __u16 *dst_port)
 {
     struct bpf_sock *sk = (struct bpf_sock *)msg->sk;
 
@@ -110,7 +111,7 @@ static inline int get_origin_dst(struct sk_msg_md *msg, struct ip_addr *dst_ip, 
     return 0;
 }
 
-static inline int alloc_dst_length(struct sk_msg_md *msg, __u32 length)
+static inline __attribute__((always_inline)) int alloc_dst_length(struct sk_msg_md *msg, __u32 length)
 {
     int ret;
     ret = bpf_msg_push_data(msg, 0, length, 0);
@@ -132,7 +133,7 @@ static inline int alloc_dst_length(struct sk_msg_md *msg, __u32 length)
         *(offset) += (payloadlen);                                                                                     \
     } while (0)
 
-static inline void encode_metadata_end(struct sk_msg_md *msg, __u32 *off)
+static inline __attribute__((always_inline)) void encode_metadata_end(struct sk_msg_md *msg, __u32 *off)
 {
     __u8 type = TLV_PAYLOAD;
     __u32 size = 0;
@@ -142,7 +143,8 @@ static inline void encode_metadata_end(struct sk_msg_md *msg, __u32 *off)
     return;
 }
 
-static inline void encode_metadata_org_dst_addr(struct sk_msg_md *msg, __u32 *off, bool v4)
+static inline __attribute__((always_inline)) void
+encode_metadata_org_dst_addr(struct sk_msg_md *msg, __u32 *off, bool v4)
 {
     struct ip_addr dst_ip = {0};
     __u16 dst_port;

--- a/bpf/kmesh/workload/sockops.c
+++ b/bpf/kmesh/workload/sockops.c
@@ -30,7 +30,7 @@ struct {
 volatile __u32 node_ip[4];
 volatile __u32 pod_gateway[4];
 
-static inline bool skip_specific_probe(struct bpf_sock_ops *skops)
+static inline __attribute__((always_inline)) bool skip_specific_probe(struct bpf_sock_ops *skops)
 {
     if (skops->family == AF_INET) {
         if (node_ip[3] == skops->remote_ip4) {
@@ -55,7 +55,8 @@ static inline bool skip_specific_probe(struct bpf_sock_ops *skops)
     return false;
 }
 
-static inline void extract_skops_to_tuple(struct bpf_sock_ops *skops, struct bpf_sock_tuple *tuple_key)
+static inline __attribute__((always_inline)) void
+extract_skops_to_tuple(struct bpf_sock_ops *skops, struct bpf_sock_tuple *tuple_key)
 {
     if (skops->family == AF_INET) {
         tuple_key->ipv4.saddr = skops->local_ip4;
@@ -75,7 +76,8 @@ static inline void extract_skops_to_tuple(struct bpf_sock_ops *skops, struct bpf
     }
 }
 
-static inline void extract_skops_to_tuple_reverse(struct bpf_sock_ops *skops, struct bpf_sock_tuple *tuple_key)
+static inline __attribute__((always_inline)) void
+extract_skops_to_tuple_reverse(struct bpf_sock_ops *skops, struct bpf_sock_tuple *tuple_key)
 {
     if (skops->family == AF_INET) {
         tuple_key->ipv4.saddr = skops->remote_ip4;
@@ -103,7 +105,7 @@ static inline void extract_skops_to_tuple_reverse(struct bpf_sock_ops *skops, st
 }
 
 // clean map_of_auth_result
-static inline void clean_auth_map(struct bpf_sock_ops *skops)
+static inline __attribute__((always_inline)) void clean_auth_map(struct bpf_sock_ops *skops)
 {
     struct bpf_sock_tuple tuple_key = {0};
     // auth run PASSIVE ESTABLISHED CB now. In this state cb
@@ -118,7 +120,7 @@ static inline void clean_auth_map(struct bpf_sock_ops *skops)
 }
 
 // insert an IP tuple into the ringbuf
-static inline void auth_ip_tuple(struct bpf_sock_ops *skops)
+static inline __attribute__((always_inline)) void auth_ip_tuple(struct bpf_sock_ops *skops)
 {
     struct ringbuf_msg_type *msg = bpf_ringbuf_reserve(&map_of_auth_req, sizeof(*msg), 0);
     if (!msg) {
@@ -139,7 +141,7 @@ static inline void auth_ip_tuple(struct bpf_sock_ops *skops)
 }
 
 // update sockmap to trigger sk_msg prog to encode metadata before sending to waypoint
-static inline void enable_encoding_metadata(struct bpf_sock_ops *skops)
+static inline __attribute__((always_inline)) void enable_encoding_metadata(struct bpf_sock_ops *skops)
 {
     int err;
     struct bpf_sock_tuple tuple_info = {0};

--- a/bpf/kmesh/workload/xdp.c
+++ b/bpf/kmesh/workload/xdp.c
@@ -15,7 +15,7 @@
 #include "authz.h"
 #include "xdp.h"
 
-static inline void shutdown_tuple(struct xdp_info *info)
+static inline __attribute__((always_inline)) void shutdown_tuple(struct xdp_info *info)
 {
     info->tcph->fin = 0;
     info->tcph->syn = 0;
@@ -24,7 +24,8 @@ static inline void shutdown_tuple(struct xdp_info *info)
     info->tcph->ack = 0;
 }
 
-static inline int should_shutdown(struct xdp_info *info, struct bpf_sock_tuple *tuple_info)
+static inline __attribute__((always_inline)) int
+should_shutdown(struct xdp_info *info, struct bpf_sock_tuple *tuple_info)
 {
     __u32 *value = bpf_map_lookup_elem(&map_of_auth_result, tuple_info);
     if (value && *value == 1) {
@@ -55,7 +56,8 @@ static bool is_authz_offload_enabled()
     return authz_offload == 1;
 }
 
-static inline wl_policies_v *get_workload_policies(struct xdp_info *info, struct bpf_sock_tuple *tuple_info)
+static inline __attribute__((always_inline)) wl_policies_v *
+get_workload_policies(struct xdp_info *info, struct bpf_sock_tuple *tuple_info)
 {
     frontend_key frontend_k = {};
     frontend_value *frontend_v = NULL;

--- a/deploy/charts/kmesh-helm/templates/daemonset.yaml
+++ b/deploy/charts/kmesh-helm/templates/daemonset.yaml
@@ -58,6 +58,31 @@ spec:
         image: {{ .Values.deploy.kmesh.image.repository }}:{{ .Values.deploy.kmesh.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.deploy.kmesh.imagePullPolicy }}
         name: kmesh
+        # The kmesh-daemon admin/status server (bpf/xds status, log level, debug
+        # endpoints) only starts listening on 15200 after BPF loading and the XDS
+        # controller have finished initializing - it is not up the instant the
+        # container process starts. Kubernetes only ever reports Pod phase
+        # "Running" the moment the process is exec'd, which is well before that.
+        # Without this probe there is no way for anything outside the process
+        # (kubectl wait, kmeshctl, other tooling) to tell those two moments apart.
+        # readyProbe (pkg/status/status_server.go) is a cheap, unconditional 200 OK
+        # once the server is listening, so this simply reports the true moment the
+        # admin port becomes reachable. It intentionally uses an exec probe rather
+        # than httpGet/tcpSocket: the admin server binds to "localhost:15200" only
+        # (not 0.0.0.0), by design, so it is not reachable from the pod IP that
+        # httpGet/tcpSocket probes target - only from inside the pod's own network
+        # namespace, which is what exec probes run in.
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - "cat < /dev/null > /dev/tcp/127.0.0.1/15200"
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          timeoutSeconds: 2
+          failureThreshold: 3
+          successThreshold: 1
         resources: {{- toYaml .Values.deploy.kmesh.resources | nindent 10 }}
         securityContext:
           privileged: true

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ replace github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
 require (
 	github.com/agiledragon/gomonkey/v2 v2.12.0
 	github.com/cespare/xxhash/v2 v2.3.0
-	github.com/cilium/ebpf v0.17.3
+	github.com/cilium/ebpf v0.19.0
 	github.com/cncf/xds/go v0.0.0-20241213214725-57cfbe6fad57
 	github.com/containernetworking/cni v1.3.0
 	github.com/containernetworking/plugins v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/chai2010/gettext-go v1.0.3 h1:9liNh8t+u26xl5ddmWLmsOsdNLwkdRTg5AG+JnT
 github.com/chai2010/gettext-go v1.0.3/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
 github.com/cheggaaa/pb/v3 v3.1.5 h1:QuuUzeM2WsAqG2gMqtzaWithDJv0i+i6UlnwSCI4QLk=
 github.com/cheggaaa/pb/v3 v3.1.5/go.mod h1:CrxkeghYTXi1lQBEI7jSn+3svI3cuc19haAj6jM60XI=
-github.com/cilium/ebpf v0.17.3 h1:FnP4r16PWYSE4ux6zN+//jMcW4nMVRvuTLVTvCjyyjg=
-github.com/cilium/ebpf v0.17.3/go.mod h1:G5EDHij8yiLzaqn0WjyfJHvRa+3aDlReIaLVRMvOyJk=
+github.com/cilium/ebpf v0.19.0 h1:Ro/rE64RmFBeA9FGjcTc+KmCeY6jXmryu6FfnzPRIao=
+github.com/cilium/ebpf v0.19.0/go.mod h1:fLCgMo3l8tZmAdM3B2XqdFzXBpwkcSTroaVqN08OWVY=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20241213214725-57cfbe6fad57 h1:put7Je9ZyxbHtwr7IqGrW4LLVUupJQ2gbsDshKISSgU=
@@ -145,8 +145,8 @@ github.com/go-openapi/jsonreference v0.21.0 h1:Rs+Y7hSXT83Jacb7kFyjn4ijOuVGSvOdF
 github.com/go-openapi/jsonreference v0.21.0/go.mod h1:LmZmgsrTkVg9LG4EaHeY8cBDslNPMo06cago5JNLkm4=
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
-github.com/go-quicktest/qt v1.101.0 h1:O1K29Txy5P2OK0dGo59b7b0LR6wKfIhttaAhHUyn7eI=
-github.com/go-quicktest/qt v1.101.0/go.mod h1:14Bz/f7NwaXPtdYEgzsx46kqSxVwTbzVZsDC26tQJow=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6 h1:teYtXy9B7y5lHTp8V9KPxpYRAVA7dozigQcMiBust1s=
+github.com/go-quicktest/qt v1.101.1-0.20240301121107-c6c8733fa1e6/go.mod h1:p4lGIVX+8Wa6ZPNDvqcxq36XpUDLh42FLetFU7odllI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=

--- a/pkg/bpf/workload/sock_connection.go
+++ b/pkg/bpf/workload/sock_connection.go
@@ -76,6 +76,8 @@ func (sc *SockConnWorkload) loadKmeshSockConnObjects() (*ebpf.CollectionSpec, er
 		opts ebpf.CollectionOptions
 	)
 	opts.Maps.PinPath = sc.Info.MapPath
+	opts.Programs.LogLevel = ebpf.LogLevelInstruction | ebpf.LogLevelStats
+	opts.Programs.LogSizeStart = 8 * 1024 * 1024
 	if helper.KernelVersionLowerThan5_13() {
 		spec, err = bpf2go.LoadKmeshCgroupSockWorkloadCompat()
 	} else {

--- a/test/e2e/run_test.sh
+++ b/test/e2e/run_test.sh
@@ -138,6 +138,47 @@ function setup_istio() {
 	done
 }
 
+
+# Dump cluster/pod state for post-mortem debugging when E2E setup fails partway
+# through. This does not change control flow - callers still decide what to do
+# (typically: print this, then exit 1) - it only makes sure that information isn't
+# lost the moment the KinD cluster is torn down at the end of the job.
+function collect_diagnostics() {
+	local ns="${1:-kmesh-system}"
+
+	echo "===== DIAGNOSTICS (namespace: $ns) ====="
+
+	echo "--- kubectl get pods -A -o wide ---"
+	kubectl get pods -A -o wide || true
+
+	echo "--- kubectl get events -n $ns --sort-by=.lastTimestamp ---"
+	kubectl get events -n "$ns" --sort-by=.lastTimestamp || true
+
+	local pods
+	pods=$(kubectl get pods -n "$ns" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+
+	if [ -z "$pods" ]; then
+		echo "(no pods found in namespace $ns)"
+	fi
+
+	for pod in $pods; do
+		echo "--- kubectl describe pod $pod -n $ns ---"
+		kubectl describe pod "$pod" -n "$ns" || true
+
+		echo "--- container restart counts for pod $pod ---"
+		kubectl get pod "$pod" -n "$ns" \
+			-o jsonpath='{range .status.containerStatuses[*]}{.name}{"  ready="}{.ready}{"  restartCount="}{.restartCount}{"\n"}{end}' || true
+
+		echo "--- kubectl logs $pod -n $ns (current container) ---"
+		kubectl logs "$pod" -n "$ns" --all-containers=true --timestamps=true || true
+
+		echo "--- kubectl logs $pod -n $ns --previous (last crashed/restarted container, if any) ---"
+		kubectl logs "$pod" -n "$ns" --all-containers=true --previous || true
+	done
+
+	echo "===== END DIAGNOSTICS ====="
+}
+
 function setup_kmesh() {
 	# skip dns proxy for ipv6
 	[[ -n ${IPV6:-} ]] && extra_args="--set features.dnsProxy.enabled=false"
@@ -157,28 +198,41 @@ function setup_kmesh() {
 		--set deploy.kmesh.containers.kmeshDaemonArgs="--mode=dual-engine --enable-bypass=false --monitoring=true --enable-ipsec=true" \
 		$extra_args
 
-	# Wait for all Kmesh pods to be ready.
+	# Wait for the Kmesh DaemonSet to actually schedule pods first: "kubectl wait"
+	# below fails immediately (rather than waiting) if the selector currently
+	# matches zero pods, which is normally true for a brief moment right after
+	# "helm install".
 	while true; do
-		pod_statuses=$(kubectl get pods -n kmesh-system -l app=kmesh -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.phase}{"\n"}{end}')
-
-		running_pods=0
-		total_pods=0
-
-		while read -r pod_name pod_status; do
-			total_pods=$((total_pods + 1))
-			if [ "$pod_status" = "Running" ]; then
-				running_pods=$((running_pods + 1))
-			fi
-		done <<<"$pod_statuses"
-
-		if [ "$running_pods" -eq "$total_pods" ]; then
-			echo "All pods of Kmesh daemon are in Running state."
+		pod_count=$(kubectl get pods -n kmesh-system -l app=kmesh --no-headers 2>/dev/null | wc -l)
+		if [ "$pod_count" -gt 0 ]; then
 			break
 		fi
-
-		echo "Waiting for pods of Kmesh daemon to enter Running state..."
+		echo "No Kmesh daemon pods scheduled yet, waiting..."
 		sleep 1
 	done
+
+	# Wait for the Kmesh daemon pods to become Ready, not just Running.
+	#
+	# "Running" only means the container process has been exec'd - it says
+	# nothing about whether kmesh-daemon has finished BPF loading and XDS
+	# controller startup and opened its admin port (15200), which is what
+	# `kmeshctl log` (below) and this test actually depend on. Treating "Running"
+	# as "ready" here is exactly the gap that used to make this script proceed
+	# straight to `kmeshctl log` while the admin server was still initializing,
+	# producing "connection refused" on port 15200 that no number of retries could
+	# fix, because the port genuinely was not open yet.
+	#
+	# The daemonset now has a readinessProbe (deploy/charts/kmesh-helm/templates/
+	# daemonset.yaml) that checks that same admin port directly, so waiting on the
+	# pod's Ready condition here waits on the real signal instead of a proxy for
+	# it. The timeout below is generous because it now bounds actual worst-case
+	# daemon startup time (BPF + XDS init), not a best-effort guess.
+	if ! kubectl wait --for=condition=Ready pod -l app=kmesh -n kmesh-system --timeout=180s; then
+		echo "Kmesh daemon pods did not become Ready within the timeout."
+		collect_diagnostics "kmesh-system"
+		exit 1
+	fi
+	echo "All pods of Kmesh daemon are Ready."
 
 	# Set log of each Kmesh pods.
 	PODS=$(kubectl get pods -n kmesh-system -l app=kmesh -o jsonpath='{.items[*].metadata.name}')
@@ -194,7 +248,11 @@ function setup_kmesh() {
 				break
 			fi
 			echo "Failed to set BPF debug log. Output: $output"
-			[ $i -eq 5 ] && echo "Failed to set BPF debug log after 5 attempts" && exit 1
+			if [ $i -eq 5 ]; then
+				echo "Failed to set BPF debug log after 5 attempts"
+				collect_diagnostics "kmesh-system"
+				exit 1
+			fi
 			sleep 2
 		done
 
@@ -207,7 +265,11 @@ function setup_kmesh() {
 				break
 			fi
 			echo "Failed to set default debug log. Output: $output"
-			[ $i -eq 5 ] && echo "Failed to set default debug log after 5 attempts" && exit 1
+			if [ $i -eq 5 ]; then
+				echo "Failed to set default debug log after 5 attempts"
+				collect_diagnostics "kmesh-system"
+				exit 1
+			fi
 			sleep 2
 		done
 	done
@@ -228,7 +290,11 @@ function setup_kmesh_log() {
 				break
 			fi
 			echo "Failed to set BPF debug log. Output: $output"
-			[ $i -eq 5 ] && echo "Failed to set BPF debug log after 5 attempts" && exit 1
+			if [ $i -eq 5 ]; then
+				echo "Failed to set BPF debug log after 5 attempts"
+				collect_diagnostics "kmesh-system"
+				exit 1
+			fi
 			sleep 2
 		done
 
@@ -241,7 +307,11 @@ function setup_kmesh_log() {
 				break
 			fi
 			echo "Failed to set default debug log. Output: $output"
-			[ $i -eq 5 ] && echo "Failed to set default debug log after 5 attempts" && exit 1
+			if [ $i -eq 5 ]; then
+				echo "Failed to set default debug log after 5 attempts"
+				collect_diagnostics "kmesh-system"
+				exit 1
+			fi
 			sleep 2
 		done
 	done


### PR DESCRIPTION
Draft/diagnostic PR - not for review yet.

E2E has been permanently broken since 2026-05-14 by a deterministic
eBPF verifier rejection during kmesh-daemon startup:

    Error: bpf Load failed: load program: invalid argument:
        processed 6750 insns (limit 1000000) max_states_per_insn 8 total_states 333 peak_states 306 mark_read 26

This is captured with the diagnostics added in #1807. This PR adds temporary instrumentation to BpfWorkload.Load() (progress logging per program) and enables full instruction-level verifier logging on all five workload program loaders, so a real CI run can reveal which program fails and the complete verifier log instead of the truncated
summary.

Will be replaced with the actual fix once the failing program and
verifier reason are identified from this run.