### PR TITLE
docs: replace stale admin endpoint reference and fix dockerfile path

### DIFF
--- a/docs/cn/zh/kmesh_commands-zh.md
+++ b/docs/cn/zh/kmesh_commands-zh.md
@@ -31,17 +31,37 @@ Flags:
 
 - 运维相关
 
+  kmesh-daemon在`localhost:15200`上提供管理接口（实现见`pkg/status/status_server.go`）。该接口仅监听环回地址，因此需要在Kmesh daemon Pod内访问，或先通过`kubectl port-forward`将端口转发到本机。推荐使用[`kmeshctl`](../../ctl/kmeshctl.md)操作这些接口。
+
+  | Method | Path | 用途 |
+  | --- | --- | --- |
+  | GET | `/version` | 查看kmesh-daemon版本信息 |
+  | GET | `/debug/ready` | 就绪探针，管理接口可用时返回`OK` |
+  | GET | `/debug/loggers` | 列出日志scope；带`?name=<scope>`时查看指定scope的日志级别（特殊scope `bpf`控制BPF程序日志） |
+  | POST | `/debug/loggers` | 设置日志级别，请求体为`{"name": "<scope>", "level": "<level>"}` |
+  | GET | `/debug/config_dump/kernel-native` | 导出kernel-native模式下的配置缓存 |
+  | GET | `/debug/config_dump/dual-engine` | 导出dual-engine模式下的workload、service和授权策略 |
+  | GET | `/debug/config_dump/bpf/kernel-native` | 导出kernel-native模式下的BPF map配置 |
+  | GET | `/debug/config_dump/bpf/dual-engine` | 导出dual-engine模式下的BPF map配置 |
+  | POST | `/monitoring?enable=<bool>` | 开启或关闭流量监控（同时联动access log、workload metrics和connection metrics） |
+  | POST | `/accesslog?enable=<bool>` | 开启或关闭access log |
+  | POST | `/workload_metrics?enable=<bool>` | 开启或关闭workload metrics |
+  | POST | `/connection_metrics?enable=<bool>` | 开启或关闭connection metrics |
+  | POST | `/authz?enable=<bool>` | 开启或关闭基于XDP的授权卸载 |
+  | GET | `/debug/pprof/` | Go pprof性能分析入口（还包括`/debug/pprof/cmdline`、`/debug/pprof/profile`、`/debug/pprof/symbol`、`/debug/pprof/trace`） |
+
   ```sh
-  # curl http://localhost:15200/help
-   /help: print list of commands
-   /options: print config options
-   /bpf/kmesh/maps: print bpf kmesh maps in kernel
-   /controller/envoy: print control-plane in envoy cache
-   /controller/kubernetes: print control-plane in kubernetes cache
-  
-  # example
-  curl http://localhost:15200/bpf/kmesh/maps
-  curl http://localhost:15200/options
+  # 将Kmesh daemon Pod的管理端口转发到本机
+  kubectl port-forward -n kmesh-system <kmesh-pod> 15200:15200
+
+  # 示例：查看版本信息
+  curl http://localhost:15200/version
+
+  # 示例：导出dual-engine模式下的配置
+  curl http://localhost:15200/debug/config_dump/dual-engine
+
+  # 示例：将default日志scope的级别设置为debug
+  curl -X POST http://localhost:15200/debug/loggers -d '{"name": "default", "level": "debug"}'
   ```
 
 - 命令使用注意事项

--- a/docs/en/kmesh_commands.md
+++ b/docs/en/kmesh_commands.md
@@ -29,19 +29,39 @@ Flags:
 ./kmesh-daemon --mode=dual-engine --enable-mda
 ```
 
-- Commands Example
+- Admin Endpoints
+
+  kmesh-daemon serves an admin interface on `localhost:15200` (implemented in `pkg/status/status_server.go`). It binds to the loopback interface only, so access it from inside the Kmesh daemon pod, or forward the port to your machine with `kubectl port-forward`. The recommended way to interact with these endpoints is through [`kmeshctl`](../ctl/kmeshctl.md), which wraps them.
+
+  | Method | Path | Purpose |
+  | --- | --- | --- |
+  | GET | `/version` | Print kmesh-daemon version information |
+  | GET | `/debug/ready` | Readiness probe, returns `OK` when the admin server is up |
+  | GET | `/debug/loggers` | List logger scopes; with `?name=<scope>` print the level of one scope (the special scope `bpf` controls BPF program logging) |
+  | POST | `/debug/loggers` | Set a logger level, request body `{"name": "<scope>", "level": "<level>"}` |
+  | GET | `/debug/config_dump/kernel-native` | Dump the configuration cache in kernel-native mode |
+  | GET | `/debug/config_dump/dual-engine` | Dump workloads, services and authorization policies in dual-engine mode |
+  | GET | `/debug/config_dump/bpf/kernel-native` | Dump the BPF map configuration in kernel-native mode |
+  | GET | `/debug/config_dump/bpf/dual-engine` | Dump the BPF map configuration in dual-engine mode |
+  | POST | `/monitoring?enable=<bool>` | Enable or disable traffic monitoring (also toggles access log, workload metrics and connection metrics) |
+  | POST | `/accesslog?enable=<bool>` | Enable or disable access log |
+  | POST | `/workload_metrics?enable=<bool>` | Enable or disable workload metrics |
+  | POST | `/connection_metrics?enable=<bool>` | Enable or disable connection metrics |
+  | POST | `/authz?enable=<bool>` | Enable or disable XDP-based authorization offloading |
+  | GET | `/debug/pprof/` | Go pprof profiling index (also `/debug/pprof/cmdline`, `/debug/pprof/profile`, `/debug/pprof/symbol`, `/debug/pprof/trace`) |
 
   ```sh
-  # curl http://localhost:15200/help
-   /help: print list of commands
-   /options: print config options
-   /bpf/kmesh/maps: print bpf kmesh maps in kernel
-   /controller/envoy: print control-plane in envoy cache
-   /controller/kubernetes: print control-plane in kubernetes cache
-  
-  # example
-  curl http://localhost:15200/bpf/kmesh/maps
-  curl http://localhost:15200/options
+  # forward the admin port from a Kmesh daemon pod
+  kubectl port-forward -n kmesh-system <kmesh-pod> 15200:15200
+
+  # example: print version information
+  curl http://localhost:15200/version
+
+  # example: dump the configuration in dual-engine mode
+  curl http://localhost:15200/debug/config_dump/dual-engine
+
+  # example: set the default logger's level to debug
+  curl -X POST http://localhost:15200/debug/loggers -d '{"name": "default", "level": "debug"}'
   ```
 
 - Precautions

--- a/docs/en/kmesh_deploy_and_develop_in_kind.md
+++ b/docs/en/kmesh_deploy_and_develop_in_kind.md
@@ -80,7 +80,7 @@ You can follow the steps below to develop in kind:
 + Build your docker image locally:
 
     ```shell
-    docker build -f build/docker/kmesh.dockerfile -t $image_name .
+    docker build -f build/docker/dockerfile -t $image_name .
     ```
 
     You should specify the `image_name`.


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

`docs/en/kmesh_commands.md` (and its Chinese mirror `docs/cn/zh/kmesh_commands-zh.md`) documents five admin HTTP endpoints that do not exist anywhere in the codebase:

| Documented endpoint | Reality |
| --- | --- |
| `/help` | no handler in `pkg/status/status_server.go` (or anywhere else) |
| `/options` | no handler in `pkg/status/status_server.go` |
| `/bpf/kmesh/maps` | no handler in `pkg/status/status_server.go` |
| `/controller/envoy` | no handler in `pkg/status/status_server.go` |
| `/controller/kubernetes` | no handler in `pkg/status/status_server.go` |

This PR replaces that section (in both the English doc and the Chinese mirror) with a reference of the endpoints actually registered by the admin server in `pkg/status/status_server.go` (`localhost:15200`): `/version`, `/debug/ready`, `/debug/loggers` (GET/POST), the four `/debug/config_dump/...` variants, the five POST toggles (`/monitoring`, `/accesslog`, `/workload_metrics`, `/connection_metrics`, `/authz`), and `/debug/pprof/`. Every table row maps 1:1 to a `s.mux.HandleFunc(...)` registration in that file. Since the server binds to loopback only, the examples go through `kubectl port-forward`, and the doc points to `kmeshctl` as the recommended interface.

Additionally, `docs/en/kmesh_deploy_and_develop_in_kind.md` instructs `docker build -f build/docker/kmesh.dockerfile ...`, but that file does not exist — the file is `build/docker/dockerfile` (the same one used by the Makefile `docker` target). Fixed the path.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Per the AI Guidance section in CONTRIBUTING.md: this PR was prepared with AI assistance; I have reviewed and verified every change against the source (`pkg/status/status_server.go`, `build/docker/`, Makefile) and can explain each of them. This PR is complementary to #1752/#1741 (daemon flag fixes in the same file — the flags block is deliberately untouched here) and #1794 (README link fixes) and deliberately avoids their hunks, so no conflicts are expected.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
