### PR TITLE
fix(bpf): replace package-level hash with local fnv instance in storeVersionInfo…

### DIFF
--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -48,8 +48,7 @@ import (
 )
 
 var (
-	log  = logger.NewLoggerScope("bpf")
-	hash = fnv.New32a()
+	log = logger.NewLoggerScope("bpf")
 )
 
 type BpfLoader struct {
@@ -249,11 +248,13 @@ func NewVersionMap(config *options.BpfConfig) *ebpf.Map {
 }
 
 func storeVersionInfo(versionMap *ebpf.Map) {
+	if versionMap == nil {
+		return
+	}
 	key := uint32(0)
-	var value uint32
-	hash.Reset()
-	hash.Write([]byte(version.Get().GitVersion))
-	value = hash.Sum32()
+	h := fnv.New32a()
+	h.Write([]byte(version.Get().GitVersion))
+	value := h.Sum32()
 	if err := versionMap.Put(&key, &value); err != nil {
 		log.Errorf("Add Version Map failed, err is %v", err)
 	}

--- a/pkg/bpf/bpf.go
+++ b/pkg/bpf/bpf.go
@@ -247,14 +247,19 @@ func NewVersionMap(config *options.BpfConfig) *ebpf.Map {
 	return m
 }
 
+func computeVersionHash() uint32 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(version.Get().GitVersion))
+	return h.Sum32()
+}
+
 func storeVersionInfo(versionMap *ebpf.Map) {
 	if versionMap == nil {
+		log.Warn("versionMap is nil, skip storing version info")
 		return
 	}
 	key := uint32(0)
-	h := fnv.New32a()
-	h.Write([]byte(version.Get().GitVersion))
-	value := h.Sum32()
+	value := computeVersionHash()
 	if err := versionMap.Put(&key, &value); err != nil {
 		log.Errorf("Add Version Map failed, err is %v", err)
 	}

--- a/pkg/bpf/bpf_test.go
+++ b/pkg/bpf/bpf_test.go
@@ -551,7 +551,7 @@ func TestStoreVersionInfoConcurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			storeVersionInfo(nil)
+			_ = computeVersionHash()
 		}()
 	}
 	wg.Wait()

--- a/pkg/bpf/bpf_test.go
+++ b/pkg/bpf/bpf_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"testing"
 
@@ -540,4 +541,18 @@ func TestDiffStructInfoAgainstBTF_NestedAndMigrateMap_Compatible(t *testing.T) {
 	if m != nil {
 		t.Fatalf("expected nil map (reuse existing), got non-nil: %v", m)
 	}
+}
+
+func TestStoreVersionInfoConcurrent(t *testing.T) {
+	var wg sync.WaitGroup
+	goroutines := 50
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			storeVersionInfo(nil)
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes a data race in `pkg/bpf/bpf.go`. 

Previously, `storeVersionInfo()` reused a shared, package-level `hash = fnv.New32a()` instance via `hash.Reset()`. `hash.Hash32` from standard library's `fnv` package is not safe for concurrent usage. In a multi-goroutine scenario or under `-race`, concurrent access could corrupt the computed version hash or cause data race warnings.

This PR removes the package-level `hash` variable and replaces it with a local `h := fnv.New32a()` instance scoped inside `storeVersionInfo()`.

**Special notes for your reviewer**:
- Added `TestStoreVersionInfoConcurrent` in `pkg/bpf/bpf_test.go` to verify concurrent safe execution.

**Does this PR introduce a user-facing change?**:
```release-note
fix: eliminate data race risk in eBPF version map initialization by using thread-local hash instance
