### PR TITLE
fix: handle mixed endpoints in DNS clusters

### DIFF
--- a/pkg/controller/ads/dns.go
+++ b/pkg/controller/ads/dns.go
@@ -17,10 +17,8 @@
 package ads
 
 import (
-	"fmt"
 	"net"
 	"net/netip"
-	"slices"
 	"sync"
 	"time"
 
@@ -172,23 +170,21 @@ func (r *dnsController) overwriteDnsCluster(cluster *clusterv3.Cluster, domain s
 	if ready {
 		newCluster := cloneCluster(cluster)
 		for _, e := range newCluster.LoadAssignment.Endpoints {
-			pos := -1
-			var lbEndpoints []*endpointv3.LbEndpoint
-			for i, le := range e.LbEndpoints {
+			lbEndpoints := make([]*endpointv3.LbEndpoint, 0, len(e.LbEndpoints))
+			for _, le := range e.LbEndpoints {
 				socketAddr, ok := le.GetEndpoint().GetAddress().GetAddress().(*v3.Address_SocketAddress)
 				if !ok {
+					lbEndpoints = append(lbEndpoints, le)
 					continue
 				}
-				_, err := netip.ParseAddr(socketAddr.SocketAddress.Address)
-				if err != nil {
-					host := socketAddr.SocketAddress.Address
-					addresses := addressesOfHostname[host]
-					fmt.Printf("addresses %#v", addresses)
-					pos = i
-					lbEndpoints = buildLbEndpoints(socketAddr.SocketAddress.GetPortValue(), addresses)
+				host := socketAddr.SocketAddress.Address
+				if _, err := netip.ParseAddr(host); err == nil {
+					lbEndpoints = append(lbEndpoints, le)
+					continue
 				}
+				lbEndpoints = append(lbEndpoints, buildLbEndpoints(socketAddr.SocketAddress.GetPortValue(), addressesOfHostname[host])...)
 			}
-			e.LbEndpoints = slices.Replace(e.LbEndpoints, pos, pos+1, lbEndpoints...)
+			e.LbEndpoints = lbEndpoints
 		}
 		return ready, newCluster
 	}

--- a/pkg/controller/ads/dns_test.go
+++ b/pkg/controller/ads/dns_test.go
@@ -115,6 +115,83 @@ func TestOverwriteDNSCluster(t *testing.T) {
 	}
 }
 
+func TestOverwriteDNSClusterMixedEndpoints(t *testing.T) {
+	const (
+		firstDomain  = "first.example.com"
+		secondDomain = "second.example.com"
+	)
+
+	newEndpoint := func(address string) *endpointv3.LbEndpoint {
+		return &endpointv3.LbEndpoint{
+			HostIdentifier: &endpointv3.LbEndpoint_Endpoint{
+				Endpoint: &endpointv3.Endpoint{
+					Address: &v3.Address{
+						Address: &v3.Address_SocketAddress{
+							SocketAddress: &v3.SocketAddress{
+								Address: address,
+								PortSpecifier: &v3.SocketAddress_PortValue{
+									PortValue: 8080,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	cluster := &clusterv3.Cluster{
+		Name: "mixed-cluster",
+		LoadAssignment: &endpointv3.ClusterLoadAssignment{
+			Endpoints: []*endpointv3.LocalityLbEndpoints{
+				{
+					LbEndpoints: []*endpointv3.LbEndpoint{
+						newEndpoint(firstDomain),
+						newEndpoint("10.0.0.1"),
+						newEndpoint(secondDomain),
+					},
+				},
+				{
+					LbEndpoints: []*endpointv3.LbEndpoint{
+						newEndpoint("10.0.0.2"),
+					},
+				},
+			},
+		},
+	}
+
+	dnsResolver, err := NewDnsController(NewAdsCache(nil))
+	assert.NoError(t, err)
+	dnsResolver.pendingHostnames[cluster.Name] = []string{firstDomain, secondDomain}
+
+	resolved := map[string][]string{
+		firstDomain:  {"192.0.2.1", "192.0.2.2"},
+		secondDomain: {"192.0.2.3"},
+	}
+	patches := gomonkey.NewPatches()
+	defer patches.Reset()
+	patches.ApplyMethod(reflect.TypeOf(dnsResolver.dnsResolver), "GetDNSAddresses",
+		func(_ *dns.DNSResolver, name string) []string {
+			return resolved[name]
+		})
+
+	ready, newCluster := dnsResolver.overwriteDnsCluster(cluster, firstDomain, resolved[firstDomain])
+	assert.True(t, ready)
+
+	var got [][]string
+	for _, locality := range newCluster.GetLoadAssignment().GetEndpoints() {
+		var addresses []string
+		for _, endpoint := range locality.GetLbEndpoints() {
+			addresses = append(addresses, endpoint.GetEndpoint().GetAddress().GetSocketAddress().GetAddress())
+		}
+		got = append(got, addresses)
+	}
+	assert.Equal(t, [][]string{
+		{"192.0.2.1", "192.0.2.2", "10.0.0.1", "192.0.2.3"},
+		{"10.0.0.2"},
+	}, got)
+}
+
 // This test aims to evaluate the concurrent writing behavior of the adsCache by utilizing the test race feature.
 // The test verifies the ability of the adsCache to handle concurrent access and updates correctly in a multi-goroutine environment.
 func TestADSCacheConcurrentWriting(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes DNS cluster rewriting for mixed hostname and IP endpoints. The old code replaced only the last hostname and panicked for localities containing only IP endpoints.

The new logic expands each hostname independently while preserving existing IP endpoints and locality order. Added regression coverage for mixed endpoints and multiple hostnames.

**Which issue(s) this PR fixes**:

Fixes #1848

**Special notes for your reviewer**:

The change is limited to `overwriteDnsCluster`. Existing IPv4-only behavior is preserved.

**Does this PR introduce a user-facing change?**:

Yes.

```release-note
Fix kernel-native DNS cluster resolution for localities containing mixed hostname and IP endpoints.