### PR TITLE
fix: retry cgroup2/bpf-fs path check to handle mount propagation delay

### DIFF
--- a/daemon/options/bpf.go
+++ b/daemon/options/bpf.go
@@ -19,6 +19,7 @@ package options
 import (
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -53,18 +54,35 @@ func (c *BpfConfig) ParseConfig() error {
 	if c.Cgroup2Path, err = filepath.Abs(c.Cgroup2Path); err != nil {
 		return err
 	}
-	if _, err = os.Stat(c.Cgroup2Path); err != nil {
+	if err = waitForPath(c.Cgroup2Path); err != nil {
 		return err
 	}
 
 	if c.BpfFsPath, err = filepath.Abs(c.BpfFsPath); err != nil {
 		return err
 	}
-	if _, err = os.Stat(c.BpfFsPath); err != nil {
+	if err = waitForPath(c.BpfFsPath); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// waitForPath retries os.Stat on path for a bounded time, to tolerate
+// mount propagation delays in containerized environments (e.g. kind).
+func waitForPath(path string) error {
+	const (
+		maxRetries = 10
+		retryDelay = 500 * time.Millisecond
+	)
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		if _, err = os.Stat(path); err == nil {
+			return nil
+		}
+		time.Sleep(retryDelay)
+	}
+	return err
 }
 
 func (c *BpfConfig) KernelNativeEnabled() bool {


### PR DESCRIPTION
Fixes #1842

The kmesh-daemon was crashing on startup with "stat /mnt/kmesh_cgroup2: no such file or directory" when running on kind. Traced it to ParseConfig() in daemon/options/bpf.go doing a single os.Stat call with no retry - if the mount isn't ready yet (which happens on kind due to mount propagation delay), it fails immediately instead of waiting.

This PR adds a waitForPath() helper that retries the stat call up to 10 times with 500ms between attempts (5 seconds total) before giving up. Applied to both the cgroup2 path and bpf-fs path checks.

Verified with make build - compiles clean, no errors.