### PR TITLE
fix(nets): prevent panic on IPv6 address in ConvertIpToUint32

### DIFF
--- a/pkg/nets/nets.go
+++ b/pkg/nets/nets.go
@@ -35,14 +35,11 @@ func ConvertIpToUint32(ip string) uint32 {
 	if netIP == nil {
 		return 0
 	}
-	// TODO: is this right?
-	if len(netIP) == net.IPv6len {
-		return binary.LittleEndian.Uint32(netIP.To4())
+	ipv4 := netIP.To4()
+	if ipv4 == nil {
+		return 0
 	}
-	if len(netIP) == net.IPv4len {
-		return binary.LittleEndian.Uint32(netIP)
-	}
-	return 0
+	return binary.LittleEndian.Uint32(ipv4)
 }
 
 // ConvertPortToBigEndian convert uint32 to network order

--- a/pkg/nets/nets_test.go
+++ b/pkg/nets/nets_test.go
@@ -28,8 +28,11 @@ func Test_ConvertIpToUint32(t *testing.T) {
 	val := ConvertIpToUint32(ip)
 	assert.Equal(t, uint32(0x100a8c0), val)
 
-	// It can not panic even for invalid ip
+	// It can not panic even for invalid ip or ipv6
 	val = ConvertIpToUint32("a.b.c.d")
+	assert.Equal(t, uint32(0), val)
+
+	val = ConvertIpToUint32("2001:db8::1")
 	assert.Equal(t, uint32(0), val)
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Fixes a panic in `nets.ConvertIpToUint32` when processing IPv6 address strings.

Previously, `len(netIP) == net.IPv6len` was evaluated on the 16-byte `net.IP` slice returned by `net.ParseIP`. For IPv6 addresses, calling `netIP.To4()` returned `nil`, and `binary.LittleEndian.Uint32(nil)` subsequently panicked with `index out of range [3]`.

This change safely checks `ipv4 := netIP.To4()` and returns `0` if `ipv4 == nil`.

**Which issue(s) this PR fixes**:
Fixes #1835

**Special notes for your reviewer**:
Included unit test assertion in `pkg/nets/nets_test.go` to ensure IPv6 address strings return `0` without panicking.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
