### PR TITLE
feat(status): implement component health checks in readyProbe

### DIFF
--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -496,10 +496,89 @@ func (s *Server) configDumpWorkload(w http.ResponseWriter, r *http.Request) {
 	printWorkloadDump(w, workloadDump)
 }
 
+type ComponentStatus struct {
+	Name    string `json:"name"`
+	Healthy bool   `json:"healthy"`
+	Message string `json:"message,omitempty"`
+}
+
+type ReadinessResponse struct {
+	Ready      bool              `json:"ready"`
+	Components []ComponentStatus `json:"components"`
+}
+
 func (s *Server) readyProbe(w http.ResponseWriter, r *http.Request) {
-	// TODO: Add some components check
-	w.WriteHeader(http.StatusOK)
-	_, _ = w.Write([]byte("OK"))
+	components := []ComponentStatus{}
+	allHealthy := true
+
+	// Check 1: BPF Loader Status (Data Plane)
+	bpfHealthy := false
+	bpfMessage := ""
+	if s.loader == nil {
+		bpfMessage = "BPF loader not initialized"
+	} else if s.config.BpfConfig.KernelNativeEnabled() {
+		if s.loader.GetBpfKmesh() != nil {
+			bpfHealthy = true
+		} else {
+			bpfMessage = "Kernel-native BPF programs not loaded"
+		}
+	} else if s.config.BpfConfig.DualEngineEnabled() {
+		if s.loader.GetBpfWorkload() != nil {
+			bpfHealthy = true
+		} else {
+			bpfMessage = "Dual-engine BPF programs not loaded"
+		}
+	} else {
+		bpfMessage = "Unknown BPF mode"
+	}
+	components = append(components, ComponentStatus{
+		Name:    "bpf_loader",
+		Healthy: bpfHealthy,
+		Message: bpfMessage,
+	})
+	allHealthy = allHealthy && bpfHealthy
+
+	// Check 2: XDS Controller Status (Control Plane Connectivity)
+	xdsHealthy := false
+	xdsMessage := ""
+	if s.xdsClient == nil {
+		xdsMessage = "XDS client not initialized"
+	} else if s.config.BpfConfig.KernelNativeEnabled() {
+		if s.xdsClient.AdsController != nil {
+			xdsHealthy = true
+		} else {
+			xdsMessage = "ADS controller not initialized"
+		}
+	} else if s.config.BpfConfig.DualEngineEnabled() {
+		if s.xdsClient.WorkloadController != nil {
+			xdsHealthy = true
+		} else {
+			xdsMessage = "Workload controller not initialized"
+		}
+	} else {
+		xdsMessage = "Unknown XDS mode"
+	}
+	components = append(components, ComponentStatus{
+		Name:    "xds_controller",
+		Healthy: xdsHealthy,
+		Message: xdsMessage,
+	})
+	allHealthy = allHealthy && xdsHealthy
+
+	response := ReadinessResponse{
+		Ready:      allHealthy,
+		Components: components,
+	}
+
+	statusCode := http.StatusOK
+	if !allHealthy {
+		statusCode = http.StatusServiceUnavailable
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(statusCode)
+	data, _ := json.MarshalIndent(response, "", "  ")
+	_, _ = w.Write(data)
 }
 
 func (s *Server) getBpfLogLevel() (*LoggerInfo, error) {

--- a/pkg/status/status_server_test.go
+++ b/pkg/status/status_server_test.go
@@ -662,3 +662,188 @@ func TestServerMonitoringHandler(t *testing.T) {
 		assert.Equal(t, constants.ENABLED, enableMonitoring)
 	})
 }
+
+func TestServer_readyProbe(t *testing.T) {
+	t.Run("all components healthy - dual engine mode", func(t *testing.T) {
+		config := options.BpfConfig{
+			Mode:        constants.DualEngineMode,
+			BpfFsPath:   "/sys/fs/bpf",
+			Cgroup2Path: "/mnt/kmesh_cgroup2",
+		}
+		cleanup, loader := test.InitBpfMap(t, config)
+		defer cleanup()
+
+		server := &Server{
+			config: &options.BootstrapConfigs{
+				BpfConfig: &config,
+			},
+			xdsClient: &controller.XdsClient{
+				WorkloadController: &workload.Controller{
+					Processor: workload.NewProcessor(loader.GetBpfWorkload().SockConn.KmeshCgroupSockWorkloadObjects.KmeshCgroupSockWorkloadMaps),
+				},
+			},
+			loader: loader,
+		}
+
+		req := httptest.NewRequest(http.MethodGet, patternReadyProbe, nil)
+		w := httptest.NewRecorder()
+		server.readyProbe(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response ReadinessResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.Nil(t, err)
+		assert.True(t, response.Ready)
+		assert.Equal(t, 2, len(response.Components))
+
+		// Check BPF loader component
+		bpfComponent := response.Components[0]
+		assert.Equal(t, "bpf_loader", bpfComponent.Name)
+		assert.True(t, bpfComponent.Healthy)
+
+		// Check XDS controller component
+		xdsComponent := response.Components[1]
+		assert.Equal(t, "xds_controller", xdsComponent.Name)
+		assert.True(t, xdsComponent.Healthy)
+	})
+
+	t.Run("bpf loader not initialized", func(t *testing.T) {
+		config := options.BpfConfig{
+			Mode:        constants.DualEngineMode,
+			BpfFsPath:   "/sys/fs/bpf",
+			Cgroup2Path: "/mnt/kmesh_cgroup2",
+		}
+
+		server := &Server{
+			config: &options.BootstrapConfigs{
+				BpfConfig: &config,
+			},
+			xdsClient: &controller.XdsClient{
+				WorkloadController: &workload.Controller{},
+			},
+			loader: nil, // BPF loader not initialized
+		}
+
+		req := httptest.NewRequest(http.MethodGet, patternReadyProbe, nil)
+		w := httptest.NewRecorder()
+		server.readyProbe(w, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+		var response ReadinessResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.Nil(t, err)
+		assert.False(t, response.Ready)
+		assert.Equal(t, 2, len(response.Components))
+
+		// Check BPF loader component
+		bpfComponent := response.Components[0]
+		assert.Equal(t, "bpf_loader", bpfComponent.Name)
+		assert.False(t, bpfComponent.Healthy)
+		assert.Equal(t, "BPF loader not initialized", bpfComponent.Message)
+	})
+
+	t.Run("xds controller not initialized", func(t *testing.T) {
+		config := options.BpfConfig{
+			Mode:        constants.DualEngineMode,
+			BpfFsPath:   "/sys/fs/bpf",
+			Cgroup2Path: "/mnt/kmesh_cgroup2",
+		}
+		cleanup, loader := test.InitBpfMap(t, config)
+		defer cleanup()
+
+		server := &Server{
+			config: &options.BootstrapConfigs{
+				BpfConfig: &config,
+			},
+			xdsClient: nil, // XDS client not initialized
+			loader:    loader,
+		}
+
+		req := httptest.NewRequest(http.MethodGet, patternReadyProbe, nil)
+		w := httptest.NewRecorder()
+		server.readyProbe(w, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+		var response ReadinessResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.Nil(t, err)
+		assert.False(t, response.Ready)
+
+		// Check XDS controller component
+		xdsComponent := response.Components[1]
+		assert.Equal(t, "xds_controller", xdsComponent.Name)
+		assert.False(t, xdsComponent.Healthy)
+		assert.Equal(t, "XDS client not initialized", xdsComponent.Message)
+	})
+
+	t.Run("all components missing", func(t *testing.T) {
+		config := options.BpfConfig{
+			Mode:        constants.DualEngineMode,
+			BpfFsPath:   "/sys/fs/bpf",
+			Cgroup2Path: "/mnt/kmesh_cgroup2",
+		}
+
+		server := &Server{
+			config: &options.BootstrapConfigs{
+				BpfConfig: &config,
+			},
+			xdsClient: nil,
+			loader:    nil,
+		}
+
+		req := httptest.NewRequest(http.MethodGet, patternReadyProbe, nil)
+		w := httptest.NewRecorder()
+		server.readyProbe(w, req)
+
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+
+		var response ReadinessResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.Nil(t, err)
+		assert.False(t, response.Ready)
+		assert.Equal(t, 2, len(response.Components))
+
+		// Both components should be unhealthy
+		assert.False(t, response.Components[0].Healthy)
+		assert.False(t, response.Components[1].Healthy)
+	})
+
+	t.Run("kernel native mode - all healthy", func(t *testing.T) {
+		config := options.BpfConfig{
+			Mode:        constants.KernelNativeMode,
+			BpfFsPath:   "/sys/fs/bpf",
+			Cgroup2Path: "/mnt/kmesh_cgroup2",
+		}
+		cleanup, loader := test.InitBpfMap(t, config)
+		defer cleanup()
+
+		server := &Server{
+			config: &options.BootstrapConfigs{
+				BpfConfig: &config,
+			},
+			xdsClient: &controller.XdsClient{
+				AdsController: ads.NewController(loader.GetBpfKmesh()),
+			},
+			loader: loader,
+		}
+
+		req := httptest.NewRequest(http.MethodGet, patternReadyProbe, nil)
+		w := httptest.NewRecorder()
+		server.readyProbe(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var response ReadinessResponse
+		err := json.Unmarshal(w.Body.Bytes(), &response)
+		assert.Nil(t, err)
+		assert.True(t, response.Ready)
+		assert.Equal(t, 2, len(response.Components))
+
+		// Check both components are healthy
+		assert.True(t, response.Components[0].Healthy)
+		assert.True(t, response.Components[1].Healthy)
+	})
+}


### PR DESCRIPTION
## Summary

This PR implements the health checks for the `/debug/ready` endpoint, addressing the TODO in `pkg/status/status_server.go`.

Previously, the endpoint always returned `200 OK` with a plain `"OK"` response. It now checks whether the main data-plane and control-plane components are initialized correctly and reports readiness based on their state.

## What changed

The readiness check now covers:

* **BPF loader**

  * Checks that the loader is initialized.
  * In kernel-native mode, verifies that the Kmesh BPF object is available.
  * In dual-engine mode, verifies that the workload BPF object is available.

* **XDS controller**

  * Checks that the XDS client is initialized.
  * In kernel-native mode, verifies that the ADS controller is available.
  * In dual-engine mode, verifies that the workload controller is available.

The endpoint now returns a structured JSON response, for example:

```json
{
  "ready": true,
  "components": [
    {"name": "bpf_loader", "healthy": true},
    {"name": "xds_controller", "healthy": true}
  ]
}
```

It returns `200 OK` when all components are healthy and `503 Service Unavailable` if any required component is unavailable.

## Compatibility note

This changes the existing endpoint behaviour in two ways:

* The response changes from plain text `"OK"` to JSON.
* The endpoint can now return `503` instead of always returning `200`.

I couldn't find any existing e2e tests or Kubernetes readiness probes depending on the current response. External consumers that explicitly parse `"OK"` may need to be updated.

## Testing

Added test coverage for:

* healthy components in dual-engine mode
* uninitialized BPF loader
* uninitialized XDS controller
* both components unavailable
* healthy components in kernel-native mode

I also verified the build and formatting locally.

## Note on XDS connectivity

This currently checks whether the relevant XDS controller is initialized, rather than checking the underlying gRPC stream state.

The stream connection is kept behind internal controller structures, so adding that check would require broader changes to the controller implementation. I kept this PR scoped to the readiness checks that can be performed using the existing interfaces. Stream-level health checking can be added separately if needed.

Addresses the TODO in `pkg/status/status_server.go`.

