### PR TITLE
fix(status): support GET in authzHandler to return authz offload status

### DIFF
--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -330,11 +330,32 @@ func (s *Server) connectionMetricHandler(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) authzHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
+	if r.Method == http.MethodGet {
+		s.getAuthzStatus(w)
+	} else if r.Method == http.MethodPost {
+		s.setAuthzStatus(w, r)
+	} else {
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) getAuthzStatus(w http.ResponseWriter) {
+	authzOffload := s.loader.GetAuthzOffload()
+	enabled := authzOffload == constants.ENABLED
+
+	data, err := json.MarshalIndent(&struct {
+		Enabled bool `json:"enabled"`
+	}{Enabled: enabled}, "", "    ")
+	if err != nil {
+		log.Errorf("Failed to marshal authz status: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
 
+func (s *Server) setAuthzStatus(w http.ResponseWriter, r *http.Request) {
 	authzInfo := r.URL.Query().Get("enable")
 	enabled, err := strconv.ParseBool(authzInfo)
 	if err != nil {

--- a/pkg/status/status_server_test.go
+++ b/pkg/status/status_server_test.go
@@ -662,3 +662,76 @@ func TestServerMonitoringHandler(t *testing.T) {
 		assert.Equal(t, constants.ENABLED, enableMonitoring)
 	})
 }
+
+func TestServerAuthzHandler(t *testing.T) {
+	t.Run("disable and check authz offload", func(t *testing.T) {
+		config := options.BpfConfig{
+			Mode:        constants.DualEngineMode,
+			BpfFsPath:   "/sys/fs/bpf",
+			Cgroup2Path: "/mnt/kmesh_cgroup2",
+		}
+		cleanup, l := test.InitBpfMap(t, config)
+		defer cleanup()
+
+		server := &Server{
+			xdsClient: &controller.XdsClient{
+				WorkloadController: &workload.Controller{
+					MetricController: &telemetry.MetricController{},
+				},
+			},
+			loader: l,
+		}
+
+		// disable authz
+		url := fmt.Sprintf("%s?enable=%s", patternAuthz, "false")
+		req := httptest.NewRequest(http.MethodPost, url, nil)
+		w := httptest.NewRecorder()
+		server.authzHandler(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// verify it shows as disabled
+		req = httptest.NewRequest(http.MethodGet, patternAuthz, nil)
+		w = httptest.NewRecorder()
+		server.authzHandler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), `"enabled": false`)
+	})
+
+	t.Run("enable and check authz offload", func(t *testing.T) {
+		config := options.BpfConfig{
+			Mode:        constants.DualEngineMode,
+			BpfFsPath:   "/sys/fs/bpf",
+			Cgroup2Path: "/mnt/kmesh_cgroup2",
+		}
+		cleanup, l := test.InitBpfMap(t, config)
+		defer cleanup()
+
+		server := &Server{
+			xdsClient: &controller.XdsClient{
+				WorkloadController: &workload.Controller{
+					MetricController: &telemetry.MetricController{},
+				},
+			},
+			loader: l,
+		}
+
+		// enable authz
+		url := fmt.Sprintf("%s?enable=%s", patternAuthz, "true")
+		req := httptest.NewRequest(http.MethodPost, url, nil)
+		w := httptest.NewRecorder()
+		server.authzHandler(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// verify it shows as enabled
+		req = httptest.NewRequest(http.MethodGet, patternAuthz, nil)
+		w = httptest.NewRecorder()
+		server.authzHandler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Contains(t, w.Body.String(), `"enabled": true`)
+
+		authzOffload := l.GetAuthzOffload()
+		assert.Equal(t, constants.ENABLED, authzOffload)
+	})
+}

--- a/pkg/status/status_server_test.go
+++ b/pkg/status/status_server_test.go
@@ -695,7 +695,15 @@ func TestServerAuthzHandler(t *testing.T) {
 		server.authzHandler(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Contains(t, w.Body.String(), `"enabled": false`)
+		var resp struct {
+			Enabled bool `json:"enabled"`
+		}
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.False(t, resp.Enabled)
+
+		authzOffload := l.GetAuthzOffload()
+		assert.Equal(t, constants.DISABLED, authzOffload)
 	})
 
 	t.Run("enable and check authz offload", func(t *testing.T) {
@@ -729,9 +737,31 @@ func TestServerAuthzHandler(t *testing.T) {
 		server.authzHandler(w, req)
 
 		assert.Equal(t, http.StatusOK, w.Code)
-		assert.Contains(t, w.Body.String(), `"enabled": true`)
+		var resp struct {
+			Enabled bool `json:"enabled"`
+		}
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.True(t, resp.Enabled)
 
 		authzOffload := l.GetAuthzOffload()
 		assert.Equal(t, constants.ENABLED, authzOffload)
+	})
+
+	t.Run("invalid method", func(t *testing.T) {
+		server := &Server{}
+		req := httptest.NewRequest(http.MethodPut, patternAuthz, nil)
+		w := httptest.NewRecorder()
+		server.authzHandler(w, req)
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("invalid enable value", func(t *testing.T) {
+		server := &Server{}
+		url := fmt.Sprintf("%s?enable=%s", patternAuthz, "invalid_value")
+		req := httptest.NewRequest(http.MethodPost, url, nil)
+		w := httptest.NewRecorder()
+		server.authzHandler(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
 	})
 }


### PR DESCRIPTION
**Problem**

I was going through the `authz` CLI code and saw that `fetchAuthzStatus()` in `ctl/authz/authz.go` sends a GET to `/authz` to check the current state. But when I looked at the server side, `authzHandler` only accepts POST and rejects everything else with 405. So `kmeshctl authz` status was never actually working — it always gets a 405 back.
due to these lines of code in authzHandler,whenever someone tried GET endpoint , it return method not allowed
```
if r.Method != http.MethodPost {
		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
		return
	}
```


**Solution**

I added GET support to `authzHandler` the same way `loggersHandler` already handles it — GET goes to a read function, POST goes to the write function.

The new `getAuthzStatus()` reads from `BpfLoader.GetAuthzOffload()` and returns the state as JSON. The POST logic is unchanged, just moved it to `setAuthzStatus()` to keep things clean.

There were no tests for this handler before so I added a couple — one to check the default state and one to verify it updates after enabling `authz`.

**Below is the terminal output from testing the /authz endpoint locally against the Kmesh status server:**
```
$ curl -s -v http://localhost:15020/authz
* Host localhost:15020 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:15020...
* Established connection to localhost (::1 port 15020) from ::1 port 34348 
* using HTTP/1.x
> GET /authz HTTP/1.1
> Host: localhost:15020
> User-Agent: curl/8.18.0
> Accept: */*
> 
* Request completely sent off
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Sat, 08 Aug 2026 05:21:38 GMT
< Content-Length: 24
< 
{
    "enabled": false
* Connection #0 to host localhost:15020 left intact
}
```

We got status 200 with Json telling if authz is enabled or not 
