### PR TITLE
fix: pair cert ADD and DELETE requests per pod to stop refCnt leak

### DIFF
--- a/pkg/controller/manage/manage_controller.go
+++ b/pkg/controller/manage/manage_controller.go
@@ -219,8 +219,9 @@ func (c *KmeshManageController) handlePodDelete(obj interface{}) {
 	if c.releaseCertRequest(pod) {
 		log.Infof("%s/%s: Pod managed by Kmesh is deleted", pod.GetNamespace(), pod.GetName())
 	}
-	// We donot need to do handleKmeshManage for delete, because we may have no change to execute a cmd in pod net ns.
-	// And we have done this in kmesh-cni
+	// We do not need to do handleKmeshManage for delete, because we may
+	// not have any change to execute a cmd in pod net ns.
+	// And we have done this in kmesh-cni.
 }
 
 func (c *KmeshManageController) handleNamespaceAdd(obj interface{}) {
@@ -261,7 +262,7 @@ func (c *KmeshManageController) handleNamespaceUpdate(oldObj, newObj interface{}
 }
 
 func (c *KmeshManageController) enableKmeshManage(pod *corev1.Pod) {
-	c.requestCertRequest(pod)
+	c.ensureCertRequested(pod)
 	if !isPodReady(pod) {
 		log.Debugf("Pod %s/%s is not ready, skipping Kmesh manage enable", pod.GetNamespace(), pod.GetName())
 		return
@@ -389,12 +390,12 @@ func (c *KmeshManageController) syncPod(key QueueItem) error {
 	return nil
 }
 
-// requestCertRequest sends a cert ADD request for pod, but only the first
+// ensureCertRequested sends a cert ADD request for pod, but only the first
 // time it's called for a given pod UID. This keeps ADD/DELETE calls into
 // SecretManager's refcounted cert cache paired 1:1 per pod, even though
 // enableKmeshManage can be invoked many times over a pod's lifetime (pod
 // Update events fire on almost any status change, not just enrollment).
-func (c *KmeshManageController) requestCertRequest(pod *corev1.Pod) {
+func (c *KmeshManageController) ensureCertRequested(pod *corev1.Pod) {
 	c.certRequestedMu.Lock()
 	_, alreadyRequested := c.certRequestedPods[pod.UID]
 	if !alreadyRequested {
@@ -409,7 +410,7 @@ func (c *KmeshManageController) requestCertRequest(pod *corev1.Pod) {
 }
 
 // releaseCertRequest sends the matching cert DELETE request for pod if (and
-// only if) requestCertRequest was previously called for it, and reports
+// only if) ensureCertRequested was previously called for it, and reports
 // whether it did so. This is what keeps the SecretManager refCnt for a
 // pod's identity from being left permanently above zero.
 func (c *KmeshManageController) releaseCertRequest(pod *corev1.Pod) bool {

--- a/pkg/controller/manage/manage_controller.go
+++ b/pkg/controller/manage/manage_controller.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 	"syscall"
 
 	"github.com/cilium/ebpf/link"
@@ -29,6 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
@@ -71,6 +73,16 @@ type KmeshManageController struct {
 	xdpProgFd         int
 	tcProgFd          int
 	mode              string
+
+	// certRequestedMu guards certRequestedPods.
+	certRequestedMu sync.Mutex
+	// certRequestedPods tracks which pods currently have an outstanding cert
+	// ADD request, keyed by pod UID. A pod's UID stays in this set from the
+	// first enableKmeshManage call until the matching release, so repeated
+	// pod Update events (which happen for almost any status change) don't
+	// send duplicate ADD requests and inflate the cert cache refCnt without
+	// a matching DELETE.
+	certRequestedPods map[types.UID]struct{}
 }
 
 func isPodReady(pod *corev1.Pod) bool {
@@ -104,6 +116,7 @@ func NewKmeshManageController(client kubernetes.Interface, sm *kmeshsecurity.Sec
 		xdpProgFd:         xdpProgFd,
 		tcProgFd:          tcProgFd,
 		mode:              mode,
+		certRequestedPods: make(map[types.UID]struct{}),
 	}
 
 	if _, err := podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -203,12 +216,11 @@ func (c *KmeshManageController) handlePodDelete(obj interface{}) {
 		}
 	}
 
-	if utils.AnnotationEnabled(pod.Annotations[constants.KmeshRedirectionAnnotation]) {
+	if c.releaseCertRequest(pod) {
 		log.Infof("%s/%s: Pod managed by Kmesh is deleted", pod.GetNamespace(), pod.GetName())
-		sendCertRequest(c.sm, pod, kmeshsecurity.DELETE)
-		// We donot need to do handleKmeshManage for delete, because we may have no change to execute a cmd in pod net ns.
-		// And we have done this in kmesh-cni
 	}
+	// We donot need to do handleKmeshManage for delete, because we may have no change to execute a cmd in pod net ns.
+	// And we have done this in kmesh-cni
 }
 
 func (c *KmeshManageController) handleNamespaceAdd(obj interface{}) {
@@ -249,7 +261,7 @@ func (c *KmeshManageController) handleNamespaceUpdate(oldObj, newObj interface{}
 }
 
 func (c *KmeshManageController) enableKmeshManage(pod *corev1.Pod) {
-	sendCertRequest(c.sm, pod, kmeshsecurity.ADD)
+	c.requestCertRequest(pod)
 	if !isPodReady(pod) {
 		log.Debugf("Pod %s/%s is not ready, skipping Kmesh manage enable", pod.GetNamespace(), pod.GetName())
 		return
@@ -266,7 +278,7 @@ func (c *KmeshManageController) enableKmeshManage(pod *corev1.Pod) {
 }
 
 func (c *KmeshManageController) disableKmeshManage(pod *corev1.Pod) {
-	sendCertRequest(c.sm, pod, kmeshsecurity.DELETE)
+	c.releaseCertRequest(pod)
 	log.Infof("%s/%s: disable Kmesh manage", pod.GetNamespace(), pod.GetName())
 	nspath, _ := ns.GetPodNSpath(pod)
 	if err := utils.HandleKmeshManage(nspath, false); err != nil {
@@ -375,6 +387,42 @@ func (c *KmeshManageController) syncPod(key QueueItem) error {
 		return utils.DelKmeshRedirectAnnotation(c.client, pod)
 	}
 	return nil
+}
+
+// requestCertRequest sends a cert ADD request for pod, but only the first
+// time it's called for a given pod UID. This keeps ADD/DELETE calls into
+// SecretManager's refcounted cert cache paired 1:1 per pod, even though
+// enableKmeshManage can be invoked many times over a pod's lifetime (pod
+// Update events fire on almost any status change, not just enrollment).
+func (c *KmeshManageController) requestCertRequest(pod *corev1.Pod) {
+	c.certRequestedMu.Lock()
+	_, alreadyRequested := c.certRequestedPods[pod.UID]
+	if !alreadyRequested {
+		c.certRequestedPods[pod.UID] = struct{}{}
+	}
+	c.certRequestedMu.Unlock()
+
+	if alreadyRequested {
+		return
+	}
+	sendCertRequest(c.sm, pod, kmeshsecurity.ADD)
+}
+
+// releaseCertRequest sends the matching cert DELETE request for pod if (and
+// only if) requestCertRequest was previously called for it, and reports
+// whether it did so. This is what keeps the SecretManager refCnt for a
+// pod's identity from being left permanently above zero.
+func (c *KmeshManageController) releaseCertRequest(pod *corev1.Pod) bool {
+	c.certRequestedMu.Lock()
+	_, wasRequested := c.certRequestedPods[pod.UID]
+	delete(c.certRequestedPods, pod.UID)
+	c.certRequestedMu.Unlock()
+
+	if !wasRequested {
+		return false
+	}
+	sendCertRequest(c.sm, pod, kmeshsecurity.DELETE)
+	return true
 }
 
 func sendCertRequest(security *kmeshsecurity.SecretManager, pod *corev1.Pod, op int) {

--- a/pkg/controller/manage/manage_controller.go
+++ b/pkg/controller/manage/manage_controller.go
@@ -395,33 +395,38 @@ func (c *KmeshManageController) syncPod(key QueueItem) error {
 // SecretManager's refcounted cert cache paired 1:1 per pod, even though
 // enableKmeshManage can be invoked many times over a pod's lifetime (pod
 // Update events fire on almost any status change, not just enrollment).
+//
+// The map update and the sendCertRequest call happen under the same lock on
+// purpose. enableKmeshManage and disableKmeshManage/handlePodDelete can run
+// concurrently for the same pod (they come from different informer
+// goroutines, e.g. a namespace-driven disable racing a pod update), so if we
+// dropped the lock before sending the request, a release could run in
+// between, see the map entry, delete it and send DELETE before our ADD ever
+// went out, leaving the pair unbalanced again.
 func (c *KmeshManageController) ensureCertRequested(pod *corev1.Pod) {
 	c.certRequestedMu.Lock()
-	_, alreadyRequested := c.certRequestedPods[pod.UID]
-	if !alreadyRequested {
-		c.certRequestedPods[pod.UID] = struct{}{}
-	}
-	c.certRequestedMu.Unlock()
+	defer c.certRequestedMu.Unlock()
 
-	if alreadyRequested {
+	if _, alreadyRequested := c.certRequestedPods[pod.UID]; alreadyRequested {
 		return
 	}
+	c.certRequestedPods[pod.UID] = struct{}{}
 	sendCertRequest(c.sm, pod, kmeshsecurity.ADD)
 }
 
 // releaseCertRequest sends the matching cert DELETE request for pod if (and
 // only if) ensureCertRequested was previously called for it, and reports
 // whether it did so. This is what keeps the SecretManager refCnt for a
-// pod's identity from being left permanently above zero.
+// pod's identity from being left permanently above zero. See the comment on
+// ensureCertRequested for why this holds the lock across the send too.
 func (c *KmeshManageController) releaseCertRequest(pod *corev1.Pod) bool {
 	c.certRequestedMu.Lock()
-	_, wasRequested := c.certRequestedPods[pod.UID]
-	delete(c.certRequestedPods, pod.UID)
-	c.certRequestedMu.Unlock()
+	defer c.certRequestedMu.Unlock()
 
-	if !wasRequested {
+	if _, wasRequested := c.certRequestedPods[pod.UID]; !wasRequested {
 		return false
 	}
+	delete(c.certRequestedPods, pod.UID)
 	sendCertRequest(c.sm, pod, kmeshsecurity.DELETE)
 	return true
 }

--- a/pkg/controller/manage/manage_controller_test.go
+++ b/pkg/controller/manage/manage_controller_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"kmesh.net/kmesh/pkg/constants"
+	kmeshsecurity "kmesh.net/kmesh/pkg/controller/security"
 	"kmesh.net/kmesh/pkg/utils"
 )
 
@@ -426,6 +427,63 @@ func TestHandleKmeshManage(t *testing.T) {
 			waitAndCheckManageAction(t, &enabled, &disabled, tt.expectManaged, tt.expectDisManaged)
 		})
 	}
+}
+
+// TestCertRequestDedupOnRepeatedPodUpdate reproduces the cert refCnt leak:
+// Kubernetes fires a pod Update event on almost any status change (readiness
+// flips, restarts, condition changes), and handlePodUpdate forwards each one
+// to handlePodAdd whenever the KmeshRedirectionAnnotation itself is
+// unchanged, which is the common case since that annotation is only patched
+// asynchronously. Before this fix, every such Update sent a fresh cert ADD
+// through enableKmeshManage, while only a single DELETE was ever sent on
+// pod deletion, so SecretManager's refcounted cert cache never dropped back
+// to zero. This test asserts ADD is only sent once per pod no matter how
+// many Update events fire, and that the single DELETE on deletion balances
+// it.
+func TestCertRequestDedupOnRepeatedPodUpdate(t *testing.T) {
+	client := fake.NewSimpleClientset()
+
+	require.NoError(t, os.Setenv("NODE_NAME", "test_node"))
+	t.Cleanup(func() {
+		os.Unsetenv("NODE_NAME")
+	})
+
+	controller, err := NewKmeshManageController(client, nil, 0, -1, "")
+	require.NoError(t, err)
+	require.NoError(t, controller.namespaceInformer.GetStore().Add(nsWithoutLabel))
+
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyFunc(utils.HandleKmeshManage, func(_ string, _ bool) error { return nil })
+
+	var addCount, deleteCount int32
+	patches.ApplyFunc(sendCertRequest, func(_ *kmeshsecurity.SecretManager, _ *corev1.Pod, op int) {
+		switch op {
+		case kmeshsecurity.ADD:
+			atomic.AddInt32(&addCount, 1)
+		case kmeshsecurity.DELETE:
+			atomic.AddInt32(&deleteCount, 1)
+		}
+	})
+
+	pod := podWithLabel.DeepCopy()
+	pod.UID = "cert-dedup-test-pod"
+
+	controller.handlePodAdd(pod)
+	for i := 0; i < 4; i++ {
+		controller.handlePodUpdate(pod.DeepCopy(), pod)
+	}
+	assert.EqualValues(t, 1, atomic.LoadInt32(&addCount), "expected exactly one cert ADD despite repeated pod Update events")
+
+	controller.handlePodDelete(pod)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&deleteCount), "expected exactly one cert DELETE to balance the single ADD")
+
+	// A pod that never triggered an ADD (e.g. it never matched ShouldEnroll)
+	// must not send a spurious DELETE on deletion.
+	untracked := podWithoutLabel.DeepCopy()
+	untracked.UID = "cert-dedup-test-pod-untracked"
+	controller.handlePodDelete(untracked)
+	assert.EqualValues(t, 1, atomic.LoadInt32(&deleteCount), "deleting a pod that was never enrolled must not send a cert DELETE")
 }
 
 func TestNsInformerHandleKmeshManage(t *testing.T) {


### PR DESCRIPTION
Fixes #1843

## What this PR does

Kubernetes fires a pod Update event on almost any status change, readiness flips, restarts, condition changes, not just when a pod actually gets enrolled or unenrolled. handlePodUpdate forwards those events straight to handlePodAdd whenever the KmeshRedirectionAnnotation itself hasn't changed, which is the common case since that annotation is only patched asynchronously through the work queue. That means enableKmeshManage was sending a cert ADD request through SecretManager on every one of those Update events for the same pod.

Only a single DELETE ever goes out, from handlePodDelete when the pod is removed. SecretManager's cert cache is refcounted, so once a pod has gone through two or more of these Update-triggered ADDs (which is normal for any pod with a restart or a readiness flap), the refCnt never makes it back down to zero. The cert entry for that identity is never evicted and keeps getting rotated against the CA forever, even after every pod using that identity is gone.

The fix tracks which pods currently have an outstanding cert request, keyed by pod UID, in the manage controller. enableKmeshManage only actually calls sendCertRequest(ADD) the first time it sees a given pod UID, and disableKmeshManage / handlePodDelete only send DELETE (and only count it) if that pod UID had a prior ADD recorded. This keeps ADD and DELETE calls into SecretManager paired 1:1 per pod regardless of how many Update events fire in between.

## Testing

Added TestCertRequestDedupOnRepeatedPodUpdate, which drives a pod through handlePodAdd followed by several handlePodUpdate calls (mirroring repeated status-only updates) and then a handlePodDelete, asserting exactly one ADD and one DELETE go out. Also verified it doesn't send a spurious DELETE for a pod that was never enrolled in the first place.

Ran the full pkg/controller/manage suite with the race detector on Linux (via the project's docker build image), all passing:

```
ok  	kmesh.net/kmesh/pkg/controller/manage	2.182s
```

## AI disclosure

I used an AI coding assistant (Claude) to help investigate this issue and draft the fix and its regression test. I reviewed and understand every change in this PR and can answer questions about any of it in review.
