### PR TITLE
fix(e2e): gate kmesh daemon setup on Pod readiness, not phase

### DIFF
--- a/deploy/charts/kmesh-helm/templates/daemonset.yaml
+++ b/deploy/charts/kmesh-helm/templates/daemonset.yaml
@@ -58,6 +58,19 @@ spec:
         image: {{ .Values.deploy.kmesh.image.repository }}:{{ .Values.deploy.kmesh.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.deploy.kmesh.imagePullPolicy }}
         name: kmesh
+        # Admin server binds to localhost:15200 only, so it can't be probed via
+        # httpGet/tcpSocket (those target the Pod IP); use exec instead.
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - "cat < /dev/null > /dev/tcp/127.0.0.1/15200"
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          timeoutSeconds: 2
+          failureThreshold: 3
+          successThreshold: 1
         resources: {{- toYaml .Values.deploy.kmesh.resources | nindent 10 }}
         securityContext:
           privileged: true

--- a/test/e2e/run_test.sh
+++ b/test/e2e/run_test.sh
@@ -138,6 +138,42 @@ function setup_istio() {
 	done
 }
 
+function collect_diagnostics() {
+	local ns="${1:-kmesh-system}"
+
+	echo "===== DIAGNOSTICS (namespace: $ns) ====="
+
+	echo "--- kubectl get pods -A -o wide ---"
+	kubectl get pods -A -o wide || true
+
+	echo "--- kubectl get events -n $ns --sort-by=.lastTimestamp ---"
+	kubectl get events -n "$ns" --sort-by=.lastTimestamp || true
+
+	local pods
+	pods=$(kubectl get pods -n "$ns" -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || true)
+
+	if [ -z "$pods" ]; then
+		echo "(no pods found in namespace $ns)"
+	fi
+
+	for pod in $pods; do
+		echo "--- kubectl describe pod $pod -n $ns ---"
+		kubectl describe pod "$pod" -n "$ns" || true
+
+		echo "--- container restart counts for pod $pod ---"
+		kubectl get pod "$pod" -n "$ns" \
+			-o jsonpath='{range .status.containerStatuses[*]}{.name}{"  ready="}{.ready}{"  restartCount="}{.restartCount}{"\n"}{end}' || true
+
+		echo "--- kubectl logs $pod -n $ns (current container) ---"
+		kubectl logs "$pod" -n "$ns" --all-containers=true --timestamps=true || true
+
+		echo "--- kubectl logs $pod -n $ns --previous (last crashed/restarted container, if any) ---"
+		kubectl logs "$pod" -n "$ns" --all-containers=true --previous || true
+	done
+
+	echo "===== END DIAGNOSTICS ====="
+}
+
 function setup_kmesh() {
 	# skip dns proxy for ipv6
 	[[ -n ${IPV6:-} ]] && extra_args="--set features.dnsProxy.enabled=false"
@@ -157,28 +193,25 @@ function setup_kmesh() {
 		--set deploy.kmesh.containers.kmeshDaemonArgs="--mode=dual-engine --enable-bypass=false --monitoring=true --enable-ipsec=true" \
 		$extra_args
 
-	# Wait for all Kmesh pods to be ready.
+	# kubectl wait below fails immediately if the selector matches zero pods, so
+	# wait for the DaemonSet to schedule at least one before using it.
 	while true; do
-		pod_statuses=$(kubectl get pods -n kmesh-system -l app=kmesh -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.phase}{"\n"}{end}')
-
-		running_pods=0
-		total_pods=0
-
-		while read -r pod_name pod_status; do
-			total_pods=$((total_pods + 1))
-			if [ "$pod_status" = "Running" ]; then
-				running_pods=$((running_pods + 1))
-			fi
-		done <<<"$pod_statuses"
-
-		if [ "$running_pods" -eq "$total_pods" ]; then
-			echo "All pods of Kmesh daemon are in Running state."
+		pod_count=$(kubectl get pods -n kmesh-system -l app=kmesh --no-headers 2>/dev/null | wc -l)
+		if [ "$pod_count" -gt 0 ]; then
 			break
 		fi
-
-		echo "Waiting for pods of Kmesh daemon to enter Running state..."
+		echo "No Kmesh daemon pods scheduled yet, waiting..."
 		sleep 1
 	done
+
+	# Wait for Ready (admin port up), not just Running (process exec'd), since
+	# kmeshctl log below depends on the admin server being reachable.
+	if ! kubectl wait --for=condition=Ready pod -l app=kmesh -n kmesh-system --timeout=180s; then
+		echo "Kmesh daemon pods did not become Ready within the timeout."
+		collect_diagnostics "kmesh-system"
+		exit 1
+	fi
+	echo "All pods of Kmesh daemon are Ready."
 
 	# Set log of each Kmesh pods.
 	PODS=$(kubectl get pods -n kmesh-system -l app=kmesh -o jsonpath='{.items[*].metadata.name}')
@@ -194,7 +227,11 @@ function setup_kmesh() {
 				break
 			fi
 			echo "Failed to set BPF debug log. Output: $output"
-			[ $i -eq 5 ] && echo "Failed to set BPF debug log after 5 attempts" && exit 1
+			if [ $i -eq 5 ]; then
+				echo "Failed to set BPF debug log after 5 attempts"
+				collect_diagnostics "kmesh-system"
+				exit 1
+			fi
 			sleep 2
 		done
 
@@ -207,7 +244,11 @@ function setup_kmesh() {
 				break
 			fi
 			echo "Failed to set default debug log. Output: $output"
-			[ $i -eq 5 ] && echo "Failed to set default debug log after 5 attempts" && exit 1
+			if [ $i -eq 5 ]; then
+				echo "Failed to set default debug log after 5 attempts"
+				collect_diagnostics "kmesh-system"
+				exit 1
+			fi
 			sleep 2
 		done
 	done
@@ -228,7 +269,11 @@ function setup_kmesh_log() {
 				break
 			fi
 			echo "Failed to set BPF debug log. Output: $output"
-			[ $i -eq 5 ] && echo "Failed to set BPF debug log after 5 attempts" && exit 1
+			if [ $i -eq 5 ]; then
+				echo "Failed to set BPF debug log after 5 attempts"
+				collect_diagnostics "kmesh-system"
+				exit 1
+			fi
 			sleep 2
 		done
 
@@ -241,7 +286,11 @@ function setup_kmesh_log() {
 				break
 			fi
 			echo "Failed to set default debug log. Output: $output"
-			[ $i -eq 5 ] && echo "Failed to set default debug log after 5 attempts" && exit 1
+			if [ $i -eq 5 ]; then
+				echo "Failed to set default debug log after 5 attempts"
+				collect_diagnostics "kmesh-system"
+				exit 1
+			fi
 			sleep 2
 		done
 	done


### PR DESCRIPTION
## What type of PR is this?

/kind enhancement

---

## What this PR does / why we need it

The E2E test setup previously waited only for the `kmesh-daemon` pods to enter the **Running** phase before executing `kmeshctl log`.

However, a pod entering the Running phase does **not** guarantee that `kmesh-daemon` has finished:

- loading its BPF programs,
- initializing the XDS controller, or
- starting the admin server on `127.0.0.1:15200`.

As a result, `kmeshctl log` could run too early and fail with `connection refused`, causing CI failures that were unrelated to the actual functionality under test.

This PR replaces the Running-phase check with proper readiness gating by:

- adding a `readinessProbe` to the DaemonSet that verifies the admin server is accepting connections on the local admin port,
- waiting for the pod's **Ready** condition in `run_test.sh` before continuing with the test setup, and
- improving failure diagnostics so startup failures can be investigated directly from CI logs.

Since the admin server only listens on localhost, the readiness probe uses an `exec` check rather than `httpGet` or `tcpSocket`.

Additionally, a reusable `collect_diagnostics()` helper is introduced to gather useful debugging information whenever setup fails, including:

- pod status
- pod descriptions
- cluster events
- restart counts
- current container logs
- previous container logs

This allows startup failures to be diagnosed without reproducing them locally while leaving the daemon's runtime behaviour unchanged.

---

## Changes included

- Add `readinessProbe` to the kmesh DaemonSet
- Wait for the pod `Ready` condition instead of the `Running` phase
- Add a pre-check to ensure pods exist before calling `kubectl wait`
- Introduce `collect_diagnostics()` for setup failures
- Collect:
  - pod status
  - pod descriptions
  - cluster events
  - restart counts
  - current logs
  - previous logs
- Invoke diagnostics automatically on all setup failure paths

---

## Why this approach

- Eliminates startup races caused by checking only the Running phase.
- Ensures tests begin only after the daemon is actually ready.
- Greatly improves CI debuggability without affecting successful runs.
- Makes future startup regressions significantly easier to diagnose.

---

## Special notes for your reviewer

- No daemon or datapath behaviour is modified.
- The readiness probe only affects E2E startup sequencing.
- Diagnostics are collected only when setup fails and do not affect successful test runs.
- The admin server binds to localhost, so an `exec` readiness probe is required instead of `httpGet` or `tcpSocket`.

---

## Does this PR introduce a user-facing change?

```release-note
Improved E2E test startup reliability by waiting for kmesh-daemon readiness instead of Pod Running status, and added automatic diagnostic collection for setup failures.
```