### PR TITLE
feat: implement component health checks in ready probe

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -557,3 +557,15 @@ func CleanupBpfMap() {
 	}
 	log.Info("cleanup bpf map success")
 }
+
+func (l *BpfLoader) IsReady() bool {
+	if l == nil || l.config == nil {
+		return false
+	}
+	if l.config.KernelNativeEnabled() {
+		return l.obj != nil
+	} else if l.config.DualEngineEnabled() {
+		return l.workloadObj != nil
+	}
+	return false
+}

--- a/pkg/controller/client.go
+++ b/pkg/controller/client.go
@@ -23,6 +23,7 @@ import (
 
 	discoveryv3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/metadata"
 	istioGrpc "istio.io/istio/pilot/pkg/grpc"
 
@@ -179,4 +180,12 @@ func (c *XdsClient) closeStreamClient() {
 
 func (c *XdsClient) Close() error {
 	return nil
+}
+
+func (c *XdsClient) IsReady() bool {
+	if c.grpcConn == nil {
+		return false
+	}
+	state := c.grpcConn.GetState()
+	return state == connectivity.Ready || state == connectivity.Idle
 }

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -497,7 +497,14 @@ func (s *Server) configDumpWorkload(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) readyProbe(w http.ResponseWriter, r *http.Request) {
-	// TODO: Add some components check
+	if s.xdsClient == nil || !s.xdsClient.IsReady() {
+		http.Error(w, "XDS client is not ready", http.StatusServiceUnavailable)
+		return
+	}
+	if s.loader == nil || !s.loader.IsReady() {
+		http.Error(w, "BPF loader is not ready", http.StatusServiceUnavailable)
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write([]byte("OK"))
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:
Currently, the `readyProbe` endpoint in `pkg/status/status_server.go` returns a hardcoded `OK` response without verifying the state of the underlying components. 

This PR implements actual component health checks before returning a `200 OK` status by verifying that:
1. The eBPF programs are successfully loaded and running (`s.loader.IsReady()`).
2. The XDS client is connected and its stream is active (`s.xdsClient.IsReady()`).

This prevents Kubernetes from prematurely routing traffic to the Kmesh daemon before its vital components are fully initialized.

**Which issue(s) this PR fixes**:
Fixes #1815 



**Does this PR introduce a user-facing change?**:
```release-note
NONE