### PR TITLE
feat(status): add debug endpoints to dump services, authz, and certs

### DIFF
--- a/daemon/manager/manager.go
+++ b/daemon/manager/manager.go
@@ -100,7 +100,7 @@ func Execute(configs *options.BootstrapConfigs) error {
 	log.Info("controller start successfully")
 	defer c.Stop()
 
-	statusServer := status.NewServer(c.GetXdsClient(), configs, bpfLoader)
+	statusServer := status.NewServer(c.GetXdsClient(), configs, bpfLoader, c.SecretManager)
 	statusServer.StartServer()
 	defer func() {
 		_ = statusServer.StopServer()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -63,6 +63,7 @@ type Controller struct {
 	ipsecController     *ipsec.Controller
 	enableByPass        bool
 	enableSecretManager bool
+	SecretManager       *security.SecretManager
 	bpfConfig           *options.BpfConfig
 	loader              *bpf.BpfLoader
 	dnsServer           *dnsclient.LocalDNSServer
@@ -113,15 +114,14 @@ func (c *Controller) Start(stopCh <-chan struct{}) error {
 	}
 
 	if c.mode == constants.DualEngineMode {
-		var secertManager *security.SecretManager
 		if c.enableSecretManager {
-			secertManager, err = security.NewSecretManager()
+			c.SecretManager, err = security.NewSecretManager()
 			if err != nil {
 				return fmt.Errorf("secretManager create failed: %v", err)
 			}
-			go secertManager.Run(stopCh)
+			go c.SecretManager.Run(stopCh)
 		}
-		kmeshManageController, err = manage.NewKmeshManageController(clientset, secertManager, c.bpfWorkloadObj.XdpAuth.XdpAuthz.FD(), tcFd, c.mode)
+		kmeshManageController, err = manage.NewKmeshManageController(clientset, c.SecretManager, c.bpfWorkloadObj.XdpAuth.XdpAuthz.FD(), tcFd, c.mode)
 	} else {
 		kolog.KmeshModuleLog(stopCh)
 		kmeshManageController, err = manage.NewKmeshManageController(clientset, nil, -1, tcFd, c.mode)

--- a/pkg/controller/security/manager.go
+++ b/pkg/controller/security/manager.go
@@ -257,3 +257,17 @@ func (s *SecretManager) retryFetchCert(identity string) {
 
 	go s.fetchCert(identity)
 }
+
+// DumpCertificates returns a snapshot of the current certificates in the cache
+func (s *SecretManager) DumpCertificates() []*istiosecurity.SecretItem {
+	s.certsCache.mu.RLock()
+	defer s.certsCache.mu.RUnlock()
+
+	var certs []*istiosecurity.SecretItem
+	for _, item := range s.certsCache.certs {
+		if item.cert != nil {
+			certs = append(certs, item.cert)
+		}
+	}
+	return certs
+}

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -38,6 +38,7 @@ import (
 	"kmesh.net/kmesh/pkg/constants"
 	"kmesh.net/kmesh/pkg/controller"
 	"kmesh.net/kmesh/pkg/controller/ads"
+	"kmesh.net/kmesh/pkg/controller/security"
 	"kmesh.net/kmesh/pkg/logger"
 	"kmesh.net/kmesh/pkg/version"
 )
@@ -47,19 +48,22 @@ var log = logger.NewLoggerScope("status")
 const (
 	adminAddr = "localhost:15200"
 
-	patternVersion            = "/version"
-	patternBpfAdsMaps         = "/debug/config_dump/bpf/kernel-native"
-	patternBpfWorkloadMaps    = "/debug/config_dump/bpf/dual-engine"
-	configDumpPrefix          = "/debug/config_dump"
-	patternConfigDumpAds      = configDumpPrefix + "/kernel-native"
-	patternConfigDumpWorkload = configDumpPrefix + "/dual-engine"
-	patternReadyProbe         = "/debug/ready"
-	patternLoggers            = "/debug/loggers"
-	patternAccesslog          = "/accesslog"
-	patternMonitoring         = "/monitoring"
-	patternWorkloadMetrics    = "/workload_metrics"
-	patternConnectionMetrics  = "/connection_metrics"
-	patternAuthz              = "/authz"
+	patternVersion               = "/version"
+	patternBpfAdsMaps            = "/debug/config_dump/bpf/kernel-native"
+	patternBpfWorkloadMaps       = "/debug/config_dump/bpf/dual-engine"
+	configDumpPrefix             = "/debug/config_dump"
+	patternConfigDumpAds         = configDumpPrefix + "/kernel-native"
+	patternConfigDumpWorkload    = configDumpPrefix + "/dual-engine"
+	patternReadyProbe            = "/debug/ready"
+	patternLoggers               = "/debug/loggers"
+	patternAccesslog             = "/accesslog"
+	patternMonitoring            = "/monitoring"
+	patternWorkloadMetrics       = "/workload_metrics"
+	patternConnectionMetrics     = "/connection_metrics"
+	patternAuthz                 = "/authz"
+	patternServices              = "/debug/services"
+	patternAuthorizationPolicies = "/debug/authorizationPolicies"
+	patternCertificates          = "/debug/certificates"
 
 	bpfLoggerName = "bpf"
 
@@ -69,19 +73,21 @@ const (
 )
 
 type Server struct {
-	config    *options.BootstrapConfigs
-	xdsClient *controller.XdsClient
-	mux       *http.ServeMux
-	server    *http.Server
-	loader    *bpf.BpfLoader
+	config        *options.BootstrapConfigs
+	xdsClient     *controller.XdsClient
+	mux           *http.ServeMux
+	server        *http.Server
+	loader        *bpf.BpfLoader
+	secretManager *security.SecretManager
 }
 
-func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs, loader *bpf.BpfLoader) *Server {
+func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs, loader *bpf.BpfLoader, secretManager *security.SecretManager) *Server {
 	s := &Server{
-		config:    configs,
-		xdsClient: c,
-		mux:       http.NewServeMux(),
-		loader:    loader,
+		config:        configs,
+		xdsClient:     c,
+		mux:           http.NewServeMux(),
+		loader:        loader,
+		secretManager: secretManager,
 	}
 	s.server = &http.Server{
 		Addr:         adminAddr,
@@ -102,7 +108,10 @@ func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs, loade
 	s.mux.HandleFunc(patternConnectionMetrics, s.connectionMetricHandler)
 	s.mux.HandleFunc(patternAuthz, s.authzHandler)
 
-	// TODO: add dump certificate, authorizationPolicies and services
+	s.mux.HandleFunc(patternServices, s.servicesHandler)
+	s.mux.HandleFunc(patternAuthorizationPolicies, s.authorizationPoliciesHandler)
+	s.mux.HandleFunc(patternCertificates, s.certificatesHandler)
+
 	s.mux.HandleFunc(patternReadyProbe, s.readyProbe)
 
 	// support pprof
@@ -581,5 +590,62 @@ func printWorkloadDump(w http.ResponseWriter, wd WorkloadDump) {
 		return
 	}
 	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
+
+func (s *Server) servicesHandler(w http.ResponseWriter, r *http.Request) {
+	if !s.checkWorkloadMode(w) {
+		return
+	}
+	services := s.xdsClient.WorkloadController.Processor.ServiceCache.List()
+	dump := make([]*Service, 0, len(services))
+	for _, svc := range services {
+		dump = append(dump, ConvertService(svc))
+	}
+	sort.Slice(dump, func(i, j int) bool {
+		return dump[i].Name < dump[j].Name
+	})
+	data, err := json.MarshalIndent(dump, "", "  ")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_, _ = w.Write(data)
+}
+
+func (s *Server) authorizationPoliciesHandler(w http.ResponseWriter, r *http.Request) {
+	if !s.checkWorkloadMode(w) {
+		return
+	}
+	policies := s.xdsClient.WorkloadController.Rbac.PoliciesList()
+	dump := make([]*AuthorizationPolicy, 0, len(policies))
+	for _, p := range policies {
+		dump = append(dump, ConvertAuthorizationPolicy(p))
+	}
+	sort.Slice(dump, func(i, j int) bool {
+		return dump[i].Name < dump[j].Name
+	})
+	data, err := json.MarshalIndent(dump, "", "  ")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	_, _ = w.Write(data)
+}
+
+func (s *Server) certificatesHandler(w http.ResponseWriter, r *http.Request) {
+	if !s.checkWorkloadMode(w) {
+		return
+	}
+	if s.secretManager == nil {
+		http.Error(w, "secret manager is not enabled", http.StatusServiceUnavailable)
+		return
+	}
+	certs := s.secretManager.DumpCertificates()
+	data, err := json.MarshalIndent(certs, "", "  ")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	_, _ = w.Write(data)
 }

--- a/test/e2e/manage_test.go
+++ b/test/e2e/manage_test.go
@@ -189,7 +189,7 @@ func TestCrossNamespace(t *testing.T) {
 
 		dst := apps.ServiceWithWaypointAtServiceGranularity
 
-		unenrolledNSTest := func() {
+		unenrolledNSTest := func(t framework.TestContext) {
 			tests := []struct {
 				svc      echo.Instances
 				enrolled bool
@@ -224,7 +224,7 @@ func TestCrossNamespace(t *testing.T) {
 		}
 
 		t.NewSubTest("cross namespace access, the new namespace is not managed by Kmesh").Run(func(t framework.TestContext) {
-			unenrolledNSTest()
+			unenrolledNSTest(t)
 		})
 
 		enrollNamespaceOrFail(t, anotherNS.Name())
@@ -246,7 +246,7 @@ func TestCrossNamespace(t *testing.T) {
 		unenrollNamespaceOrFail(t, anotherNS.Name())
 
 		t.NewSubTest("cross namespace access, the new namespace is not managed by Kmesh **AGAIN**").Run(func(t framework.TestContext) {
-			unenrolledNSTest()
+			unenrolledNSTest(t)
 		})
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:
The Kmesh status server currently supports dumping workloads and loggers via the `/debug` endpoints. However, there was a `TODO` in `pkg/status/status_server.go` to add endpoints for dumping `services`, `authorizationPolicies`, and `certificates`. 

This PR implements those missing endpoints (`/debug/services`, `/debug/authorizationPolicies`, `/debug/certificates`) to make it significantly easier for operators and developers to debug traffic routing and security issues in Kmesh by inspecting the internal caches. 

To accomplish this:
- Exposed `SecretManager` on the `Controller` struct and passed it down to the status server.
- Implemented `DumpCertificates()` with safe `RLock()` caching.
- Created `servicesHandler`, `authorizationPoliciesHandler`, and `certificatesHandler` that fetch their respective objects and return them as pretty-formatted JSON.

**Which issue(s) this PR fixes**:
Fixes #1866 

**Special notes for your reviewer**:
The handlers have been implemented following the exact same pattern and formatting as `configDumpWorkload`.

**Does this PR introduce a user-facing change?**:
```release-note
Added /debug/services, /debug/authorizationPolicies, and /debug/certificates endpoints to the status server for dumping internal Kmesh configurations.