### PR TITLE
fix(ctl): only delete waypoint Gateways on delete --all

### DIFF
--- a/ctl/waypoint/waypoint.go
+++ b/ctl/waypoint/waypoint.go
@@ -492,6 +492,9 @@ func deleteWaypoints(cmd *cobra.Command, kubeClient kube.CLIClient, namespace st
 			return err
 		}
 		for _, gw := range waypoints.Items {
+			if gw.Spec.GatewayClassName != constants.WaypointGatewayClassName {
+				continue
+			}
 			names = append(names, gw.Name)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`kmeshctl waypoint delete --all` deleted all Gateways in the namespace. Filter by `istio-waypoint` GatewayClass, matching `list`/`status`.

**Which issue(s) this PR fixes**:
Fixes #1864

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
fix: kmeshctl waypoint delete --all only deletes waypoint Gateways
```