### PR TITLE
fix(ctl): match the daemon's monitoring-disabled message

### DIFF
--- a/ctl/monitoring/monitoring.go
+++ b/ctl/monitoring/monitoring.go
@@ -203,7 +203,7 @@ func SetObservabilityPerKmeshDaemon(cli kube.CLIClient, podName, info string, ob
 			return
 		}
 		bodyString := string(bodyBytes)
-		if resp.StatusCode == http.StatusBadRequest && bytes.Contains(bodyBytes, []byte(fmt.Sprintf("Kmesh monitoring is disable, cannot enable %s.", observablityType))) {
+		if resp.StatusCode == http.StatusBadRequest && bytes.Contains(bodyBytes, []byte(fmt.Sprintf("Kmesh monitoring is disabled, cannot enable %s.", observablityType))) {
 			log.Errorf("failed to enable %s: %v. Need to start Kmesh's Monitoring. Please run `kmeshctl monitoring -h` for more help.", observablityType, bodyString)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`kmeshctl` searched the daemon's 400 response body for `"Kmesh monitoring is disable, cannot enable %s."`, but `pkg/status` sends `"Kmesh monitoring is disabled, cannot enable %s."` (`status_server.go`).

Because of the `disable` / `disabled` mismatch, the `bytes.Contains` check at `ctl/monitoring/monitoring.go` was always false for all three sub-toggles (`accesslog`, `workload metrics`, `connection metrics`), so the `log.Errorf` carrying the hint was unreachable. Enabling a sub-toggle while global monitoring was off printed only:

```
Error: received status code 400
```

even though the daemon had sent an explanation and `kmeshctl` had already read it into `bodyBytes`.

This PR corrects the string on the `kmeshctl` side so the daemon's explanation and the hint are surfaced.

**Which issue(s) this PR fixes**:

Fixes #1854

**Special notes for your reviewer**:
This PR fixes the typo inline, but this could be easily reintroduced unintentionally; So I wondering could we make this error message a shared constant - which prevents such bugs in future.

Verification:

- `gofmt -l ./ctl/` clean; `golangci-lint run --config=common/config/.golangci.yaml ./ctl/...` exits 0; `codespell` clean.
- `go test ./ctl/monitoring/` passes.


**Does this PR introduce a user-facing change?**:
No