### PR TITLE
fix(controller): prevent nil pointer dereference in Controller.Stop()

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -194,9 +194,13 @@ func (c *Controller) Stop() {
 		c.ipsecController.Stop()
 	}
 	if c.client != nil {
-		c.client.Close()
+		if err := c.client.Close(); err != nil {
+			log.Errorf("failed to close client: %v", err)
+		}
 		if c.client.WorkloadController != nil {
-			c.client.WorkloadController.Close()
+			if err := c.client.WorkloadController.Close(); err != nil {
+				log.Errorf("failed to close workload controller: %v", err)
+			}
 		}
 	}
 	if c.dnsServer != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -195,12 +195,12 @@ func (c *Controller) Stop() {
 	}
 	if c.client != nil {
 		c.client.Close()
+		if c.client.WorkloadController != nil {
+			c.client.WorkloadController.Close()
+		}
 	}
 	if c.dnsServer != nil {
 		c.dnsServer.Close()
-	}
-	if c.client.WorkloadController != nil {
-		c.client.WorkloadController.Close()
 	}
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"kmesh.net/kmesh/daemon/options"
+)
+
+func TestControllerStop(t *testing.T) {
+	t.Run("nil controller", func(t *testing.T) {
+		var c *Controller
+		assert.NotPanics(t, func() {
+			c.Stop()
+		})
+	})
+
+	t.Run("nil client and nil dnsServer", func(t *testing.T) {
+		c := &Controller{
+			bpfConfig: &options.BpfConfig{
+				EnableIPsec: false,
+			},
+			client:    nil,
+			dnsServer: nil,
+		}
+		assert.NotPanics(t, func() {
+			c.Stop()
+		})
+	})
+
+	t.Run("non-nil client with nil WorkloadController", func(t *testing.T) {
+		c := &Controller{
+			bpfConfig: &options.BpfConfig{
+				EnableIPsec: false,
+			},
+			client:    &XdsClient{},
+			dnsServer: nil,
+		}
+		assert.NotPanics(t, func() {
+			c.Stop()
+		})
+	})
+}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"kmesh.net/kmesh/daemon/options"
+	"kmesh.net/kmesh/pkg/controller/workload"
+	"kmesh.net/kmesh/pkg/controller/workload/bpfcache"
 )
 
 func TestControllerStop(t *testing.T) {
@@ -53,6 +55,30 @@ func TestControllerStop(t *testing.T) {
 			client:    &XdsClient{},
 			dnsServer: nil,
 		}
+		assert.NotPanics(t, func() {
+			c.Stop()
+		})
+	})
+
+	t.Run("non-nil client with non-nil WorkloadController", func(t *testing.T) {
+		workloadMap := bpfcache.NewFakeWorkloadMap(t)
+		defer bpfcache.CleanupFakeWorkloadMap(workloadMap)
+
+		processor := workload.NewProcessor(workloadMap)
+		wlCtrl := &workload.Controller{
+			Processor: processor,
+		}
+
+		c := &Controller{
+			bpfConfig: &options.BpfConfig{
+				EnableIPsec: false,
+			},
+			client: &XdsClient{
+				WorkloadController: wlCtrl,
+			},
+			dnsServer: nil,
+		}
+
 		assert.NotPanics(t, func() {
 			c.Stop()
 		})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes a potential nil-pointer dereference panic in `Controller.Stop()`.

Previously, `c.client.WorkloadController` was accessed outside the `if c.client != nil` guard. If `Controller.Start()` failed partway through before `c.client` was initialized (or if `c.client` was `nil`), calling `Controller.Stop()` resulted in a runtime panic.

This PR moves the `c.client.WorkloadController` check inside the `if c.client != nil` block.

**Which issue(s) this PR fixes**:
Fixes #1866 (or reference related issue)

**Special notes for your reviewer**:
- Added unit tests in `pkg/controller/controller_test.go` covering `Stop()` behavior when `Controller`, `c.client`, or `WorkloadController` are `nil`.

**Does this PR introduce a user-facing change?**:
```release-note
fix: prevent nil pointer dereference in Controller.Stop() when xDS client is uninitialized
