### PR TITLE
Title: status: expose BPF operating mode in /version endpoint

### DIFF
--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -117,7 +117,13 @@ func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs, loade
 func (s *Server) version(w http.ResponseWriter, r *http.Request) {
 	v := version.Get()
 
-	data, err := json.MarshalIndent(&v, "", "  ")
+	data, err := json.MarshalIndent(&struct {
+		version.Info
+		Mode string `json:"mode"`
+	}{
+		Info: v,
+		Mode: s.config.BpfConfig.Mode,
+	}, "", "  ")
 	if err != nil {
 		log.Errorf("Failed to marshal version info: %v", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -341,7 +341,7 @@ func (s *Server) authzHandler(w http.ResponseWriter, r *http.Request) {
 		if authzOffload := s.loader.GetAuthzOffload(); authzOffload == constants.ENABLED {
 			enabled = true
 		}
-		
+
 		response := map[string]bool{"enabled": enabled}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -336,6 +336,21 @@ func (s *Server) connectionMetricHandler(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *Server) authzHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method == http.MethodGet {
+		enabled := false
+		if authzOffload := s.loader.GetAuthzOffload(); authzOffload == constants.ENABLED {
+			enabled = true
+		}
+		
+		response := map[string]bool{"enabled": enabled}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			log.Errorf("Failed to encode authz response: %v", err)
+		}
+		return
+	}
+
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
 		return

--- a/pkg/status/status_server_test.go
+++ b/pkg/status/status_server_test.go
@@ -662,3 +662,130 @@ func TestServerMonitoringHandler(t *testing.T) {
 		assert.Equal(t, constants.ENABLED, enableMonitoring)
 	})
 }
+
+func TestServerAuthzHandler(t *testing.T) {
+	t.Run("disable and check authz offload", func(t *testing.T) {
+		config := options.BpfConfig{
+			Mode:        constants.DualEngineMode,
+			BpfFsPath:   "/sys/fs/bpf",
+			Cgroup2Path: "/mnt/kmesh_cgroup2",
+		}
+		cleanup, l := test.InitBpfMap(t, config)
+		defer cleanup()
+
+		server := &Server{
+			xdsClient: &controller.XdsClient{
+				WorkloadController: &workload.Controller{
+					MetricController: &telemetry.MetricController{},
+				},
+			},
+			loader: l,
+		}
+
+		// disable authz
+		url := fmt.Sprintf("%s?enable=%s", patternAuthz, "false")
+		req := httptest.NewRequest(http.MethodPost, url, nil)
+		w := httptest.NewRecorder()
+		server.authzHandler(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// verify it shows as disabled
+		req = httptest.NewRequest(http.MethodGet, patternAuthz, nil)
+		w = httptest.NewRecorder()
+		server.authzHandler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp struct {
+			Enabled bool `json:"enabled"`
+		}
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.False(t, resp.Enabled)
+
+		authzOffload := l.GetAuthzOffload()
+		assert.Equal(t, constants.DISABLED, authzOffload)
+	})
+
+	t.Run("enable and check authz offload", func(t *testing.T) {
+		config := options.BpfConfig{
+			Mode:        constants.DualEngineMode,
+			BpfFsPath:   "/sys/fs/bpf",
+			Cgroup2Path: "/mnt/kmesh_cgroup2",
+		}
+		cleanup, l := test.InitBpfMap(t, config)
+		defer cleanup()
+
+		server := &Server{
+			xdsClient: &controller.XdsClient{
+				WorkloadController: &workload.Controller{
+					MetricController: &telemetry.MetricController{},
+				},
+			},
+			loader: l,
+		}
+
+		// enable authz
+		url := fmt.Sprintf("%s?enable=%s", patternAuthz, "true")
+		req := httptest.NewRequest(http.MethodPost, url, nil)
+		w := httptest.NewRecorder()
+		server.authzHandler(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		// verify it shows as enabled
+		req = httptest.NewRequest(http.MethodGet, patternAuthz, nil)
+		w = httptest.NewRecorder()
+		server.authzHandler(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp struct {
+			Enabled bool `json:"enabled"`
+		}
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.True(t, resp.Enabled)
+
+		authzOffload := l.GetAuthzOffload()
+		assert.Equal(t, constants.ENABLED, authzOffload)
+	})
+
+	t.Run("invalid method", func(t *testing.T) {
+		server := &Server{}
+		req := httptest.NewRequest(http.MethodPut, patternAuthz, nil)
+		w := httptest.NewRecorder()
+		server.authzHandler(w, req)
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+
+	t.Run("invalid enable value", func(t *testing.T) {
+		server := &Server{}
+		url := fmt.Sprintf("%s?enable=%s", patternAuthz, "invalid_value")
+		req := httptest.NewRequest(http.MethodPost, url, nil)
+		w := httptest.NewRecorder()
+		server.authzHandler(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	})
+}
+
+func TestServerVersion(t *testing.T) {
+	t.Run("returns mode from config", func(t *testing.T) {
+		server := &Server{
+			config: &options.BootstrapConfigs{
+				BpfConfig: &options.BpfConfig{
+					Mode: constants.DualEngineMode,
+				},
+			},
+		}
+
+		req := httptest.NewRequest(http.MethodGet, patternVersion, nil)
+		w := httptest.NewRecorder()
+		server.version(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		var resp struct {
+			Mode string `json:"mode"`
+		}
+		err := json.Unmarshal(w.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.Equal(t, constants.DualEngineMode, resp.Mode)
+	})
+}


### PR DESCRIPTION
**Problem :** 
 While looking at the API, I saw that external tools (like `kmeshctl` or the new MCP server) have no direct way to know if Kmesh is running in kernel-native or dual-engine mode. Because of this, tools are forced to guess by blindly hitting mode-specific endpoints just to see if they fail.

**What I knew:** I knew that the Kmesh Server already stores this mode internally in `s.config.BpfConfig.Mode`. The simplest and cleanest way to fix this "guessing" problem is to just expose this mode in the standard /version endpoint.

**How I solved it :**

I updated the /version handler in `status_server.go`. Now, it returns the standard version info along with a new "mode" field in the JSON response.
I added a unit test (`TestServerVersion`) in `status_server_test.go` to make sure the API returns the correct mode based on the config.

**How it will be useful:** 
Now, any client can just make one simple call to /version on startup and immediately know which BPF maps and config endpoints they can use. Also, this makes it possible for the `kmeshctl` version command to print the operating mode in the future, which will be super helpful for users debugging their clusters.

