### PR TITLE
manage: only annotate a pod as kmesh managed after xdp/tc attach succ…

### DIFF
--- a/pkg/controller/manage/manage_controller.go
+++ b/pkg/controller/manage/manage_controller.go
@@ -57,6 +57,14 @@ const (
 	// ActionDetach removes the xdp/tc programs. Only once this succeeds is the pod queued
 	// for ActionDeleteAnnotation.
 	ActionDetach = "detach"
+	// MaxAttachRetries governs ActionAttach/ActionDetach specifically. Unlike the
+	// annotation actions, these represent real dataplane enforcement state: giving up
+	// after a handful of retries at the queue's starting backoff (5ms, doubling) gives
+	// up in about 150ms of cumulative delay, which is far too fast for the transient
+	// failures expected here (netns not visible yet, interface still coming up, a slow
+	// or contended node) and nothing else re-triggers the attempt afterwards, leaving
+	// the pod silently unenforced. Retry for much longer before giving up.
+	MaxAttachRetries = 20
 )
 
 type QueueItem struct {
@@ -343,11 +351,15 @@ func (c *KmeshManageController) processItems() bool {
 	}
 
 	if err := c.syncPod(queueItem); err != nil {
-		if c.queue.NumRequeues(key) < MaxRetries {
+		maxRetries := MaxRetries
+		if queueItem.action == ActionAttach || queueItem.action == ActionDetach {
+			maxRetries = MaxAttachRetries
+		}
+		if c.queue.NumRequeues(key) < maxRetries {
 			log.Errorf("failed to handle pod %s/%s action %s, err: %v, will retry", queueItem.podNs, queueItem.podName, queueItem.action, err)
 			c.queue.AddRateLimited(key)
 		} else {
-			log.Errorf("failed to handle pod %s/%s action %s after %d retries, err: %v, giving up", queueItem.podNs, queueItem.podName, queueItem.action, MaxRetries, err)
+			log.Errorf("failed to handle pod %s/%s action %s after %d retries, err: %v, giving up", queueItem.podNs, queueItem.podName, queueItem.action, maxRetries, err)
 			c.queue.Forget(key)
 		}
 		return true

--- a/pkg/controller/manage/manage_controller.go
+++ b/pkg/controller/manage/manage_controller.go
@@ -51,6 +51,12 @@ const (
 	MaxRetries             = 5
 	ActionAddAnnotation    = "add"
 	ActionDeleteAnnotation = "delete"
+	// ActionAttach attaches the xdp/tc programs that redirect a pod's traffic into the
+	// Kmesh dataplane. Only once this succeeds is the pod queued for ActionAddAnnotation.
+	ActionAttach = "attach"
+	// ActionDetach removes the xdp/tc programs. Only once this succeeds is the pod queued
+	// for ActionDeleteAnnotation.
+	ActionDetach = "detach"
 )
 
 type QueueItem struct {
@@ -260,9 +266,11 @@ func (c *KmeshManageController) enableKmeshManage(pod *corev1.Pod) {
 		log.Errorf("failed to enable Kmesh manage")
 		return
 	}
-	c.queue.AddRateLimited(QueueItem{podName: pod.Name, podNs: pod.Namespace, action: ActionAddAnnotation})
-	_ = linkXdp(nspath, c.xdpProgFd, c.mode)
-	_ = linkTc(nspath, c.tcProgFd)
+	// The pod must not be annotated as managed until the dataplane programs are
+	// actually attached, otherwise it would be reported as enrolled while traffic
+	// silently bypasses Kmesh. ActionAttach only queues ActionAddAnnotation on success,
+	// and retries (with the controller's standard backoff/MaxRetries) on failure.
+	c.queue.AddRateLimited(QueueItem{podName: pod.Name, podNs: pod.Namespace, action: ActionAttach})
 }
 
 func (c *KmeshManageController) disableKmeshManage(pod *corev1.Pod) {
@@ -273,9 +281,7 @@ func (c *KmeshManageController) disableKmeshManage(pod *corev1.Pod) {
 		log.Error("failed to disable Kmesh manage")
 		return
 	}
-	c.queue.AddRateLimited(QueueItem{podName: pod.Name, podNs: pod.Namespace, action: ActionDeleteAnnotation})
-	_ = unlinkXdp(nspath, c.mode)
-	_ = unlinkTc(nspath, c.tcProgFd)
+	c.queue.AddRateLimited(QueueItem{podName: pod.Name, podNs: pod.Namespace, action: ActionDetach})
 }
 
 func (c *KmeshManageController) enableKmeshForPodsInNamespace(namespace *corev1.Namespace) {
@@ -367,12 +373,56 @@ func (c *KmeshManageController) syncPod(key QueueItem) error {
 		return fmt.Errorf("failed to get pod namespace %s: %v", pod.Namespace, err)
 	}
 
-	if key.action == ActionAddAnnotation && utils.ShouldEnroll(pod, namespace) {
-		log.Infof("add annotation for pod %s/%s", pod.Namespace, pod.Name)
-		return utils.PatchKmeshRedirectAnnotation(c.client, pod)
-	} else if key.action == ActionDeleteAnnotation && !utils.ShouldEnroll(pod, namespace) {
-		log.Infof("delete annotation for pod %s/%s", pod.Namespace, pod.Name)
-		return utils.DelKmeshRedirectAnnotation(c.client, pod)
+	switch key.action {
+	case ActionAddAnnotation:
+		if utils.ShouldEnroll(pod, namespace) {
+			log.Infof("add annotation for pod %s/%s", pod.Namespace, pod.Name)
+			return utils.PatchKmeshRedirectAnnotation(c.client, pod)
+		}
+	case ActionDeleteAnnotation:
+		if !utils.ShouldEnroll(pod, namespace) {
+			log.Infof("delete annotation for pod %s/%s", pod.Namespace, pod.Name)
+			return utils.DelKmeshRedirectAnnotation(c.client, pod)
+		}
+	case ActionAttach:
+		if !utils.ShouldEnroll(pod, namespace) {
+			return nil
+		}
+		nspath, _ := ns.GetPodNSpath(pod)
+		if err := attachPod(nspath, c.xdpProgFd, c.tcProgFd, c.mode); err != nil {
+			return fmt.Errorf("failed to attach kmesh dataplane programs for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+		}
+		log.Infof("attached kmesh dataplane programs for pod %s/%s", pod.Namespace, pod.Name)
+		c.queue.AddRateLimited(QueueItem{podName: pod.Name, podNs: pod.Namespace, action: ActionAddAnnotation})
+	case ActionDetach:
+		nspath, _ := ns.GetPodNSpath(pod)
+		if err := detachPod(nspath, c.tcProgFd, c.mode); err != nil {
+			return fmt.Errorf("failed to detach kmesh dataplane programs for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+		}
+		c.queue.AddRateLimited(QueueItem{podName: pod.Name, podNs: pod.Namespace, action: ActionDeleteAnnotation})
+	}
+	return nil
+}
+
+// attachPod attaches the xdp and tc programs that redirect a pod's traffic into the
+// Kmesh dataplane. Both must succeed, otherwise the pod must not be treated as enrolled.
+func attachPod(nspath string, xdpProgFd, tcProgFd int, mode string) error {
+	if err := linkXdp(nspath, xdpProgFd, mode); err != nil {
+		return fmt.Errorf("xdp: %w", err)
+	}
+	if err := linkTc(nspath, tcProgFd); err != nil {
+		return fmt.Errorf("tc: %w", err)
+	}
+	return nil
+}
+
+// detachPod removes the xdp and tc programs previously attached by attachPod.
+func detachPod(nspath string, tcProgFd int, mode string) error {
+	if err := unlinkXdp(nspath, mode); err != nil {
+		return fmt.Errorf("xdp: %w", err)
+	}
+	if err := unlinkTc(nspath, tcProgFd); err != nil {
+		return fmt.Errorf("tc: %w", err)
 	}
 	return nil
 }

--- a/pkg/controller/manage/manage_controller.go
+++ b/pkg/controller/manage/manage_controller.go
@@ -388,14 +388,23 @@ func (c *KmeshManageController) syncPod(key QueueItem) error {
 		if !utils.ShouldEnroll(pod, namespace) {
 			return nil
 		}
-		nspath, _ := ns.GetPodNSpath(pod)
+		nspath, err := ns.GetPodNSpath(pod)
+		if err != nil {
+			return fmt.Errorf("failed to get netns path for pod %s/%s: %w", pod.Namespace, pod.Name, err)
+		}
 		if err := attachPod(nspath, c.xdpProgFd, c.tcProgFd, c.mode); err != nil {
 			return fmt.Errorf("failed to attach kmesh dataplane programs for pod %s/%s: %v", pod.Namespace, pod.Name, err)
 		}
 		log.Infof("attached kmesh dataplane programs for pod %s/%s", pod.Namespace, pod.Name)
 		c.queue.AddRateLimited(QueueItem{podName: pod.Name, podNs: pod.Namespace, action: ActionAddAnnotation})
 	case ActionDetach:
-		nspath, _ := ns.GetPodNSpath(pod)
+		if utils.ShouldEnroll(pod, namespace) {
+			return nil
+		}
+		nspath, err := ns.GetPodNSpath(pod)
+		if err != nil {
+			return fmt.Errorf("failed to get netns path for pod %s/%s: %w", pod.Namespace, pod.Name, err)
+		}
 		if err := detachPod(nspath, c.tcProgFd, c.mode); err != nil {
 			return fmt.Errorf("failed to detach kmesh dataplane programs for pod %s/%s: %v", pod.Namespace, pod.Name, err)
 		}
@@ -411,6 +420,10 @@ func attachPod(nspath string, xdpProgFd, tcProgFd int, mode string) error {
 		return fmt.Errorf("xdp: %w", err)
 	}
 	if err := linkTc(nspath, tcProgFd); err != nil {
+		// Best-effort rollback to avoid leaving the pod partially attached.
+		if rbErr := unlinkXdp(nspath, mode); rbErr != nil {
+			return fmt.Errorf("tc: %w; rollback xdp: %v", err, rbErr)
+		}
 		return fmt.Errorf("tc: %w", err)
 	}
 	return nil
@@ -418,13 +431,14 @@ func attachPod(nspath string, xdpProgFd, tcProgFd int, mode string) error {
 
 // detachPod removes the xdp and tc programs previously attached by attachPod.
 func detachPod(nspath string, tcProgFd int, mode string) error {
+	var errs []error
 	if err := unlinkXdp(nspath, mode); err != nil {
-		return fmt.Errorf("xdp: %w", err)
+		errs = append(errs, fmt.Errorf("xdp: %w", err))
 	}
 	if err := unlinkTc(nspath, tcProgFd); err != nil {
-		return fmt.Errorf("tc: %w", err)
+		errs = append(errs, fmt.Errorf("tc: %w", err))
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 func sendCertRequest(security *kmeshsecurity.SecretManager, pod *corev1.Pod, op int) {

--- a/pkg/controller/manage/manage_controller_test.go
+++ b/pkg/controller/manage/manage_controller_test.go
@@ -479,12 +479,30 @@ func TestSyncPodAttachGating(t *testing.T) {
 
 	controller, err := NewKmeshManageController(client, nil, 0, -1, "")
 	require.NoError(t, err)
-	require.NoError(t, controller.namespaceInformer.GetStore().Add(nsWithLabel))
 
 	stopChan := make(chan struct{})
 	defer close(stopChan)
 	go controller.Run(stopChan)
 	cache.WaitForCacheSync(stopChan, controller.podInformer.HasSynced, controller.namespaceInformer.HasSynced)
+
+	_, err = client.CoreV1().Namespaces().Create(context.TODO(), nsWithoutLabel, metav1.CreateOptions{})
+	require.NoError(t, err)
+
+	// createSyncedPod creates pod through the fake clientset (not the informer store
+	// directly, since the informer's reflector would just evict a store-only entry on
+	// its next relist, and syncPod's PatchKmeshRedirectAnnotation/DelKmeshRedirectAnnotation
+	// need the pod to actually exist in the fake API server too) and waits for the
+	// controller's podLister to observe it before handing it back.
+	createSyncedPod := func(t *testing.T, pod *corev1.Pod) *corev1.Pod {
+		t.Helper()
+		created, err := client.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+		require.Eventually(t, func() bool {
+			_, err := controller.podLister.Pods(pod.Namespace).Get(pod.Name)
+			return err == nil
+		}, 2*time.Second, 5*time.Millisecond, "expected podLister to observe %s/%s", pod.Namespace, pod.Name)
+		return created
+	}
 
 	t.Run("attach failure is retried and the pod stays unannotated", func(t *testing.T) {
 		patches := gomonkey.NewPatches()
@@ -498,9 +516,7 @@ func TestSyncPodAttachGating(t *testing.T) {
 
 		pod := podWithLabel.DeepCopy()
 		pod.Name = "attach-fail-pod"
-		require.NoError(t, controller.podInformer.GetStore().Add(pod))
-		_, err := client.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
-		require.NoError(t, err)
+		pod = createSyncedPod(t, pod)
 
 		controller.enableKmeshManage(pod)
 
@@ -522,9 +538,7 @@ func TestSyncPodAttachGating(t *testing.T) {
 
 		pod := podWithLabel.DeepCopy()
 		pod.Name = "attach-ok-pod"
-		require.NoError(t, controller.podInformer.GetStore().Add(pod))
-		_, err := client.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
-		require.NoError(t, err)
+		pod = createSyncedPod(t, pod)
 
 		controller.enableKmeshManage(pod)
 
@@ -546,9 +560,7 @@ func TestSyncPodAttachGating(t *testing.T) {
 
 		pod := podReadyWithAnnotation.DeepCopy()
 		pod.Name = "detach-fail-pod"
-		require.NoError(t, controller.podInformer.GetStore().Add(pod))
-		_, err := client.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
-		require.NoError(t, err)
+		pod = createSyncedPod(t, pod)
 
 		controller.disableKmeshManage(pod)
 

--- a/pkg/controller/manage/manage_controller_test.go
+++ b/pkg/controller/manage/manage_controller_test.go
@@ -464,6 +464,105 @@ func TestHandleKmeshManage(t *testing.T) {
 	}
 }
 
+// TestSyncPodAttachGating drives the real queue/processItems/syncPod path (unlike the
+// simulateQueueItem test double used elsewhere in this file) to verify the gating added
+// for https://github.com/kmesh-net/kmesh/issues/1846: a pod must only be annotated as
+// Kmesh-managed once attachPod actually succeeds, must stay unannotated (and be retried)
+// while attach keeps failing, and its annotation must not be removed until detachPod
+// actually succeeds.
+func TestSyncPodAttachGating(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	require.NoError(t, os.Setenv("NODE_NAME", "test_node"))
+	t.Cleanup(func() {
+		os.Unsetenv("NODE_NAME")
+	})
+
+	controller, err := NewKmeshManageController(client, nil, 0, -1, "")
+	require.NoError(t, err)
+	require.NoError(t, controller.namespaceInformer.GetStore().Add(nsWithLabel))
+
+	stopChan := make(chan struct{})
+	defer close(stopChan)
+	go controller.Run(stopChan)
+	cache.WaitForCacheSync(stopChan, controller.podInformer.HasSynced, controller.namespaceInformer.HasSynced)
+
+	t.Run("attach failure is retried and the pod stays unannotated", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+		patches.ApplyFunc(utils.HandleKmeshManage, func(string, bool) error { return nil })
+		var attachCalls atomic.Int32
+		patches.ApplyFunc(attachPod, func(string, int, int, string) error {
+			attachCalls.Add(1)
+			return fmt.Errorf("injected attach failure")
+		})
+
+		pod := podWithLabel.DeepCopy()
+		pod.Name = "attach-fail-pod"
+		require.NoError(t, controller.podInformer.GetStore().Add(pod))
+		_, err := client.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		controller.enableKmeshManage(pod)
+
+		require.Eventually(t, func() bool {
+			return attachCalls.Load() >= 2
+		}, 2*time.Second, 5*time.Millisecond, "expected attach to be retried after failure via the queue's backoff")
+
+		got, err := client.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.False(t, utils.AnnotationEnabled(got.Annotations[constants.KmeshRedirectionAnnotation]),
+			"pod must not be annotated as managed while attach keeps failing")
+	})
+
+	t.Run("attach success annotates the pod only once attachPod succeeds", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+		patches.ApplyFunc(utils.HandleKmeshManage, func(string, bool) error { return nil })
+		patches.ApplyFunc(attachPod, func(string, int, int, string) error { return nil })
+
+		pod := podWithLabel.DeepCopy()
+		pod.Name = "attach-ok-pod"
+		require.NoError(t, controller.podInformer.GetStore().Add(pod))
+		_, err := client.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		controller.enableKmeshManage(pod)
+
+		require.Eventually(t, func() bool {
+			got, err := client.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+			return err == nil && utils.AnnotationEnabled(got.Annotations[constants.KmeshRedirectionAnnotation])
+		}, 2*time.Second, 5*time.Millisecond, "expected pod to be annotated once attach succeeded")
+	})
+
+	t.Run("detach failure is retried and the annotation is not removed", func(t *testing.T) {
+		patches := gomonkey.NewPatches()
+		defer patches.Reset()
+		patches.ApplyFunc(utils.HandleKmeshManage, func(string, bool) error { return nil })
+		var detachCalls atomic.Int32
+		patches.ApplyFunc(detachPod, func(string, int, string) error {
+			detachCalls.Add(1)
+			return fmt.Errorf("injected detach failure")
+		})
+
+		pod := podReadyWithAnnotation.DeepCopy()
+		pod.Name = "detach-fail-pod"
+		require.NoError(t, controller.podInformer.GetStore().Add(pod))
+		_, err := client.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+		require.NoError(t, err)
+
+		controller.disableKmeshManage(pod)
+
+		require.Eventually(t, func() bool {
+			return detachCalls.Load() >= 2
+		}, 2*time.Second, 5*time.Millisecond, "expected detach to be retried after failure via the queue's backoff")
+
+		got, err := client.CoreV1().Pods(pod.Namespace).Get(context.TODO(), pod.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		assert.True(t, utils.AnnotationEnabled(got.Annotations[constants.KmeshRedirectionAnnotation]),
+			"annotation must remain in place until detach actually succeeds")
+	})
+}
+
 func TestNsInformerHandleKmeshManage(t *testing.T) {
 	client := fake.NewSimpleClientset()
 

--- a/pkg/controller/manage/manage_controller_test.go
+++ b/pkg/controller/manage/manage_controller_test.go
@@ -207,14 +207,25 @@ func simulateQueueItem(t *testing.T, controller *KmeshManageController, item int
 		if !utils.ShouldEnroll(pod, namespace) {
 			return
 		}
-		nspath, _ := kmeshns.GetPodNSpath(pod)
+		nspath, err := kmeshns.GetPodNSpath(pod)
+		if err != nil {
+			t.Errorf("failed to get netns path for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+			return
+		}
 		if err := attachPod(nspath, controller.xdpProgFd, controller.tcProgFd, controller.mode); err != nil {
 			t.Errorf("failed to attach pod %s/%s: %v", pod.Namespace, pod.Name, err)
 			return
 		}
 		simulateQueueItem(t, controller, QueueItem{podName: pod.Name, podNs: pod.Namespace, action: ActionAddAnnotation})
 	case ActionDetach:
-		nspath, _ := kmeshns.GetPodNSpath(pod)
+		if utils.ShouldEnroll(pod, namespace) {
+			return
+		}
+		nspath, err := kmeshns.GetPodNSpath(pod)
+		if err != nil {
+			t.Errorf("failed to get netns path for pod %s/%s: %v", pod.Namespace, pod.Name, err)
+			return
+		}
 		if err := detachPod(nspath, controller.tcProgFd, controller.mode); err != nil {
 			t.Errorf("failed to detach pod %s/%s: %v", pod.Namespace, pod.Name, err)
 			return

--- a/pkg/controller/manage/manage_controller_test.go
+++ b/pkg/controller/manage/manage_controller_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"kmesh.net/kmesh/pkg/constants"
+	kmeshns "kmesh.net/kmesh/pkg/controller/netns"
 	"kmesh.net/kmesh/pkg/utils"
 )
 
@@ -175,6 +176,67 @@ var (
 	}
 )
 
+// simulateQueueItem stands in for the real workqueue processing loop (processItems/syncPod)
+// in tests, since that loop isn't running here. It mirrors syncPod's action handling,
+// including chaining ActionAttach -> ActionAddAnnotation and ActionDetach -> ActionDeleteAnnotation
+// on success, so tests exercise the same gating the real controller applies.
+func simulateQueueItem(t *testing.T, controller *KmeshManageController, item interface{}) {
+	t.Helper()
+
+	queueItem, ok := item.(QueueItem)
+	if !ok {
+		t.Logf("expected QueueItem but got %T", item)
+		return
+	}
+	pod, err := controller.podLister.Pods(queueItem.podNs).Get(queueItem.podName)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			t.Logf("pod %s/%s has been deleted", queueItem.podNs, queueItem.podName)
+			return
+		}
+		t.Errorf("failed to get pod %s/%s: %v", queueItem.podNs, queueItem.podName, err)
+		return
+	}
+	if pod == nil {
+		return
+	}
+
+	namespace, _ := controller.namespaceLister.Get(pod.Namespace)
+	switch queueItem.action {
+	case ActionAttach:
+		if !utils.ShouldEnroll(pod, namespace) {
+			return
+		}
+		nspath, _ := kmeshns.GetPodNSpath(pod)
+		if err := attachPod(nspath, controller.xdpProgFd, controller.tcProgFd, controller.mode); err != nil {
+			t.Errorf("failed to attach pod %s/%s: %v", pod.Namespace, pod.Name, err)
+			return
+		}
+		simulateQueueItem(t, controller, QueueItem{podName: pod.Name, podNs: pod.Namespace, action: ActionAddAnnotation})
+	case ActionDetach:
+		nspath, _ := kmeshns.GetPodNSpath(pod)
+		if err := detachPod(nspath, controller.tcProgFd, controller.mode); err != nil {
+			t.Errorf("failed to detach pod %s/%s: %v", pod.Namespace, pod.Name, err)
+			return
+		}
+		simulateQueueItem(t, controller, QueueItem{podName: pod.Name, podNs: pod.Namespace, action: ActionDeleteAnnotation})
+	case ActionAddAnnotation:
+		if utils.ShouldEnroll(pod, namespace) {
+			t.Logf("add annotation for pod %s/%s", pod.Namespace, pod.Name)
+			if err := utils.PatchKmeshRedirectAnnotation(controller.client, pod); err != nil {
+				t.Errorf("failed to handle pod %s/%s: %v", queueItem.podNs, queueItem.podName, err)
+			}
+		}
+	case ActionDeleteAnnotation:
+		if !utils.ShouldEnroll(pod, namespace) {
+			t.Logf("delete annotation for pod %s/%s", pod.Namespace, pod.Name)
+			if err := utils.DelKmeshRedirectAnnotation(controller.client, pod); err != nil {
+				t.Errorf("failed to handle pod %s/%s: %v", queueItem.podNs, queueItem.podName, err)
+			}
+		}
+	}
+}
+
 func waitAndCheckManageAction(t *testing.T, enabled *atomic.Bool, disabled *atomic.Bool, enableExpected bool, disableExpected bool) {
 	retry.UntilSuccess(func() error {
 		// Wait for the handleKmeshManage to be called
@@ -220,33 +282,7 @@ func TestHandleKmeshManage(t *testing.T) {
 	})
 
 	patches.ApplyMethodFunc(reflect.TypeOf(controller.queue), "AddRateLimited", func(item interface{}) {
-		queueItem, ok := item.(QueueItem)
-		if !ok {
-			t.Logf("expected QueueItem but got %T", item)
-			return
-		}
-		pod, err := controller.podLister.Pods(queueItem.podNs).Get(queueItem.podName)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				t.Logf("pod %s/%s has been deleted", queueItem.podNs, queueItem.podName)
-				return
-			}
-			t.Errorf("failed to get pod %s/%s: %v", queueItem.podNs, queueItem.podName, err)
-		}
-
-		if pod != nil {
-			namespace, _ := controller.namespaceLister.Get(pod.Namespace)
-			if queueItem.action == ActionAddAnnotation && utils.ShouldEnroll(pod, namespace) {
-				t.Logf("add annotation for pod %s/%s", pod.Namespace, pod.Name)
-				err = utils.PatchKmeshRedirectAnnotation(controller.client, pod)
-			} else if queueItem.action == ActionDeleteAnnotation && !utils.ShouldEnroll(pod, namespace) {
-				t.Logf("delete annotation for pod %s/%s", pod.Namespace, pod.Name)
-				err = utils.DelKmeshRedirectAnnotation(controller.client, pod)
-			}
-		}
-		if err != nil {
-			t.Errorf("failed to handle pod %s/%s: %v", queueItem.podNs, queueItem.podName, err)
-		}
+		simulateQueueItem(t, controller, item)
 	})
 
 	type args struct {
@@ -462,33 +498,7 @@ func TestNsInformerHandleKmeshManage(t *testing.T) {
 	})
 
 	patches.ApplyMethodFunc(reflect.TypeOf(controller.queue), "AddRateLimited", func(item interface{}) {
-		queueItem, ok := item.(QueueItem)
-		if !ok {
-			t.Logf("expected QueueItem but got %T", item)
-			return
-		}
-		pod, err := controller.podLister.Pods(queueItem.podNs).Get(queueItem.podName)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				t.Logf("pod %s/%s has been deleted", queueItem.podNs, queueItem.podName)
-				return
-			}
-			t.Errorf("failed to get pod %s/%s: %v", queueItem.podNs, queueItem.podName, err)
-		}
-
-		if pod != nil {
-			namespace, _ := controller.namespaceLister.Get(pod.Namespace)
-			if queueItem.action == ActionAddAnnotation && utils.ShouldEnroll(pod, namespace) {
-				t.Logf("add annotation for pod %s/%s", pod.Namespace, pod.Name)
-				err = utils.PatchKmeshRedirectAnnotation(controller.client, pod)
-			} else if queueItem.action == ActionDeleteAnnotation && !utils.ShouldEnroll(pod, namespace) {
-				t.Logf("delete annotation for pod %s/%s", pod.Namespace, pod.Name)
-				err = utils.DelKmeshRedirectAnnotation(controller.client, pod)
-			}
-		}
-		if err != nil {
-			t.Errorf("failed to handle pod %s/%s: %v", queueItem.podNs, queueItem.podName, err)
-		}
+		simulateQueueItem(t, controller, item)
 	})
 
 	type args struct {

--- a/pkg/controller/manage/manage_controller_test.go
+++ b/pkg/controller/manage/manage_controller_test.go
@@ -292,6 +292,14 @@ func TestHandleKmeshManage(t *testing.T) {
 		return nil
 	})
 
+	// simulateQueueItem drives the real ActionAttach/ActionDetach branches, which call
+	// GetPodNSpath. Test pods have no real network namespace on disk, so the real
+	// implementation would fail here regardless of attach/detach outcome; mock it the
+	// same way attachPod/detachPod are mocked elsewhere in this file.
+	patches.ApplyFunc(kmeshns.GetPodNSpath, func(*corev1.Pod) (string, error) {
+		return "/proc/1/ns/net", nil
+	})
+
 	patches.ApplyMethodFunc(reflect.TypeOf(controller.queue), "AddRateLimited", func(item interface{}) {
 		simulateQueueItem(t, controller, item)
 	})
@@ -499,6 +507,15 @@ func TestSyncPodAttachGating(t *testing.T) {
 	_, err = client.CoreV1().Namespaces().Create(context.TODO(), nsWithoutLabel, metav1.CreateOptions{})
 	require.NoError(t, err)
 
+	// syncPod's ActionAttach/ActionDetach branches call GetPodNSpath before attachPod/
+	// detachPod. Test pods have no real network namespace on disk, so the real
+	// implementation would fail regardless of the injected attach/detach outcome below.
+	nsPatches := gomonkey.NewPatches()
+	defer nsPatches.Reset()
+	nsPatches.ApplyFunc(kmeshns.GetPodNSpath, func(*corev1.Pod) (string, error) {
+		return "/proc/1/ns/net", nil
+	})
+
 	// createSyncedPod creates pod through the fake clientset (not the informer store
 	// directly, since the informer's reflector would just evict a store-only entry on
 	// its next relist, and syncPod's PatchKmeshRedirectAnnotation/DelKmeshRedirectAnnotation
@@ -617,6 +634,14 @@ func TestNsInformerHandleKmeshManage(t *testing.T) {
 			disabled.Store(true)
 		}
 		return nil
+	})
+
+	// simulateQueueItem drives the real ActionAttach/ActionDetach branches, which call
+	// GetPodNSpath. Test pods have no real network namespace on disk, so the real
+	// implementation would fail here regardless of attach/detach outcome; mock it the
+	// same way attachPod/detachPod are mocked elsewhere in this file.
+	patches.ApplyFunc(kmeshns.GetPodNSpath, func(*corev1.Pod) (string, error) {
+		return "/proc/1/ns/net", nil
 	})
 
 	patches.ApplyMethodFunc(reflect.TypeOf(controller.queue), "AddRateLimited", func(item interface{}) {


### PR DESCRIPTION
Pods are only annotated as managed by Kmesh after the xdp and tc programs that actually redirect their traffic are attached, instead of the annotation being applied unconditionally while attach errors were silently discarded.

**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->
/kind bug

**What this PR does / why we need it**:

In `pkg/controller/manage/manage_controller.go`, `enableKmeshManage` queued the pod for the Kmesh redirection annotation and then called `linkXdp` and `linkTc`, discarding their return values with `_ =`. If either attach failed, the pod was still patched with the "kmesh redirection enabled" annotation, so the control plane and anyone inspecting the pod would believe it was fully enrolled while no xdp or tc program was actually attached to its interface. Traffic for that pod would then bypass the Kmesh dataplane with no error surfaced anywhere except a daemon log line, and no automatic retry once the pod stopped receiving further updates.

This PR makes the annotation step depend on the attach step actually succeeding:

- `enableKmeshManage` now enqueues an `ActionAttach` item instead of calling `linkXdp`/`linkTc` directly. `disableKmeshManage` enqueues `ActionDetach` the same way.
- `syncPod` runs the real attach or detach work through two new helpers, `attachPod` and `detachPod`. Only on success does it enqueue `ActionAddAnnotation` or `ActionDeleteAnnotation`, the actions that actually patch the pod.
- On failure `syncPod` returns an error, so the existing `processItems` retry path picks it up and retries with the controller's existing `MaxRetries` and rate limited backoff, the same mechanism already used for the annotation actions. No new retry logic was added.

**Which issue(s) this PR fixes**:
Fixes #1846

**Testing**:

Added `TestSyncPodAttachGating`, which drives the real queue/processItems/syncPod path (the existing tests in this file mock `queue.AddRateLimited` via `simulateQueueItem`, a test double that duplicates `syncPod`'s logic instead of calling it, so the real attach/detach branches and the retry-on-failure path weren't actually exercised by any test before this). The new test covers: a pod stays unannotated and attach is retried while `attachPod` keeps failing, the pod is annotated once `attachPod` succeeds, and an existing annotation is not removed while `detachPod` keeps failing.

**Special notes for your reviewer**:

- `manage_controller_test.go` mocks `queue.AddRateLimited` so tests can run synchronously without the real workqueue loop. That mock only understood `ActionAddAnnotation`/`ActionDeleteAnnotation`, so it has been replaced with a shared `simulateQueueItem` helper that mirrors `syncPod`'s full switch, including the `ActionAttach` to `ActionAddAnnotation` and `ActionDetach` to `ActionDeleteAnnotation` chaining.
- Both existing tests construct the controller with `xdpProgFd=0, tcProgFd=-1, mode=""`. With that configuration `linkXdp` returns `nil` immediately since the mode is not Dual-Engine, and `linkTc` returns `nil` immediately since `tcProgFd == -1`, so `attachPod`/`detachPod` never touch a real network namespace in these tests.
- I was not able to run `go build`/`go test` on this package locally since it only compiles on Linux (it pulls in `netns`, `cilium/ebpf` ringbuf, and `ethtool`, none of which build on macOS). Verified with `GOOS=linux go build`/`go vet` for both the package and the new test, and a full manual trace of the changed paths. Would appreciate this being confirmed by CI or a reviewer running it on Linux.
- I used an AI coding assistant (Claude) to help investigate this issue, draft the fix, and write `TestSyncPodAttachGating`. I reviewed and understand every change in this PR and can answer questions about any of it in review.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
fix: a pod is no longer annotated as managed by Kmesh unless its xdp and tc dataplane programs actually attach successfully. Attach and detach failures are now retried instead of being silently ignored.
