### PR TITLE
fix: synchronize RBAC policy lookup

### DIFF
--- a/pkg/auth/policy_store.go
+++ b/pkg/auth/policy_store.go
@@ -102,6 +102,14 @@ func (ps *policyStore) removePolicy(policyKey string) {
 	}
 }
 
+func (ps *policyStore) getByKey(key string) (*security.Authorization, bool) {
+	ps.rwLock.RLock()
+	defer ps.rwLock.RUnlock()
+
+	policy, ok := ps.byKey[key]
+	return policy, ok
+}
+
 // getAllPolicies returns a copied set of all policy names
 func (ps *policyStore) getAllPolicies() map[string]string {
 	ps.rwLock.RLock()

--- a/pkg/auth/rbac.go
+++ b/pkg/auth/rbac.go
@@ -235,7 +235,7 @@ func (r *Rbac) aggregate(workload *workloadapi.Workload) (allowPolicies, denyPol
 	policyNames = append(policyNames, r.policyStore.getByNamespace("")...)
 
 	for _, policyName := range policyNames {
-		if policy, ok := r.policyStore.byKey[policyName]; ok {
+		if policy, ok := r.policyStore.getByKey(policyName); ok {
 			if policy.Action == security.Action_ALLOW {
 				allowPolicies = append(allowPolicies, policy)
 			} else if policy.Action == security.Action_DENY {

--- a/pkg/auth/rbac_test.go
+++ b/pkg/auth/rbac_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"sync"
 	"syscall"
 	"testing"
 	"unsafe"
@@ -1979,6 +1980,40 @@ func TestRbac_doRbac(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRbacConcurrentPolicyUpdate(t *testing.T) {
+	rbac := NewRbac(nil)
+	policy := &security.Authorization{
+		Name:      "policy",
+		Namespace: "default",
+		Scope:     security.Scope_WORKLOAD_SELECTOR,
+	}
+	workload := &workloadapi.Workload{
+		Namespace:             "default",
+		AuthorizationPolicies: []string{policy.ResourceName()},
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 1000; i++ {
+			assert.NoError(t, rbac.UpdatePolicy(policy))
+			rbac.RemovePolicy(policy.ResourceName())
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < 1000; i++ {
+			rbac.aggregate(workload)
+		}
+	}()
+	close(start)
+	wg.Wait()
 }
 
 func Test_handleAuthorizationTypeResponse(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Uses the existing policy store lock when looking up RBAC policies. This prevents policy updates from racing with authorization checks and causing a concurrent map access panic.

Adds a regression test for concurrent policy updates and lookups.

**Which issue(s) this PR fixes**:

Fixes #1852

**Special notes for your reviewer**:

The change only replaces the direct `byKey` access with a locked store lookup.

**Does this PR introduce a user-facing change?**:

Yes.

```release-note
Fix a race between RBAC policy updates and authorization checks.
