### PR TITLE
refactor(ctl): decouple kmeshctl output from os.Stdout for MCP integration

### DIFF
--- a/ctl/authz/authz.go
+++ b/ctl/authz/authz.go
@@ -137,7 +137,7 @@ func NewStatusCmd() *cobra.Command {
 				fmt.Fprintf(tw, "%s\t%s\n", s.Pod, s.Status)
 			}
 			tw.Flush()
-			fmt.Print(buf.String())
+			fmt.Fprint(cmd.OutOrStdout(), buf.String())
 		},
 	}
 	return cmd

--- a/ctl/dump/dump.go
+++ b/ctl/dump/dump.go
@@ -103,16 +103,17 @@ func RunDump(cmd *cobra.Command, args []string, outputFormat string) error {
 		os.Exit(1)
 	}
 
+	out := cmd.OutOrStdout()
 	if outputFormat == "json" {
-		fmt.Println(string(body))
+		fmt.Fprintln(out, string(body))
 		return nil
 	}
 
 	switch mode {
 	case constants.KernelNativeMode:
-		printKernelNativeTable(body)
+		printKernelNativeTable(out, body)
 	case constants.DualEngineMode:
-		printDualEngineTable(body)
+		printDualEngineTable(out, body)
 	}
 
 	return nil
@@ -120,15 +121,15 @@ func RunDump(cmd *cobra.Command, args []string, outputFormat string) error {
 
 // printKernelNativeTable parses and displays kernel-native config dump as tables.
 // Static and dynamic resources of the same type are consolidated under a single header.
-func printKernelNativeTable(body []byte) {
+func printKernelNativeTable(out io.Writer, body []byte) {
 	configDump := &adminv2.ConfigDump{}
 	if err := protojson.Unmarshal(body, configDump); err != nil {
 		log.Errorf("failed to parse config dump: %v, falling back to raw output", err)
-		fmt.Println(string(body))
+		fmt.Fprintln(out, string(body))
 		return
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
 	static, dynamic := configDump.GetStaticResources(), configDump.GetDynamicResources()
 
 	// Clusters
@@ -145,7 +146,7 @@ func printKernelNativeTable(body []byte) {
 			}
 		}
 		_ = w.Flush()
-		fmt.Println()
+		fmt.Fprintln(out)
 	}
 
 	// Listeners
@@ -176,7 +177,7 @@ func printKernelNativeTable(body []byte) {
 			printListeners(dynamic)
 		}
 		_ = w.Flush()
-		fmt.Println()
+		fmt.Fprintln(out)
 	}
 
 	// Routes
@@ -196,7 +197,7 @@ func printKernelNativeTable(body []byte) {
 			printRoutes(dynamic)
 		}
 		_ = w.Flush()
-		fmt.Println()
+		fmt.Fprintln(out)
 	}
 }
 
@@ -230,15 +231,15 @@ type policyEntry struct {
 }
 
 // printDualEngineTable parses and displays dual-engine config dump as tables.
-func printDualEngineTable(body []byte) {
+func printDualEngineTable(out io.Writer, body []byte) {
 	var dump workloadDump
 	if err := json.Unmarshal(body, &dump); err != nil {
 		log.Errorf("failed to parse workload dump: %v, falling back to raw output", err)
-		fmt.Println(string(body))
+		fmt.Fprintln(out, string(body))
 		return
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
 
 	if len(dump.Workloads) > 0 {
 		fmt.Fprintln(w, "NAME\tNAMESPACE\tADDRESSES\tPROTOCOL\tSTATUS")
@@ -252,7 +253,7 @@ func printDualEngineTable(body []byte) {
 			)
 		}
 		_ = w.Flush()
-		fmt.Println()
+		fmt.Fprintln(out)
 	}
 
 	if len(dump.Services) > 0 {
@@ -266,7 +267,7 @@ func printDualEngineTable(body []byte) {
 			)
 		}
 		_ = w.Flush()
-		fmt.Println()
+		fmt.Fprintln(out)
 	}
 
 	if len(dump.Policies) > 0 {
@@ -280,7 +281,7 @@ func printDualEngineTable(body []byte) {
 			)
 		}
 		_ = w.Flush()
-		fmt.Println()
+		fmt.Fprintln(out)
 	}
 }
 

--- a/ctl/log/log.go
+++ b/ctl/log/log.go
@@ -87,31 +87,31 @@ func GetJson(url string, val any) error {
 	return nil
 }
 
-func GetLoggerNames(url string) {
+func GetLoggerNames(out io.Writer, url string) {
 	var loggerNames []string
 	if err := GetJson(url, &loggerNames); err != nil {
 		log.Errorf("failed to get logger names: %v", err)
 		return
 	}
 
-	fmt.Printf("Existing Loggers:\n")
+	fmt.Fprintf(out, "Existing Loggers:\n")
 	for _, logger := range loggerNames {
-		fmt.Printf("\t%s\n", logger)
+		fmt.Fprintf(out, "\t%s\n", logger)
 	}
 }
 
-func GetLoggerLevel(url string) {
+func GetLoggerLevel(out io.Writer, url string) {
 	var loggerInfo LoggerInfo
 	if err := GetJson(url, &loggerInfo); err != nil {
 		log.Errorf("failed to get logger level: %v", err)
 		return
 	}
 
-	fmt.Printf("Logger Name: %s\n", loggerInfo.Name)
-	fmt.Printf("Logger Level: %s\n", loggerInfo.Level)
+	fmt.Fprintf(out, "Logger Name: %s\n", loggerInfo.Name)
+	fmt.Fprintf(out, "Logger Level: %s\n", loggerInfo.Level)
 }
 
-func SetLoggerLevel(url string, setFlag string) {
+func SetLoggerLevel(out io.Writer, url string, setFlag string) {
 	if !strings.Contains(setFlag, ":") {
 		log.Errorf("Invalid set flag, which should be loggerName:loggerLevel (e.g. default:debug)")
 		os.Exit(1)
@@ -153,7 +153,7 @@ func SetLoggerLevel(url string, setFlag string) {
 		log.Errorf("failed to read HTTP response body: %v", err)
 		return
 	}
-	fmt.Println(string(body))
+	fmt.Fprintln(out, string(body))
 }
 
 func RunGetOrSetLoggerLevel(cmd *cobra.Command, args []string) {
@@ -178,15 +178,16 @@ func RunGetOrSetLoggerLevel(cmd *cobra.Command, args []string) {
 
 	url := fmt.Sprintf("http://%s%s", fw.Address(), patternLoggers)
 
+	out := cmd.OutOrStdout()
 	setFlag, _ := cmd.Flags().GetString("set")
 	if setFlag == "" {
 		if len(args) >= 2 {
 			url += fmt.Sprintf("?name=%s", args[1])
-			GetLoggerLevel(url)
+			GetLoggerLevel(out, url)
 		} else {
-			GetLoggerNames(url)
+			GetLoggerNames(out, url)
 		}
 	} else {
-		SetLoggerLevel(url, setFlag)
+		SetLoggerLevel(out, url, setFlag)
 	}
 }

--- a/ctl/secret/secret.go
+++ b/ctl/secret/secret.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -85,7 +86,7 @@ kmeshctl secret create --key=$(echo -n "{36-character user-defined key here}" | 
 kmeshctl secret get`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			GetSecret()
+			GetSecret(cmd.OutOrStdout())
 		},
 	}
 
@@ -198,7 +199,7 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 	}
 }
 
-func GetSecret() {
+func GetSecret(out io.Writer) {
 	secret, err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Get(context.TODO(), SecretName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -240,11 +241,11 @@ func GetSecret() {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Secret name: %s\n", SecretName)
-	fmt.Printf("Namespace: %s\n", utils.KmeshNamespace)
-	fmt.Printf("Created: %s\n", secret.CreationTimestamp.Format("2006-01-02 15:04:05"))
-	fmt.Println("IPsec Configuration:")
-	fmt.Println(string(displayData))
+	fmt.Fprintf(out, "Secret name: %s\n", SecretName)
+	fmt.Fprintf(out, "Namespace: %s\n", utils.KmeshNamespace)
+	fmt.Fprintf(out, "Created: %s\n", secret.CreationTimestamp.Format("2006-01-02 15:04:05"))
+	fmt.Fprintln(out, "IPsec Configuration:")
+	fmt.Fprintln(out, string(displayData))
 }
 
 func DeleteSecret() {


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:
This PR refactors the core `kmeshctl` CLI commands (`dump`, `log`, `authz`, and `secret`) to decouple their output logic from `os.Stdout`.

Currently, these commands print strings and tables directly to standard output via raw `fmt.Println()` and `fmt.Printf()`. To prepare the Kmesh codebase for the upcoming **MCP Server** (Issue #1800), the MCP server will need to call these CLI functions programmatically. Because the MCP protocol relies on a strict JSON-RPC stream over `stdout`, any native prints to `os.Stdout` by imported packages will corrupt the stream and crash the AI agent. 

By utilizing Cobra's `cmd.OutOrStdout()` and injecting an `io.Writer` into our display functions, these commands are now highly composable and safe to import programmatically, while maintaining identical behavior for regular CLI users.

**Which issue(s) this PR fixes**:
Fixes #1830 

**Special notes for your reviewer**:
This is a pure architectural refactor for output safety. No core business logic, eBPF logic, or CLI flag parsing was changed. All local builds (`make ctl`) and tests (`go test ./ctl/...`) pass successfully.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
