### PR TITLE
fix: handle IPsec tombstone delete events

### DIFF
--- a/pkg/controller/encryption/ipsec/ipsec_controller.go
+++ b/pkg/controller/encryption/ipsec/ipsec_controller.go
@@ -292,8 +292,16 @@ func (c *Controller) handleKNIUpdate(oldObj, newObj interface{}) {
 func (c *Controller) handleKNIDelete(obj interface{}) {
 	node, ok := obj.(*v1alpha1.KmeshNodeInfo)
 	if !ok {
-		log.Errorf("expected *v1alpha1_core.KmeshNodeInfo but got %T in handle delete func", obj)
-		return
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			log.Errorf("couldn't get object from tombstone %#v", obj)
+			return
+		}
+		node, ok = tombstone.Obj.(*v1alpha1.KmeshNodeInfo)
+		if !ok {
+			log.Errorf("tombstone contained object that is not a KmeshNodeInfo %#v", obj)
+			return
+		}
 	}
 	nodeNsPath := kmesh_netns.GetNodeNSpath()
 	deleteFunc := func(netns.NetNS) error {

--- a/pkg/controller/encryption/ipsec/ipsec_controller_test.go
+++ b/pkg/controller/encryption/ipsec/ipsec_controller_test.go
@@ -267,8 +267,8 @@ func TestHandleKNIEvents(t *testing.T) {
 	})
 
 	t.Run("handleKNIDelete", func(t *testing.T) {
-		// Test case 1: Normal delete of remote node
-		t.Run("Normal delete of remote node", func(t *testing.T) {
+		// Test case 1: Delete remote node from tombstone
+		t.Run("Delete remote node from tombstone", func(t *testing.T) {
 			controller := prepare(t)
 			// Create patches for network namespace operations
 			nsPatches := gomonkey.NewPatches()
@@ -300,8 +300,8 @@ func TestHandleKNIEvents(t *testing.T) {
 				assert.Contains(t, testRemoteNodeInfo.Spec.PodCIDRs, remoteCIDR)
 			})
 
-			// Call handleKNIDelete with remote node
-			controller.handleKNIDelete(testRemoteNodeInfo)
+			// Call handleKNIDelete with tombstone
+			controller.handleKNIDelete(cache.DeletedFinalStateUnknown{Obj: testRemoteNodeInfo})
 
 			// Verify that Clean was called for each address
 			assert.Equal(t, len(testRemoteNodeInfo.Spec.Addresses), cleanCallCount, "ipsecHandler.Clean should be called once for each address")


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Handles informer tombstones in the KmeshNodeInfo delete handler so stale IPsec and CIDR state is cleaned up.

**Which issue(s) this PR fixes**:

Fixes #1828

**Special notes for your reviewer**:

Adds coverage for the tombstone delete path.

**Does this PR introduce a user-facing change?**:

```release-note
NONE