### PR TITLE
fix: remove stale workload addresses from cache

### DIFF
--- a/pkg/controller/workload/cache/workload_cache.go
+++ b/pkg/controller/workload/cache/workload_cache.go
@@ -76,6 +76,14 @@ func (w *cache) AddOrUpdateWorkload(workload *workloadapi.Workload) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 
+	if oldWorkload := w.byUid[workload.Uid]; oldWorkload != nil {
+		for _, ip := range oldWorkload.Addresses {
+			addr, _ := netip.AddrFromSlice(ip)
+			networkAddress := composeNetworkAddress(oldWorkload.Network, addr)
+			w.deleteAddr(networkAddress, workload.Uid)
+		}
+	}
+
 	w.byUid[workload.Uid] = workload
 
 	// We should exclude the workloads that use host network mode

--- a/pkg/controller/workload/cache/workload_cache_test.go
+++ b/pkg/controller/workload/cache/workload_cache_test.go
@@ -114,6 +114,20 @@ func TestAddOrUpdateWorkload(t *testing.T) {
 		assert.Equal(t, newWorkload, w.byUid["123456"])
 		assert.Equal(t, newWorkload, w.byAddr[NetworkAddress{Network: newWorkload.Network, Address: addr}])
 	})
+
+	t.Run("workload address update", func(t *testing.T) {
+		w := NewWorkloadCache()
+		workload := common.CreateFakeWorkload("1.2.3.4", "", common.WithWorkloadBasicInfo("ut-workload", "123456", "ut-net"))
+		w.AddOrUpdateWorkload(workload)
+
+		newWorkload := common.CreateFakeWorkload("1.2.3.5", "", common.WithWorkloadBasicInfo("ut-workload", "123456", "ut-net"))
+		w.AddOrUpdateWorkload(newWorkload)
+
+		oldAddr := netip.MustParseAddr("1.2.3.4")
+		newAddr := netip.MustParseAddr("1.2.3.5")
+		assert.Equal(t, (*workloadapi.Workload)(nil), w.byAddr[NetworkAddress{Network: "ut-net", Address: oldAddr}])
+		assert.Equal(t, newWorkload, w.byAddr[NetworkAddress{Network: "ut-net", Address: newAddr}])
+	})
 }
 
 func TestDeleteWorkload(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Removes stale workload address entries when a workload is updated with a new address.

**Which issue(s) this PR fixes**:

Fixes #1822

**Special notes for your reviewer**:

Added a regression test for workload address updates.

**Does this PR introduce a user-facing change?**:

```release-note
NONE