### PR TITLE
auth: remove stale namespace/global index entries on policy rescope

### DIFF
--- a/pkg/auth/policy_store.go
+++ b/pkg/auth/policy_store.go
@@ -47,26 +47,26 @@ func (ps *policyStore) updatePolicy(authPolicy *security.Authorization) error {
 		return nil
 	}
 	key := authPolicy.ResourceName()
-	ps.rwLock.Lock()
-	defer ps.rwLock.Unlock()
-	var ns string
+
+	// Validate the scope before mutating any index so a rejected update
+	// cannot leave the store in a partially modified state.
 	switch authPolicy.GetScope() {
-	case security.Scope_WORKLOAD_SELECTOR:
-		ps.byKey[key] = authPolicy
-		return nil
-	case security.Scope_GLOBAL:
-		ns = ""
-	case security.Scope_NAMESPACE:
-		ns = authPolicy.GetNamespace()
+	case security.Scope_WORKLOAD_SELECTOR, security.Scope_GLOBAL, security.Scope_NAMESPACE:
 	default:
 		return fmt.Errorf("invalid scope %v of authorization policy", authPolicy.GetScope())
 	}
 
-	if s, ok := ps.byNamespace[ns]; !ok {
-		ps.byNamespace[ns] = sets.New(key)
-	} else {
-		s.Insert(key)
+	ps.rwLock.Lock()
+	defer ps.rwLock.Unlock()
+
+	// A policy may change scope on update (e.g. NAMESPACE -> GLOBAL). Unlink the
+	// previously stored version first so no stale namespace/global index entry
+	// is left pointing at it.
+	if old, ok := ps.byKey[key]; ok {
+		ps.unlinkPolicyLocked(key, old)
 	}
+
+	ps.linkPolicyLocked(key, authPolicy)
 	ps.byKey[key] = authPolicy
 	return nil
 }
@@ -82,20 +82,47 @@ func (ps *policyStore) removePolicy(policyKey string) {
 	}
 	// remove authPolicy from byKey
 	delete(ps.byKey, policyKey)
+	ps.unlinkPolicyLocked(policyKey, authPolicy)
+}
 
-	var ns string
-	switch authPolicy.Scope {
+// namespaceIndexKey returns the byNamespace key for a policy and whether the
+// policy is tracked in the namespace index at all. WORKLOAD_SELECTOR scoped
+// policies are only tracked in byKey, so they report ok=false.
+func namespaceIndexKey(authPolicy *security.Authorization) (string, bool) {
+	switch authPolicy.GetScope() {
 	case security.Scope_GLOBAL:
-		ns = ""
+		return "", true
 	case security.Scope_NAMESPACE:
-		ns = authPolicy.GetNamespace()
+		return authPolicy.GetNamespace(), true
 	default:
+		return "", false
+	}
+}
+
+// linkPolicyLocked adds the policy key to the namespace index for its current
+// scope. Callers must hold rwLock.
+func (ps *policyStore) linkPolicyLocked(key string, authPolicy *security.Authorization) {
+	ns, ok := namespaceIndexKey(authPolicy)
+	if !ok {
 		return
 	}
-
-	// remove authPolicy key from byNamespace
 	if s, ok := ps.byNamespace[ns]; ok {
-		s.Delete(policyKey)
+		s.Insert(key)
+	} else {
+		ps.byNamespace[ns] = sets.New(key)
+	}
+}
+
+// unlinkPolicyLocked removes the policy key from the namespace index for the
+// scope of the supplied policy, pruning the namespace bucket when it becomes
+// empty. Callers must hold rwLock.
+func (ps *policyStore) unlinkPolicyLocked(key string, authPolicy *security.Authorization) {
+	ns, ok := namespaceIndexKey(authPolicy)
+	if !ok {
+		return
+	}
+	if s, ok := ps.byNamespace[ns]; ok {
+		s.Delete(key)
 		if s.IsEmpty() {
 			delete(ps.byNamespace, ns)
 		}

--- a/pkg/auth/policy_store.go
+++ b/pkg/auth/policy_store.go
@@ -123,7 +123,7 @@ func (ps *policyStore) unlinkPolicyLocked(key string, authPolicy *security.Autho
 	}
 	if s, ok := ps.byNamespace[ns]; ok {
 		s.Delete(key)
-		if s.IsEmpty() {
+		if len(s) == 0 {
 			delete(ps.byNamespace, ns)
 		}
 	}

--- a/pkg/auth/policy_store_test.go
+++ b/pkg/auth/policy_store_test.go
@@ -96,6 +96,96 @@ func Test_policyStore_updatePolicy(t *testing.T) {
 	}
 }
 
+// Test_policyStore_updatePolicy_scopeChange verifies that when an existing
+// policy changes scope, the stale namespace/global index entry is removed so a
+// policy is only discoverable through the index matching its current scope.
+func Test_policyStore_updatePolicy_scopeChange(t *testing.T) {
+	newAuth := func(scope security.Scope) *security.Authorization {
+		return &security.Authorization{
+			Name:      "auth-name",
+			Namespace: "auth-namespace",
+			Scope:     scope,
+		}
+	}
+
+	tests := []struct {
+		name string
+		from security.Scope
+		to   security.Scope
+		// oldNs is the namespace index bucket that must no longer contain the
+		// policy after the update; "" is the global bucket.
+		oldNs string
+		// newNs is the namespace index bucket that must contain the policy after
+		// the update, or "-" when the policy should not be in any bucket.
+		newNs string
+	}{
+		{"namespace to global", security.Scope_NAMESPACE, security.Scope_GLOBAL, "auth-namespace", ""},
+		{"namespace to workload selector", security.Scope_NAMESPACE, security.Scope_WORKLOAD_SELECTOR, "auth-namespace", "-"},
+		{"global to namespace", security.Scope_GLOBAL, security.Scope_NAMESPACE, "", "auth-namespace"},
+		{"global to workload selector", security.Scope_GLOBAL, security.Scope_WORKLOAD_SELECTOR, "", "-"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ps := newPolicyStore()
+			initial := newAuth(tt.from)
+			key := initial.ResourceName()
+			if err := ps.updatePolicy(initial); err != nil {
+				t.Fatalf("updatePolicy(initial) error = %v", err)
+			}
+			if err := ps.updatePolicy(newAuth(tt.to)); err != nil {
+				t.Fatalf("updatePolicy(updated) error = %v", err)
+			}
+
+			// The stale bucket must not reference the policy anymore.
+			if s, ok := ps.byNamespace[tt.oldNs]; ok && s.Contains(key) {
+				t.Errorf("policy %q still present in stale namespace index bucket %q", key, tt.oldNs)
+			}
+
+			if tt.newNs == "-" {
+				for ns, s := range ps.byNamespace {
+					if s.Contains(key) {
+						t.Errorf("policy %q should not be in any namespace index bucket, found in %q", key, ns)
+					}
+				}
+			} else if s, ok := ps.byNamespace[tt.newNs]; !ok || !s.Contains(key) {
+				t.Errorf("policy %q missing from expected namespace index bucket %q", key, tt.newNs)
+			}
+
+			// The policy must always remain resolvable by key.
+			if _, ok := ps.byKey[key]; !ok {
+				t.Errorf("policy %q missing from byKey after update", key)
+			}
+		})
+	}
+}
+
+// Test_policyStore_updatePolicy_scopeChangeKeepsSiblings verifies that
+// rescoping one policy does not evict other policies sharing the same
+// namespace index bucket.
+func Test_policyStore_updatePolicy_scopeChangeKeepsSiblings(t *testing.T) {
+	ps := newPolicyStore()
+	p1 := &security.Authorization{Name: "p1", Namespace: "ns1", Scope: security.Scope_NAMESPACE}
+	p2 := &security.Authorization{Name: "p2", Namespace: "ns1", Scope: security.Scope_NAMESPACE}
+	if err := ps.updatePolicy(p1); err != nil {
+		t.Fatalf("updatePolicy(p1) error = %v", err)
+	}
+	if err := ps.updatePolicy(p2); err != nil {
+		t.Fatalf("updatePolicy(p2) error = %v", err)
+	}
+
+	// Rescope p1 to global; p2 must stay in the ns1 bucket.
+	if err := ps.updatePolicy(&security.Authorization{Name: "p1", Namespace: "ns1", Scope: security.Scope_GLOBAL}); err != nil {
+		t.Fatalf("updatePolicy(p1 rescope) error = %v", err)
+	}
+	if s, ok := ps.byNamespace["ns1"]; !ok || !s.Contains(p2.ResourceName()) {
+		t.Errorf("sibling policy %q should remain in namespace bucket ns1", p2.ResourceName())
+	}
+	if ps.byNamespace["ns1"].Contains(p1.ResourceName()) {
+		t.Errorf("rescoped policy %q should no longer be in namespace bucket ns1", p1.ResourceName())
+	}
+}
+
 func Test_policyStore_removePolicy(t *testing.T) {
 	config := options.BpfConfig{
 		Mode:        constants.DualEngineMode,


### PR DESCRIPTION
## **What this PR does / why we need it**:

`policyStore` maintains authorization policies in two indexes: `byKey` (ns/name → policy) and `byNamespace` (namespace, or `""` for global → set of policy keys). When an existing policy is updated with a **different scope** (e.g. `NAMESPACE` → `GLOBAL`), `updatePolicy` added the key to the new index bucket but never removed it from the old one, leaving a stale reference behind.

Since `Rbac.aggregate()` collects policy names from the namespace and global buckets and resolves each through `byKey`, a stale entry means a rescoped policy keeps being enforced against workloads it should no longer apply to — e.g. a policy narrowed from namespace-wide to a single workload selector would still be enforced against every workload in that namespace, producing incorrect ALLOW/DENY decisions until Kmesh restarts.

This PR fixes `updatePolicy` to unlink the previously stored version of a policy from its old namespace/global bucket before linking the new one, using two small helpers (`linkPolicyLocked`/`unlinkPolicyLocked`) that centralize the index invariant and are also reused by `removePolicy`. Scope validation now happens before any index mutation, so a rejected update can't leave the store partially modified.

## **Which issue(s) this PR fixes**:
Fixes #1813

## **Special notes for your reviewer**:

- Added `Test_policyStore_updatePolicy_scopeChange` covering all four rescope transitions (`NAMESPACE↔GLOBAL`, `NAMESPACE/GLOBAL → WORKLOAD_SELECTOR`), asserting the stale bucket no longer references the policy and the correct new bucket does.
- Added `Test_policyStore_updatePolicy_scopeChangeKeepsSiblings` to guard against over-deletion — rescoping one policy must not evict other policies sharing the same namespace bucket.
- No behavior change for policies that keep the same scope across updates, or for `removePolicy`.
- I used AI assistance (Claude Code) to help implement this fix; I've reviewed and understand the change and can answer questions on it.

## **Does this PR introduce a user-facing change?**:

```release-note
Fixed a bug where Kmesh could keep enforcing a stale copy of an Authorization policy against the wrong workloads after the policy's scope was changed (e.g. namespace-scoped to global), until Kmesh restarted.
```