### PR TITLE
fix: avoid error log when random lb fails to select backend due to no active backends

### DIFF
--- a/bpf/kmesh/workload/include/service.h
+++ b/bpf/kmesh/workload/include/service.h
@@ -20,7 +20,7 @@ static inline int lb_random_handle(struct kmesh_context *kmesh_ctx, __u32 servic
     int rand_k = 0;
 
     if (service_v->prio_endpoint_count[0] == 0)
-        return 0;
+        return -ENOENT;
 
     endpoint_k.service_id = service_id;
     endpoint_k.prio = 0; // for random handle，all endpoints are saved with highest priority


### PR DESCRIPTION
This PR fixes an issue where the random load balancer tries to select a backend even when there are no active backends, resulting in a noent error log from EbpfMap. The fix checks if the active backend size is 0 before performing the random selection, returning early to avoid the error.

Fixes #1577