### PR TITLE
 fix: make kmesh readiness probe work correctly for e2e test stability

### DIFF
--- a/deploy/charts/kmesh-helm/templates/daemonset.yaml
+++ b/deploy/charts/kmesh-helm/templates/daemonset.yaml
@@ -58,6 +58,14 @@ spec:
         image: {{ .Values.deploy.kmesh.image.repository }}:{{ .Values.deploy.kmesh.image.tag | default .Chart.AppVersion }}
         imagePullPolicy: {{ .Values.deploy.kmesh.imagePullPolicy }}
         name: kmesh
+        readinessProbe:
+          httpGet:
+            path: /debug/ready
+            port: 15200
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 5
         resources: {{- toYaml .Values.deploy.kmesh.resources | nindent 10 }}
         securityContext:
           privileged: true

--- a/deploy/yaml/kmesh.yaml
+++ b/deploy/yaml/kmesh.yaml
@@ -74,6 +74,14 @@ spec:
       containers:
         - name: kmesh
           image: ghcr.io/kmesh-net/kmesh:latest
+          readinessProbe:
+            httpGet:
+              path: /debug/ready
+              port: 15200
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 5
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh", "-c"]
           args:

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -45,7 +45,7 @@ import (
 var log = logger.NewLoggerScope("status")
 
 const (
-	adminAddr = "localhost:15200"
+	adminAddr = ":15200"
 
 	patternVersion            = "/version"
 	patternBpfAdsMaps         = "/debug/config_dump/bpf/kernel-native"

--- a/test/e2e/run_test.sh
+++ b/test/e2e/run_test.sh
@@ -158,27 +158,13 @@ function setup_kmesh() {
 		$extra_args
 
 	# Wait for all Kmesh pods to be ready.
-	while true; do
-		pod_statuses=$(kubectl get pods -n kmesh-system -l app=kmesh -o jsonpath='{range .items[*]}{.metadata.name}{" "}{.status.phase}{"\n"}{end}')
-
-		running_pods=0
-		total_pods=0
-
-		while read -r pod_name pod_status; do
-			total_pods=$((total_pods + 1))
-			if [ "$pod_status" = "Running" ]; then
-				running_pods=$((running_pods + 1))
-			fi
-		done <<<"$pod_statuses"
-
-		if [ "$running_pods" -eq "$total_pods" ]; then
-			echo "All pods of Kmesh daemon are in Running state."
-			break
-		fi
-
-		echo "Waiting for pods of Kmesh daemon to enter Running state..."
-		sleep 1
-	done
+	echo "Waiting for Kmesh daemon to become Ready..."
+	kubectl wait \
+	  --for=condition=Ready \
+	  pods \
+	  -l app=kmesh \
+	  -n kmesh-system \
+	  --timeout=120s
 
 	# Set log of each Kmesh pods.
 	PODS=$(kubectl get pods -n kmesh-system -l app=kmesh -o jsonpath='{.items[*].metadata.name}')

--- a/test/e2e/run_test.sh
+++ b/test/e2e/run_test.sh
@@ -160,11 +160,11 @@ function setup_kmesh() {
 	# Wait for all Kmesh pods to be ready.
 	echo "Waiting for Kmesh daemon to become Ready..."
 	kubectl wait \
-	  --for=condition=Ready \
-	  pods \
-	  -l app=kmesh \
-	  -n kmesh-system \
-	  --timeout=120s
+		--for=condition=Ready \
+		pods \
+		-l app=kmesh \
+		-n kmesh-system \
+		--timeout=120s
 
 	# Set log of each Kmesh pods.
 	PODS=$(kubectl get pods -n kmesh-system -l app=kmesh -o jsonpath='{.items[*].metadata.name}')

--- a/test/e2e/run_test.sh
+++ b/test/e2e/run_test.sh
@@ -164,7 +164,12 @@ function setup_kmesh() {
 		pods \
 		-l app=kmesh \
 		-n kmesh-system \
-		--timeout=120s
+		--timeout=300s || {
+		echo "Kmesh pods failed to become ready"
+		kubectl get pods -n kmesh-system -l app=kmesh
+		kubectl describe pods -n kmesh-system -l app=kmesh
+		exit 1
+	}
 
 	# Set log of each Kmesh pods.
 	PODS=$(kubectl get pods -n kmesh-system -l app=kmesh -o jsonpath='{.items[*].metadata.name}')


### PR DESCRIPTION
# Description

## What type of PR is this?

/kind bug

## What this PR does

Fixes Kmesh readiness detection in Kubernetes by making the status server reachable from the Pod network interface and adding proper readiness handling for E2E test stability.

The PR:
- Updates the Kmesh status server to listen on all interfaces instead of only `localhost`
- Adds a Kubernetes readiness probe using the existing `/debug/ready` endpoint
- Updates the E2E setup flow to wait for Kubernetes Ready condition after pod startup, ensuring Kmesh initialization is complete before tests begin.

## Why we need this

The E2E tests were failing because Kmesh was not correctly reporting readiness in Kubernetes.

The status server was bound to:

```go
adminAddr = "localhost:15200"
```

Kubernetes readiness probes send requests to the Pod IP address, not the container loopback interface. Because of this, the kubelet could not reach:

```
/debug/ready
```

and Kmesh pods could not transition to the Ready state.

This caused E2E tests to start before Kmesh dataplane initialization was complete, resulting in:

- Kmesh status server connection failures on port `15200`
- `/debug/loggers` EOF errors
- Failed BPF debug logger setup
- Traffic bypassing waypoint L7 processing
- `X-Request-Id not set, is L7 processing enabled?` failures in `TestMixNsAndServiceWaypoint`

## Fixes

- Changed the Kmesh status server binding from:

```go
localhost:15200
```

to:

```go
:15200
```

so Kubernetes probes and in-cluster components can access the endpoint.

- Added readiness probe using the existing endpoint:

```yaml
readinessProbe:
  httpGet:
    path: /debug/ready
    port: 15200
```

- Updated `test/e2e/run_test.sh` to wait for Kmesh pods to become Ready.

## Testing

Validated through GitHub Actions:

- ✅ E2E Test (istio 1.26)
- ✅ E2E Test (istio 1.27)
- ✅ E2E Test (istio 1.28)
- ✅ E2E IPv6 Test (istio 1.26)
- ✅ E2E IPv6 Test (istio 1.27)
- ✅ E2E IPv6 Test (istio 1.28)

Fixes #1859