### PR TITLE
debug: add optional BPF verifier logging flag

### DIFF
--- a/daemon/options/bpf.go
+++ b/daemon/options/bpf.go
@@ -34,6 +34,7 @@ type BpfConfig struct {
 	EnablePeriodicReport bool
 	EnableProfiling      bool
 	EnableIPsec          bool
+	BpfVerifierLogLevel  uint32
 }
 
 func (c *BpfConfig) AttachFlags(cmd *cobra.Command) {
@@ -45,6 +46,8 @@ func (c *BpfConfig) AttachFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().BoolVar(&c.EnablePeriodicReport, "periodic-report", false, "enable kmesh periodic report in daemon process")
 	cmd.PersistentFlags().BoolVar(&c.EnableProfiling, "profiling", false, "whether to enable profiling or not, default to false")
 	cmd.PersistentFlags().BoolVar(&c.EnableIPsec, "enable-ipsec", false, "enable ipsec encryption and authentication between nodes")
+	cmd.PersistentFlags().Uint32Var(&c.BpfVerifierLogLevel, "bpf-verifier-log-level", 0,
+		"bpf verifier log level bitmask for debugging bpf program loads (1=branch, 2=instruction, 4=stats; OR values together); 0 disables verifier logging")
 }
 
 func (c *BpfConfig) ParseConfig() error {

--- a/daemon/options/bpf_test.go
+++ b/daemon/options/bpf_test.go
@@ -14,19 +14,23 @@
  * limitations under the License.
  */
 
-package general
+package options
 
-import "github.com/cilium/ebpf"
+import (
+	"testing"
 
-type BpfInfo struct {
-	MapPath     string
-	BpfFsPath   string
-	Cgroup2Path string
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
 
-	Type       ebpf.ProgramType
-	AttachType ebpf.AttachType
+func TestBpfVerifierLogLevelFlag(t *testing.T) {
+	cfg := &BpfConfig{}
+	cmd := &cobra.Command{Use: "kmesh-daemon"}
+	cfg.AttachFlags(cmd)
 
-	// VerifierLogLevel is the ebpf verifier log level bitmask requested via
-	// --bpf-verifier-log-level. A value of 0 disables verifier logging.
-	VerifierLogLevel uint32
+	// Disabled by default, matching existing behavior when the flag is unset.
+	assert.Equal(t, uint32(0), cfg.BpfVerifierLogLevel)
+
+	assert.NoError(t, cmd.ParseFlags([]string{"--bpf-verifier-log-level=3"}))
+	assert.Equal(t, uint32(3), cfg.BpfVerifierLogLevel)
 }

--- a/docs/cn/zh/kmesh_commands-zh.md
+++ b/docs/cn/zh/kmesh_commands-zh.md
@@ -10,7 +10,8 @@ Usage:
   kmesh-daemon [flags]
 
 Flags:
-      --bpf-fs-path string     bpf fs path (default "/sys/fs/bpf")
+      --bpf-fs-path string             bpf fs path (default "/sys/fs/bpf")
+      --bpf-verifier-log-level uint32  bpf verifier log level bitmask for debugging bpf program loads (1=branch, 2=instruction, 4=stats; OR values together); 0 disables verifier logging (default 0)
       --cgroup2-path string    cgroup2 path (default "/mnt/kmesh_cgroup2")
       --enable-mda             enable mda
   -h, --help                   help for kmesh-daemon
@@ -27,6 +28,8 @@ Flags:
 ./kmesh-daemon --mode=kernel-native --enable-mda
 # example
 ./kmesh-daemon --mode=dual-engine --enable-mda
+# example
+./kmesh-daemon --mode=dual-engine --bpf-verifier-log-level=1
   ```
 
 - 运维相关
@@ -52,3 +55,7 @@ Flags:
     [root@localhost Kmesh]# mount | grep "/sys/fs/bpf"
     none on /sys/fs/bpf type bpf (rw,nosuid,nodev,noexec,relatime,mode=700)
     ```
+
+  - `--bpf-verifier-log-level` 默认关闭（`0`），不会带来任何运行时开销。用于调试 bpf 程序加载/校验失败问题，取值为直接
+    透传给 bpf verifier 的位掩码（`1`=branch，`2`=instruction，`4`=stats，可以按位或组合，如 `3`）。开启后，kmesh 会捕获
+    完整的 verifier 输出并写入 daemon 日志。

--- a/docs/en/kmesh_commands.md
+++ b/docs/en/kmesh_commands.md
@@ -10,7 +10,8 @@ Usage:
   kmesh-daemon [flags]
 
 Flags:
-      --bpf-fs-path string     bpf fs path (default "/sys/fs/bpf")
+      --bpf-fs-path string             bpf fs path (default "/sys/fs/bpf")
+      --bpf-verifier-log-level uint32  bpf verifier log level bitmask for debugging bpf program loads (1=branch, 2=instruction, 4=stats; OR values together); 0 disables verifier logging (default 0)
       --cgroup2-path string    cgroup2 path (default "/mnt/kmesh_cgroup2")
       --enable-mda             enable mda
   -h, --help                   help for kmesh-daemon
@@ -27,6 +28,8 @@ Flags:
 ./kmesh-daemon --mode=kernel-native --enable-mda
 # example
 ./kmesh-daemon --mode=dual-engine --enable-mda
+# example
+./kmesh-daemon --mode=dual-engine --bpf-verifier-log-level=1
 ```
 
 - Commands Example
@@ -52,3 +55,7 @@ Flags:
     [root@localhost Kmesh]# mount | grep "/sys/fs/bpf"
     none on /sys/fs/bpf type bpf (rw,nosuid,nodev,noexec,relatime,mode=700)
     ```
+
+  - `--bpf-verifier-log-level` is disabled (`0`) by default and adds no runtime overhead. Set it to debug bpf program load/verifier
+    failures; the value is a bitmask passed straight through to the bpf verifier (`1`=branch, `2`=instruction, `4`=stats, values
+    may be OR'd, e.g. `3`). When non-zero, kmesh captures the full verifier output and writes it to the daemon log.

--- a/pkg/bpf/ads/sock_connection.go
+++ b/pkg/bpf/ads/sock_connection.go
@@ -47,6 +47,7 @@ func (sc *BpfSockConn) NewBpf(cfg *options.BpfConfig) error {
 	sc.Info.MapPath = cfg.BpfFsPath + "/bpf_kmesh/map/"
 	sc.Info.BpfFsPath = cfg.BpfFsPath + "/bpf_kmesh/sockconn/"
 	sc.Info.Cgroup2Path = cfg.Cgroup2Path
+	sc.Info.VerifierLogLevel = cfg.BpfVerifierLogLevel
 
 	if err := os.MkdirAll(sc.Info.MapPath,
 		syscall.S_IRUSR|syscall.S_IWUSR|syscall.S_IXUSR|
@@ -70,6 +71,7 @@ func (sc *BpfSockConn) loadKmeshSockConnObjects() (*ebpf.CollectionSpec, error) 
 		opts ebpf.CollectionOptions
 	)
 	opts.Maps.PinPath = sc.Info.MapPath
+	opts.Programs = utils.ProgramOptionsForVerifierLog(sc.Info.VerifierLogLevel)
 
 	spec, err = loadKmeshCgroupSock()
 	if err != nil || spec == nil {
@@ -79,6 +81,11 @@ func (sc *BpfSockConn) loadKmeshSockConnObjects() (*ebpf.CollectionSpec, error) 
 	utils.SetMapPinType(spec, ebpf.PinByName)
 	if err = spec.LoadAndAssign(&sc.KmeshCgroupSockObjects, &opts); err != nil {
 		return nil, err
+	}
+
+	if sc.Info.VerifierLogLevel != 0 {
+		progs := reflect.ValueOf(sc.KmeshCgroupSockObjects.KmeshCgroupSockPrograms)
+		utils.LogVerifierOutput(&progs, log.Infof)
 	}
 
 	return spec, nil

--- a/pkg/bpf/ads/sock_ops.go
+++ b/pkg/bpf/ads/sock_ops.go
@@ -35,6 +35,7 @@ func (sc *BpfSockOps) NewBpf(cfg *options.BpfConfig) error {
 	sc.Info.MapPath = cfg.BpfFsPath + "/bpf_kmesh/map/"
 	sc.Info.BpfFsPath = cfg.BpfFsPath + "/bpf_kmesh/sockops/"
 	sc.Info.Cgroup2Path = cfg.Cgroup2Path
+	sc.Info.VerifierLogLevel = cfg.BpfVerifierLogLevel
 
 	if err := os.MkdirAll(sc.Info.MapPath,
 		syscall.S_IRUSR|syscall.S_IWUSR|syscall.S_IXUSR|
@@ -59,6 +60,7 @@ func (sc *BpfSockOps) loadKmeshSockopsObjects() (*ebpf.CollectionSpec, error) {
 	)
 
 	opts.Maps.PinPath = sc.Info.MapPath
+	opts.Programs = utils.ProgramOptionsForVerifierLog(sc.Info.VerifierLogLevel)
 	spec, err = loadKmeshSockOps()
 	if err != nil || spec == nil {
 		return nil, err
@@ -67,6 +69,11 @@ func (sc *BpfSockOps) loadKmeshSockopsObjects() (*ebpf.CollectionSpec, error) {
 	utils.SetMapPinType(spec, ebpf.PinByName)
 	if err = spec.LoadAndAssign(&sc.KmeshSockopsObjects, &opts); err != nil {
 		return nil, err
+	}
+
+	if sc.Info.VerifierLogLevel != 0 {
+		progs := reflect.ValueOf(sc.KmeshSockopsObjects.KmeshSockopsPrograms)
+		utils.LogVerifierOutput(&progs, log.Infof)
 	}
 
 	return spec, nil

--- a/pkg/bpf/general/tc.go
+++ b/pkg/bpf/general/tc.go
@@ -28,8 +28,11 @@ import (
 	"kmesh.net/kmesh/daemon/options"
 	"kmesh.net/kmesh/pkg/bpf/utils"
 	"kmesh.net/kmesh/pkg/constants"
+	"kmesh.net/kmesh/pkg/logger"
 	helper "kmesh.net/kmesh/pkg/utils"
 )
+
+var log = logger.NewLoggerScope("bpf_general")
 
 type BpfTCGeneral struct {
 	InfoTcMarkEncrypt BpfInfo
@@ -55,10 +58,12 @@ func (tc *BpfTCGeneral) newBpf(encryptInfo *BpfInfo, decryptInfo *BpfInfo, cfg *
 	encryptInfo.MapPath = generalMapPath
 	encryptInfo.BpfFsPath = generalFsPath
 	encryptInfo.Cgroup2Path = cfg.Cgroup2Path
+	encryptInfo.VerifierLogLevel = cfg.BpfVerifierLogLevel
 
 	decryptInfo.MapPath = generalMapPath
 	decryptInfo.BpfFsPath = generalFsPath
 	decryptInfo.Cgroup2Path = cfg.Cgroup2Path
+	decryptInfo.VerifierLogLevel = cfg.BpfVerifierLogLevel
 
 	if err := os.MkdirAll(generalMapPath,
 		syscall.S_IRUSR|syscall.S_IWUSR|syscall.S_IXUSR|
@@ -86,7 +91,9 @@ func (tc *BpfTCGeneral) loadKmeshTCObjects() (*ebpf.CollectionSpec, *ebpf.Collec
 	)
 
 	optsTcMarkEncrypt.Maps.PinPath = tc.InfoTcMarkEncrypt.MapPath
+	optsTcMarkEncrypt.Programs = utils.ProgramOptionsForVerifierLog(tc.InfoTcMarkEncrypt.VerifierLogLevel)
 	optsTcMarkDecrypt.Maps.PinPath = tc.InfoTcMarkDecrypt.MapPath
+	optsTcMarkDecrypt.Programs = utils.ProgramOptionsForVerifierLog(tc.InfoTcMarkDecrypt.VerifierLogLevel)
 	if helper.KernelVersionLowerThan5_13() {
 		specTcMarkEncrypt, errTcMarkEncrypt = general.LoadKmeshTcMarkEncryptCompat()
 		specTcMarkDecrypt, errTcMarkDecrypt = general.LoadKmeshTcMarkDecryptCompat()
@@ -110,6 +117,15 @@ func (tc *BpfTCGeneral) loadKmeshTCObjects() (*ebpf.CollectionSpec, *ebpf.Collec
 	}
 	if err := specTcMarkDecrypt.LoadAndAssign(&tc.KmeshTcMarkDecryptObjects, &optsTcMarkDecrypt); err != nil {
 		return nil, nil, err
+	}
+
+	if tc.InfoTcMarkEncrypt.VerifierLogLevel != 0 {
+		progs := reflect.ValueOf(tc.KmeshTcMarkEncryptObjects.KmeshTcMarkEncryptPrograms)
+		utils.LogVerifierOutput(&progs, log.Infof)
+	}
+	if tc.InfoTcMarkDecrypt.VerifierLogLevel != 0 {
+		progs := reflect.ValueOf(tc.KmeshTcMarkDecryptObjects.KmeshTcMarkDecryptPrograms)
+		utils.LogVerifierOutput(&progs, log.Infof)
 	}
 
 	return specTcMarkEncrypt, specTcMarkDecrypt, nil

--- a/pkg/bpf/utils/bpf_helper.go
+++ b/pkg/bpf/utils/bpf_helper.go
@@ -18,6 +18,7 @@ package utils
 
 import (
 	"os"
+	"reflect"
 	"strconv"
 
 	"fmt"
@@ -25,6 +26,40 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/link"
 )
+
+// VerifierLogSize is the starting size, in bytes, of the verifier log buffer
+// used when BPF verifier logging is enabled. It is sized generously so the
+// full verifier output for kmesh's BPF programs can be captured without
+// relying on the ebpf library's automatic buffer-doubling retries.
+const VerifierLogSize = 10 * 1024 * 1024
+
+// ProgramOptionsForVerifierLog returns the ebpf.ProgramOptions needed to
+// capture verifier output at the given log level. A level of 0 returns the
+// zero value, leaving default (no verifier logging) program load behavior
+// unchanged.
+func ProgramOptionsForVerifierLog(level uint32) ebpf.ProgramOptions {
+	if level == 0 {
+		return ebpf.ProgramOptions{}
+	}
+	return ebpf.ProgramOptions{
+		LogLevel:     ebpf.LogLevel(level),
+		LogSizeStart: VerifierLogSize,
+	}
+}
+
+// LogVerifierOutput logs the captured eBPF verifier output for each
+// *ebpf.Program field in value (a bpf2go-generated *Programs struct).
+// Fields with no captured output (verifier logging disabled or load
+// skipped it) are left untouched.
+func LogVerifierOutput(value *reflect.Value, logf func(format string, args ...interface{})) {
+	for i := 0; i < value.NumField(); i++ {
+		prog, ok := value.Field(i).Interface().(*ebpf.Program)
+		if !ok || prog == nil || prog.VerifierLog == "" {
+			continue
+		}
+		logf("bpf verifier log for %s:\n%s", value.Type().Field(i).Name, prog.VerifierLog)
+	}
+}
 
 func SetEnvByBpfMapId(m *ebpf.Map, key string) error {
 	info, _ := m.Info()

--- a/pkg/bpf/utils/bpf_helper_test.go
+++ b/pkg/bpf/utils/bpf_helper_test.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/cilium/ebpf"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProgramOptionsForVerifierLog(t *testing.T) {
+	// Disabled (default) level must return the zero value, preserving
+	// default program load behavior.
+	assert.Equal(t, ebpf.ProgramOptions{}, ProgramOptionsForVerifierLog(0))
+
+	opts := ProgramOptionsForVerifierLog(3)
+	assert.Equal(t, ebpf.LogLevel(3), opts.LogLevel)
+	assert.Equal(t, uint32(VerifierLogSize), opts.LogSizeStart)
+}
+
+type testPrograms struct {
+	Foo *ebpf.Program
+	Bar *ebpf.Program
+	Baz *ebpf.Program
+}
+
+func TestLogVerifierOutput(t *testing.T) {
+	progs := testPrograms{
+		Foo: &ebpf.Program{VerifierLog: "foo verifier output"},
+		Bar: &ebpf.Program{}, // loaded, but no captured output
+		Baz: nil,             // never loaded
+	}
+
+	var logged []string
+	logf := func(format string, args ...interface{}) {
+		logged = append(logged, fmt.Sprintf(format, args...))
+	}
+
+	value := reflect.ValueOf(progs)
+	LogVerifierOutput(&value, logf)
+
+	if assert.Len(t, logged, 1) {
+		assert.Contains(t, logged[0], "Foo")
+		assert.Contains(t, logged[0], "foo verifier output")
+	}
+}
+
+func TestLogVerifierOutputNoop(t *testing.T) {
+	progs := testPrograms{}
+
+	logf := func(format string, args ...interface{}) {
+		t.Fatalf("logf should not be called when no verifier output was captured")
+	}
+
+	value := reflect.ValueOf(progs)
+	LogVerifierOutput(&value, logf)
+}

--- a/pkg/bpf/workload/sendmsg.go
+++ b/pkg/bpf/workload/sendmsg.go
@@ -45,6 +45,7 @@ func (sm *BpfSendMsgWorkload) NewBpf(cfg *options.BpfConfig, sockOpsWorkloadObj 
 	sm.Info.MapPath = cfg.BpfFsPath + "/bpf_kmesh_workload/map/"
 	sm.Info.BpfFsPath = cfg.BpfFsPath + "/bpf_kmesh_workload/sendmsg/"
 	sm.Info.Cgroup2Path = cfg.Cgroup2Path
+	sm.Info.VerifierLogLevel = cfg.BpfVerifierLogLevel
 	sm.sockOpsWorkloadObj = sockOpsWorkloadObj
 
 	if err := os.MkdirAll(sm.Info.MapPath,
@@ -70,6 +71,7 @@ func (sm *BpfSendMsgWorkload) loadKmeshSendmsgObjects() (*ebpf.CollectionSpec, e
 	)
 
 	opts.Maps.PinPath = sm.Info.MapPath
+	opts.Programs = utils.ProgramOptionsForVerifierLog(sm.Info.VerifierLogLevel)
 	if helper.KernelVersionLowerThan5_13() {
 		spec, err = bpf2go.LoadKmeshSendmsgCompat()
 	} else {
@@ -82,6 +84,11 @@ func (sm *BpfSendMsgWorkload) loadKmeshSendmsgObjects() (*ebpf.CollectionSpec, e
 	utils.SetMapPinType(spec, ebpf.PinByName)
 	if err = spec.LoadAndAssign(&sm.KmeshSendmsgObjects, &opts); err != nil {
 		return nil, err
+	}
+
+	if sm.Info.VerifierLogLevel != 0 {
+		progs := reflect.ValueOf(sm.KmeshSendmsgObjects.KmeshSendmsgPrograms)
+		utils.LogVerifierOutput(&progs, log.Infof)
 	}
 
 	// bpflink for sk_msg is supported in kernel 6.13, so we update sendmsg manually here

--- a/pkg/bpf/workload/skb.go
+++ b/pkg/bpf/workload/skb.go
@@ -46,6 +46,7 @@ func (cs *BpfCroupSkbWorkload) NewBpf(cfg *options.BpfConfig) error {
 	cs.Info.MapPath = cfg.BpfFsPath + "/bpf_kmesh_workload/map/"
 	cs.Info.BpfFsPath = cfg.BpfFsPath + "/bpf_kmesh_workload/cgroup_skb/"
 	cs.Info.Cgroup2Path = cfg.Cgroup2Path
+	cs.Info.VerifierLogLevel = cfg.BpfVerifierLogLevel
 	cs.InfoEg = cs.Info
 	if err := os.MkdirAll(cs.Info.MapPath,
 		syscall.S_IRUSR|syscall.S_IWUSR|syscall.S_IXUSR|
@@ -70,6 +71,7 @@ func (cs *BpfCroupSkbWorkload) loadKmeshCgroupSkbObjects() (*ebpf.CollectionSpec
 	)
 
 	opts.Maps.PinPath = cs.Info.MapPath
+	opts.Programs = utils.ProgramOptionsForVerifierLog(cs.Info.VerifierLogLevel)
 
 	if helper.KernelVersionLowerThan5_13() {
 		spec, err = bpf2go.LoadKmeshCgroupSkbCompat()
@@ -86,6 +88,11 @@ func (cs *BpfCroupSkbWorkload) loadKmeshCgroupSkbObjects() (*ebpf.CollectionSpec
 	utils.SetMapPinType(spec, ebpf.PinByName)
 	if err = spec.LoadAndAssign(&cs.KmeshCgroupSkbObjects, &opts); err != nil {
 		return nil, err
+	}
+
+	if cs.Info.VerifierLogLevel != 0 {
+		progs := reflect.ValueOf(cs.KmeshCgroupSkbObjects.KmeshCgroupSkbPrograms)
+		utils.LogVerifierOutput(&progs, log.Infof)
 	}
 
 	return spec, nil

--- a/pkg/bpf/workload/sock_connection.go
+++ b/pkg/bpf/workload/sock_connection.go
@@ -50,6 +50,7 @@ func (sc *SockConnWorkload) NewBpf(cfg *options.BpfConfig) error {
 	sc.Info.MapPath = cfg.BpfFsPath + "/bpf_kmesh_workload/map/"
 	sc.Info.BpfFsPath = cfg.BpfFsPath + "/bpf_kmesh_workload/sockconn/"
 	sc.Info.Cgroup2Path = cfg.Cgroup2Path
+	sc.Info.VerifierLogLevel = cfg.BpfVerifierLogLevel
 	sc.Info6 = sc.Info
 	sc.InfoDns4 = sc.Info
 	sc.InfoDnsRcv4 = sc.Info
@@ -76,6 +77,7 @@ func (sc *SockConnWorkload) loadKmeshSockConnObjects() (*ebpf.CollectionSpec, er
 		opts ebpf.CollectionOptions
 	)
 	opts.Maps.PinPath = sc.Info.MapPath
+	opts.Programs = utils.ProgramOptionsForVerifierLog(sc.Info.VerifierLogLevel)
 	if helper.KernelVersionLowerThan5_13() {
 		spec, err = bpf2go.LoadKmeshCgroupSockWorkloadCompat()
 	} else {
@@ -88,6 +90,11 @@ func (sc *SockConnWorkload) loadKmeshSockConnObjects() (*ebpf.CollectionSpec, er
 	utils.SetMapPinType(spec, ebpf.PinByName)
 	if err = spec.LoadAndAssign(&sc.KmeshCgroupSockWorkloadObjects, &opts); err != nil {
 		return nil, err
+	}
+
+	if sc.Info.VerifierLogLevel != 0 {
+		progs := reflect.ValueOf(sc.KmeshCgroupSockWorkloadObjects.KmeshCgroupSockWorkloadPrograms)
+		utils.LogVerifierOutput(&progs, log.Infof)
 	}
 
 	return spec, nil

--- a/pkg/bpf/workload/sock_ops.go
+++ b/pkg/bpf/workload/sock_ops.go
@@ -44,6 +44,7 @@ func (so *BpfSockOpsWorkload) NewBpf(cfg *options.BpfConfig) error {
 	so.Info.MapPath = cfg.BpfFsPath + "/bpf_kmesh_workload/map/"
 	so.Info.BpfFsPath = cfg.BpfFsPath + "/bpf_kmesh_workload/sockops/"
 	so.Info.Cgroup2Path = cfg.Cgroup2Path
+	so.Info.VerifierLogLevel = cfg.BpfVerifierLogLevel
 
 	if err := os.MkdirAll(so.Info.MapPath,
 		syscall.S_IRUSR|syscall.S_IWUSR|syscall.S_IXUSR|
@@ -68,6 +69,7 @@ func (so *BpfSockOpsWorkload) loadKmeshSockopsObjects() (*ebpf.CollectionSpec, e
 	)
 
 	opts.Maps.PinPath = so.Info.MapPath
+	opts.Programs = utils.ProgramOptionsForVerifierLog(so.Info.VerifierLogLevel)
 
 	if helper.KernelVersionLowerThan5_13() {
 		spec, err = bpf2go.LoadKmeshSockopsWorkloadCompat()
@@ -84,6 +86,11 @@ func (so *BpfSockOpsWorkload) loadKmeshSockopsObjects() (*ebpf.CollectionSpec, e
 	utils.SetMapPinType(spec, ebpf.PinByName)
 	if err = spec.LoadAndAssign(&so.KmeshSockopsWorkloadObjects, &opts); err != nil {
 		return nil, err
+	}
+
+	if so.Info.VerifierLogLevel != 0 {
+		progs := reflect.ValueOf(so.KmeshSockopsWorkloadObjects.KmeshSockopsWorkloadPrograms)
+		utils.LogVerifierOutput(&progs, log.Infof)
 	}
 
 	return spec, nil

--- a/pkg/bpf/workload/xdp.go
+++ b/pkg/bpf/workload/xdp.go
@@ -41,6 +41,7 @@ func (xa *BpfXdpAuthWorkload) NewBpf(cfg *options.BpfConfig) error {
 	xa.Info.MapPath = cfg.BpfFsPath + "/bpf_kmesh_workload/map/"
 	xa.Info.BpfFsPath = cfg.BpfFsPath + "/bpf_kmesh_workload/xdpauth/"
 	xa.Info.Cgroup2Path = cfg.Cgroup2Path
+	xa.Info.VerifierLogLevel = cfg.BpfVerifierLogLevel
 
 	if err := os.MkdirAll(xa.Info.MapPath,
 		syscall.S_IRUSR|syscall.S_IWUSR|syscall.S_IXUSR|
@@ -65,6 +66,7 @@ func (xa *BpfXdpAuthWorkload) loadKmeshXdpAuthObjects() (*ebpf.CollectionSpec, e
 	)
 
 	opts.Maps.PinPath = xa.Info.MapPath
+	opts.Programs = utils.ProgramOptionsForVerifierLog(xa.Info.VerifierLogLevel)
 	if helper.KernelVersionLowerThan5_13() {
 		spec, err = bpf2go.LoadKmeshXDPAuthCompat()
 	} else {
@@ -80,6 +82,11 @@ func (xa *BpfXdpAuthWorkload) loadKmeshXdpAuthObjects() (*ebpf.CollectionSpec, e
 	utils.SetMapPinType(spec, ebpf.PinByName)
 	if err = spec.LoadAndAssign(&xa.KmeshXDPAuthObjects, &opts); err != nil {
 		return nil, err
+	}
+
+	if xa.Info.VerifierLogLevel != 0 {
+		progs := reflect.ValueOf(xa.KmeshXDPAuthObjects.KmeshXDPAuthPrograms)
+		utils.LogVerifierOutput(&progs, log.Infof)
 	}
 
 	return spec, nil


### PR DESCRIPTION
## What type of PR is this?

/kind enhancement

---

## What this PR does / why we need it

Debugging BPF verifier failures currently requires modifying source code, rebuilding the daemon, redeploying, and collecting logs from each iteration. This makes investigating verifier rejections slow and difficult, especially in CI.

This PR introduces an optional `--bpf-verifier-log-level` flag for `kmesh-daemon` to expose eBPF verifier logs without changing the default execution path.

When the flag is left at its default value (`0`), Kmesh behaves exactly as before and incurs no additional runtime overhead.

When a non-zero value is supplied:

- Configures `ebpf.CollectionOptions.Programs.LogLevel`
- Configures `Programs.LogSizeStart` to capture complete verifier output
- Applies the configuration consistently across every BPF loader
- Emits verifier logs through the daemon logger to simplify debugging of load failures

To avoid duplicated configuration logic, verifier option construction is centralized in a shared helper used by all BPF program loaders.

Documentation has also been updated to describe the new debugging option.

---

## Changes included

- Add optional `--bpf-verifier-log-level` daemon flag (default: `0`)
- Thread verifier log configuration through all BPF program loaders
- Centralize `ebpf.CollectionOptions` construction in a shared helper
- Capture and emit verifier logs when explicitly enabled
- Update English and Chinese command documentation
- Add unit tests covering:
  - flag parsing and default behaviour
  - CollectionOptions construction
  - verifier log capture behaviour

---

## Why this approach

- Default behaviour is unchanged.
- No additional runtime cost unless the flag is explicitly enabled.
- Makes diagnosing BPF verifier failures significantly easier without introducing debug-only source modifications.
- Reduces future debugging time for verifier-related CI failures and development.

## Special notes for your reviewer

- Default behaviour remains identical (`--bpf-verifier-log-level=0`).
- This PR is intended purely as a debugging enhancement and does not modify datapath behaviour.
- The verifier logging path is only activated when the flag is explicitly provided.

---

## Does this PR introduce a user-facing change?

```release-note
Added an optional `--bpf-verifier-log-level` flag to kmesh-daemon for collecting detailed eBPF verifier logs during BPF program loading. The flag is disabled by default and does not change normal runtime behaviour.