### PR TITLE
fix: guard pendingHostnames with the existing RWMutex in ads dnsController

### DIFF
--- a/pkg/controller/ads/dns.go
+++ b/pkg/controller/ads/dns.go
@@ -90,11 +90,13 @@ func (r *dnsController) processDomains(cds []*clusterv3.Cluster) {
 	domains := getPendingResolveDomain(cds)
 
 	// store all pending hostnames of clusters in pendingHostnames
+	r.Lock()
 	for _, cluster := range cds {
 		clusterName := cluster.GetName()
 		info := getHostName(cluster)
 		r.pendingHostnames[clusterName] = info
 	}
+	r.Unlock()
 
 	// delete any scheduled re-resolve for domains we no longer care about
 	r.dnsResolver.RemoveUnwatchDomain(domains)
@@ -156,7 +158,9 @@ func (r *dnsController) updateClusters(pendingDomain *pendingResolveDomain, doma
 
 func (r *dnsController) overwriteDnsCluster(cluster *clusterv3.Cluster, domain string, addrs []string) (bool, *clusterv3.Cluster) {
 	ready := true
+	r.RLock()
 	hostNames := r.pendingHostnames[cluster.GetName()]
+	r.RUnlock()
 	addressesOfHostname := make(map[string][]string)
 
 	for _, hostName := range hostNames {

--- a/pkg/controller/ads/dns.go
+++ b/pkg/controller/ads/dns.go
@@ -90,10 +90,13 @@ func (r *dnsController) processDomains(cds []*clusterv3.Cluster) {
 	domains := getPendingResolveDomain(cds)
 
 	// store all pending hostnames of clusters in pendingHostnames
-	r.Lock()
+	pending := make(map[string][]string, len(cds))
 	for _, cluster := range cds {
 		clusterName := cluster.GetName()
-		info := getHostName(cluster)
+		pending[clusterName] = getHostName(cluster)
+	}
+	r.Lock()
+	for clusterName, info := range pending {
 		r.pendingHostnames[clusterName] = info
 	}
 	r.Unlock()

--- a/pkg/controller/ads/dns_test.go
+++ b/pkg/controller/ads/dns_test.go
@@ -147,6 +147,68 @@ func TestADSCacheConcurrentWriting(t *testing.T) {
 	wg.Wait()
 }
 
+// This test aims to evaluate the concurrent access to pendingHostnames using the test race feature.
+// processDomains (write) and overwriteDnsCluster (read) run on separate goroutines in production,
+// so this reproduces that pattern to catch unsynchronized map access.
+func TestPendingHostnamesConcurrentAccess(t *testing.T) {
+	p := NewController(nil).Processor
+	dnsResolver, err := NewDnsController(p.Cache)
+	assert.NoError(t, err)
+
+	cluster := &clusterv3.Cluster{
+		Name: "ut-cluster",
+		ClusterDiscoveryType: &clusterv3.Cluster_Type{
+			Type: clusterv3.Cluster_LOGICAL_DNS,
+		},
+		LoadAssignment: &endpointv3.ClusterLoadAssignment{
+			Endpoints: []*endpointv3.LocalityLbEndpoints{
+				{
+					LbEndpoints: []*endpointv3.LbEndpoint{
+						{
+							HostIdentifier: &endpointv3.LbEndpoint_Endpoint{
+								Endpoint: &endpointv3.Endpoint{
+									Address: &v3.Address{
+										Address: &v3.Address_SocketAddress{
+											SocketAddress: &v3.SocketAddress{
+												Address: "www.google.com",
+												PortSpecifier: &v3.SocketAddress_PortValue{
+													PortValue: uint32(9898),
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: mimics processClusters() calling processDomains() on every CDS push.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			dnsResolver.processDomains([]*clusterv3.Cluster{cluster})
+		}
+	}()
+
+	// Reader: mimics updateClusters()/overwriteDnsCluster() running from refreshWorker
+	// or the goroutine spawned inside processDomains for an already-resolved domain.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			dnsResolver.overwriteDnsCluster(cluster, "www.google.com", []string{"10.1.1.1"})
+		}
+	}()
+
+	wg.Wait()
+}
+
 func TestHandleCdsResponseWithDns(t *testing.T) {
 	cluster1 := &clusterv3.Cluster{
 		Name: "ut-cluster1",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`dnsController.pendingHostnames` in `pkg/controller/ads/dns.go` was being written in `processDomains()` (runs on the `processClusters` goroutine) and read in `overwriteDnsCluster()` (runs from the independent `refreshWorker` goroutine, and from goroutines spawned inside `processDomains` itself) with no locking at all, even though the struct already has a `sync.RWMutex` used to protect the sibling field `clusterCache`.

This is an unsynchronized concurrent map access. Since `refreshWorker` and `processClusters` run independently for the lifetime of the daemon, a DNS refresh completing while a CDS update is being processed can cause the Go runtime to hit `fatal error: concurrent map read and map write`, which is unrecoverable and kills the whole kmesh-daemon process in Kernel-Native mode.

This PR just extends the struct's existing `RWMutex` to also cover `pendingHostnames`, taking `Lock()`/`Unlock()` around the write in `processDomains` and `RLock()`/`RUnlock()` around the read in `overwriteDnsCluster`. This matches how the Dual-Engine `dnsController` in `pkg/controller/workload/dns.go` already guards its equivalent fields.

Added `TestPendingHostnamesConcurrentAccess` in `dns_test.go`, which runs the write path (`processDomains`) and read path (`overwriteDnsCluster`) concurrently on separate goroutines, matching the real goroutine wiring in `Run()`, so `go test -race` catches any regression here.

**Which issue(s) this PR fixes**:
Fixes #1840

**Special notes for your reviewer**:

I used AI assistance (Claude) to help analyze the goroutine wiring in this file and draft this fix, per the AI Guidance in CONTRIBUTING.md. I reviewed the change myself: it's a minimal, mechanical fix (two lock/unlock pairs) that mirrors the locking pattern already used for `clusterCache` a few lines away in the same file, so there's no new locking strategy introduced.

I wasn't able to run `go test -race` locally in my dev environment since building `pkg/controller/ads` needs the generated eBPF `.o` objects, which need a full clang/kernel-header build I don't have on hand (macOS host). Happy to paste CI output or run it again if reviewers want to see the race detector output directly.

**Does this PR introduce a user-facing change?**:
```release-note
Fix a data race on `pendingHostnames` in the Kernel-Native mode DNS resolver that could crash kmesh-daemon with `fatal error: concurrent map read and map write` under concurrent CDS updates and DNS refreshes.
```