### PR TITLE
fix(ctl): exit non-zero when kmeshctl log --set gets HTTP error

### DIFF
--- a/ctl/log/log.go
+++ b/ctl/log/log.go
@@ -111,10 +111,9 @@ func GetLoggerLevel(url string) {
 	fmt.Printf("Logger Level: %s\n", loggerInfo.Level)
 }
 
-func SetLoggerLevel(url string, setFlag string) {
+func SetLoggerLevel(url string, setFlag string) error {
 	if !strings.Contains(setFlag, ":") {
-		log.Errorf("Invalid set flag, which should be loggerName:loggerLevel (e.g. default:debug)")
-		os.Exit(1)
+		return fmt.Errorf("invalid set flag, which should be loggerName:loggerLevel (e.g. default:debug)")
 	}
 	splits := strings.Split(setFlag, ":")
 	loggerName := splits[0]
@@ -126,34 +125,35 @@ func SetLoggerLevel(url string, setFlag string) {
 	}
 	data, err := json.Marshal(loggerInfo)
 	if err != nil {
-		log.Errorf("Error marshaling logger info: %v", err)
-		return
+		return fmt.Errorf("error marshaling logger info: %v", err)
 	}
 
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(data))
 	if err != nil {
-		log.Errorf("Error creating request: %v", err)
-		return
+		return fmt.Errorf("error creating request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Errorf("failed to make HTTP request: %v", err)
-		return
+		return fmt.Errorf("failed to make HTTP request: %v", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		log.Errorf("Error: received status code %d", resp.StatusCode)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("received status code %d", resp.StatusCode)
+		}
+		return fmt.Errorf("received status code %d, Response body: %s", resp.StatusCode, body)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Errorf("failed to read HTTP response body: %v", err)
-		return
+		return fmt.Errorf("failed to read HTTP response body: %v", err)
 	}
 	fmt.Println(string(body))
+	return nil
 }
 
 func RunGetOrSetLoggerLevel(cmd *cobra.Command, args []string) {
@@ -187,6 +187,9 @@ func RunGetOrSetLoggerLevel(cmd *cobra.Command, args []string) {
 			GetLoggerNames(url)
 		}
 	} else {
-		SetLoggerLevel(url, setFlag)
+		if err := SetLoggerLevel(url, setFlag); err != nil {
+			log.Errorf("%v", err)
+			os.Exit(1)
+		}
 	}
 }

--- a/ctl/log/log_test.go
+++ b/ctl/log/log_test.go
@@ -1,0 +1,64 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logs
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSetLoggerLevelNonOKStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, "logger nosuch does not exist")
+	}))
+	defer srv.Close()
+
+	err := SetLoggerLevel(srv.URL, "nosuch:debug")
+	if err == nil {
+		t.Fatal("expected error when server returns non-OK status, got nil")
+	}
+	if !strings.Contains(err.Error(), "400") {
+		t.Errorf("error %q should mention status code 400", err)
+	}
+}
+
+func TestSetLoggerLevelOK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "set logger success")
+	}))
+	defer srv.Close()
+
+	err := SetLoggerLevel(srv.URL, "default:debug")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSetLoggerLevelInvalidFlag(t *testing.T) {
+	err := SetLoggerLevel("http://example.com", "nodebug")
+	if err == nil {
+		t.Fatal("expected error for invalid set flag")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`kmeshctl log --set` logged non-OK HTTP responses but still printed the body and exited 0, so a failed set (bad logger name/level) looked successful.

This change returns an error on non-OK status and calls `os.Exit(1)`, and adds unit tests for the set path.

**Which issue(s) this PR fixes**:
Fixes #1861

**Special notes for your reviewer**:

- `SetLoggerLevel` now returns `error` (aligned with `GetJson`)
x
**Does this PR introduce a user-facing change?**:
```release-note
kmeshctl log --set now exits non-zero when the daemon returns a non-OK HTTP status.
```