### PR TITLE
fix: recalculate locality-LB endpoint priorities after LocalityInfo initialization

### DIFF
--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -569,9 +569,31 @@ func (p *Processor) handleWorkload(workload *workloadapi.Workload) error {
 	}
 
 	// update kmesh localityCache
-	// TODO: recalculate endpoints priority once local locality is set
+	// The first local workload initializes LocalityInfo.
+	// Remote workloads processed before this were inserted with
+	// priority 0 because locality could not yet be calculated.
+	// Recalculate endpoint priorities for all locality-LB services.
 	if p.locality.LocalityInfo == nil && p.nodeName == workload.GetNode() {
-		p.locality.SetLocality(p.nodeName, workload.GetClusterId(), workload.GetNetwork(), workload.GetLocality())
+		p.locality.SetLocality(
+			p.nodeName,
+			workload.GetClusterId(),
+			workload.GetNetwork(),
+			workload.GetLocality(),
+		)
+
+		for _, svc := range p.ServiceCache.List() {
+			if lb := svc.GetLoadBalancing(); lb != nil &&
+				lb.GetMode() != workloadapi.LoadBalancing_UNSPECIFIED_MODE {
+				serviceID := p.hashName.Hash(svc.ResourceName())
+				if err := p.updateEndpointPriority(serviceID, true); err != nil {
+					return fmt.Errorf(
+						"recalculate endpoint priority for service %s failed: %w",
+						svc.ResourceName(),
+						err,
+					)
+				}
+			}
+		}
 	}
 
 	// Exclude unhealthy workload, which is not ready to serve traffic, but keep it in the frontend

--- a/pkg/controller/workload/workload_processor_test.go
+++ b/pkg/controller/workload/workload_processor_test.go
@@ -851,3 +851,119 @@ func TestLocalityLBWithNilLocalityInfo(t *testing.T) {
 
 	hashNameClean(p)
 }
+
+func TestLocalityLBPriorityRecalculationAfterLocalityInitialization(t *testing.T) {
+	workloadMap := bpfcache.NewFakeWorkloadMap(t)
+	defer bpfcache.CleanupFakeWorkloadMap(workloadMap)
+
+	p := NewProcessor(workloadMap)
+
+	// No local workload has been processed yet.
+	assert.Nil(t, p.locality.LocalityInfo)
+
+	res := &service_discovery_v3.DeltaDiscoveryResponse{}
+
+	// Create a service using locality load balancing.
+	localityLBScope := []workloadapi.LoadBalancing_Scope{
+		workloadapi.LoadBalancing_REGION,
+		workloadapi.LoadBalancing_ZONE,
+		workloadapi.LoadBalancing_SUBZONE,
+	}
+	localityLoadBalancing := createLoadBalancing(
+		workloadapi.LoadBalancing_FAILOVER,
+		localityLBScope,
+	)
+	svc := common.CreateFakeService(
+		"svc1",
+		"10.240.10.1",
+		"10.240.10.200",
+		localityLoadBalancing,
+	)
+
+	res.Resources = append(res.Resources, &service_discovery_v3.Resource{
+		Resource: protoconv.MessageToAny(serviceToAddress(svc)),
+	})
+
+	// Process a remote workload before locality information is initialized.
+	wl := createWorkload(
+		"waypoint1",
+		"10.244.0.1",
+		"other-node",
+		workloadapi.NetworkMode_STANDARD,
+		createLocality("r1", "z1", "s1"),
+		"svc1",
+	)
+
+	res.Resources = append(res.Resources, &service_discovery_v3.Resource{
+		Resource: protoconv.MessageToAny(workloadToAddress(wl)),
+	})
+
+	err := p.handleAddressTypeResponse(res)
+	assert.NoError(t, err)
+
+	workloadID := checkFrontEndMap(t, wl.Addresses[0], p)
+	svcID := checkFrontEndMap(t, svc.Addresses[0].Address, p)
+
+	// The endpoint is initially inserted with priority 0 because locality
+	// information is unavailable.
+	oldKey := bpfcache.EndpointKey{
+		ServiceId:    svcID,
+		Prio:         0,
+		BackendIndex: 1,
+	}
+
+	var oldValue bpfcache.EndpointValue
+	err = p.bpf.EndpointLookup(&oldKey, &oldValue)
+	assert.NoError(t, err)
+	assert.Equal(t, workloadID, oldValue.BackendUid)
+
+	// Process the first local workload to initialize locality information.
+	localRes := &service_discovery_v3.DeltaDiscoveryResponse{}
+
+	localWorkload := createWorkload(
+		"local-wl",
+		"10.244.0.2",
+		os.Getenv("NODE_NAME"),
+		workloadapi.NetworkMode_STANDARD,
+		createLocality("r2", "z2", "s2"),
+		"svc1",
+	)
+
+	localRes.Resources = append(localRes.Resources, &service_discovery_v3.Resource{
+		Resource: protoconv.MessageToAny(workloadToAddress(localWorkload)),
+	})
+
+	err = p.handleAddressTypeResponse(localRes)
+	assert.NoError(t, err)
+
+	expectedPrio := p.locality.CalcLocalityLBPrio(
+		wl,
+		localityLBScope,
+	)
+
+	// The remote workload should no longer remain in the priority-0 bucket.
+	err = p.bpf.EndpointLookup(&oldKey, &oldValue)
+	assert.NoError(t, err)
+	assert.NotEqual(
+		t,
+		workloadID,
+		oldValue.BackendUid,
+		"remote workload should no longer remain at priority 0",
+	)
+
+	// The remote workload should now exist at its locality-derived priority.
+	newKey := bpfcache.EndpointKey{
+		ServiceId:    svcID,
+		Prio:         expectedPrio,
+		BackendIndex: 1,
+	}
+
+	var newValue bpfcache.EndpointValue
+	err = p.bpf.EndpointLookup(&newKey, &newValue)
+	assert.NoError(t, err)
+	assert.Equal(t, workloadID, newValue.BackendUid)
+
+	checkServiceMap(t, p, svcID, svc, 0, 1)
+
+	hashNameClean(p)
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When a remote workload is processed before any local workload, `LocalityInfo` has not yet been initialized. In this case, the endpoint is added to the service using the fallback priority (`0`).

Once the first local workload initializes `LocalityInfo`, existing endpoints belonging to locality-aware services are not re-evaluated, causing them to continue using the fallback priority instead of their locality-derived priority.

This PR recalculates endpoint priorities for locality-aware services immediately after `LocalityInfo` is initialized for the first time. It also adds a regression test covering this execution order to prevent future regressions.

**Which issue(s) this PR fixes**:

Fixes #1838

**Special notes for your reviewer**:

The regression test reproduces the following sequence:

1. A locality-aware service is created.
2. A remote workload is processed before any local workload.
3. The endpoint is inserted with the fallback priority (`0`).
4. The first local workload initializes `LocalityInfo`.
5. The test verifies that the remote endpoint is moved to its locality-derived priority.

**Does this PR introduce a user-facing change?**:

```release-note
Fix an issue where endpoints added before LocalityInfo initialization could retain the fallback priority instead of being updated according to locality-based load balancing.
```