### PR TITLE
fix(workload): perform DNS resolution asynchronously for workloads without addresses

### DIFF
--- a/pkg/controller/workload/dns_test.go
+++ b/pkg/controller/workload/dns_test.go
@@ -339,3 +339,72 @@ func TestCloneWorkload(t *testing.T) {
 		})
 	}
 }
+
+func TestAsyncDNSResolution_NonBlocking(t *testing.T) {
+	workloadMap := bpfcache.NewFakeWorkloadMap(t)
+	defer bpfcache.CleanupFakeWorkloadMap(workloadMap)
+
+	p := NewProcessor(workloadMap)
+	p.DnsResolverChan = make(chan *workloadapi.Workload, 10)
+
+	wlNeedsDNS := &workloadapi.Workload{
+		Uid:       "uid-dns-1",
+		Name:      "wl-dns",
+		Namespace: "default",
+		Hostname:  "slow.example.com",
+		Addresses: nil,
+	}
+
+	wlHasIP := &workloadapi.Workload{
+		Uid:       "uid-ip-2",
+		Name:      "wl-ip",
+		Namespace: "default",
+		Addresses: [][]byte{netip.MustParseAddr("10.1.2.3").AsSlice()},
+	}
+
+	start := time.Now()
+	p.handleServicesAndWorkloads(nil, []*workloadapi.Workload{wlNeedsDNS, wlHasIP})
+	elapsed := time.Since(start)
+
+	// Assert that handleServicesAndWorkloads returned immediately (< 200ms) without waiting for 3s DNS timeout
+	assert.True(t, elapsed < 200*time.Millisecond, "handleServicesAndWorkloads blocked for %v, expected non-blocking execution", elapsed)
+
+	// Assert that wlHasIP was processed and added to cache immediately
+	processedWL := p.WorkloadCache.GetWorkloadByUid("uid-ip-2")
+	assert.NotNil(t, processedWL, "workload with IP should be processed immediately without waiting for DNS resolution")
+}
+
+func TestAsyncDNSResolution_AppliedOnResolution(t *testing.T) {
+	workloadMap := bpfcache.NewFakeWorkloadMap(t)
+	defer bpfcache.CleanupFakeWorkloadMap(workloadMap)
+
+	p := NewProcessor(workloadMap)
+	p.DnsResolverChan = make(chan *workloadapi.Workload, 10)
+
+	wlNeedsDNS := &workloadapi.Workload{
+		Uid:       "uid-dns-resolve",
+		Name:      "wl-dns-resolve",
+		Namespace: "default",
+		Hostname:  "resolve.example.com",
+		Addresses: nil,
+	}
+
+	p.handleServicesAndWorkloads(nil, []*workloadapi.Workload{wlNeedsDNS})
+
+	// Retrieve the channel created for this workload's resolution
+	p.dnsMapMutex.RLock()
+	resCh, ok := p.ResolvedDomainChanMap["uid-dns-resolve"]
+	p.dnsMapMutex.RUnlock()
+	assert.True(t, ok, "resolution channel should be registered in ResolvedDomainChanMap")
+
+	// Simulate successful DNS resolution
+	resolvedWorkload := cloneWorkload(wlNeedsDNS)
+	resolvedWorkload.Addresses = [][]byte{netip.MustParseAddr("192.168.10.50").AsSlice()}
+	resCh <- resolvedWorkload
+
+	// Assert that async worker applies the resolved workload to cache/bpf within 1 second
+	assert.Eventually(t, func() bool {
+		wl := p.WorkloadCache.GetWorkloadByUid("uid-dns-resolve")
+		return wl != nil && len(wl.Addresses) > 0
+	}, 1*time.Second, 10*time.Millisecond, "resolved workload should be asynchronously applied")
+}

--- a/pkg/controller/workload/dns_test.go
+++ b/pkg/controller/workload/dns_test.go
@@ -366,12 +366,20 @@ func TestAsyncDNSResolution_NonBlocking(t *testing.T) {
 	p.handleServicesAndWorkloads(nil, []*workloadapi.Workload{wlNeedsDNS, wlHasIP})
 	elapsed := time.Since(start)
 
-	// Assert that handleServicesAndWorkloads returned immediately (< 200ms) without waiting for 3s DNS timeout
-	assert.True(t, elapsed < 200*time.Millisecond, "handleServicesAndWorkloads blocked for %v, expected non-blocking execution", elapsed)
+	// Assert that handleServicesAndWorkloads returned promptly relative to dnsResolveTimeout
+	assert.True(t, elapsed < dnsResolveTimeout/10, "handleServicesAndWorkloads blocked for %v, expected non-blocking execution (< %v)", elapsed, dnsResolveTimeout/10)
 
 	// Assert that wlHasIP was processed and added to cache immediately
 	processedWL := p.WorkloadCache.GetWorkloadByUid("uid-ip-2")
 	assert.NotNil(t, processedWL, "workload with IP should be processed immediately without waiting for DNS resolution")
+
+	// Clean up pending resolution channel so task worker doesn't idle until timeout
+	p.dnsMapMutex.RLock()
+	resCh, ok := p.ResolvedDomainChanMap["uid-dns-1"]
+	p.dnsMapMutex.RUnlock()
+	if ok {
+		close(resCh)
+	}
 }
 
 func TestAsyncDNSResolution_AppliedOnResolution(t *testing.T) {

--- a/pkg/controller/workload/workload_controller.go
+++ b/pkg/controller/workload/workload_controller.go
@@ -56,6 +56,7 @@ func NewController(bpfWorkload *bpfwl.BpfWorkload, enableMonitoring, enablePerfM
 	}
 	processor.DnsResolverChan = dnsResolverController.workloadsChan
 	processor.ResolvedDomainChanMap = dnsResolverController.ResolvedDomainChanMap
+	processor.dnsMapMutex = &dnsResolverController.RWMutex
 
 	// Set up callback to clean DNS cache when workload is deleted
 	processor.onWorkloadDeleted = func(workloadName string) {

--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -56,7 +56,6 @@ type dnsPendingTask struct {
 	uid      string
 	workload *workloadapi.Workload
 	resCh    chan *workloadapi.Workload
-	deadline time.Time
 }
 
 type Processor struct {
@@ -86,7 +85,6 @@ type Processor struct {
 	DnsResolverChan       chan *workloadapi.Workload
 	ResolvedDomainChanMap map[string]chan *workloadapi.Workload
 	dnsMapMutex           *sync.RWMutex
-	dnsPendingTasksChan   chan *dnsPendingTask
 	// Callback to remove workload from DNS cache when workload is deleted
 	onWorkloadDeleted func(workloadName string)
 }
@@ -94,7 +92,7 @@ type Processor struct {
 func NewProcessor(workloadMap bpf2go.KmeshCgroupSockWorkloadMaps) *Processor {
 	serviceCache := cache.NewServiceCache()
 
-	p := &Processor{
+	return &Processor{
 		hashName:              utils.NewHashName(),
 		bpf:                   bpf.NewCache(workloadMap),
 		nodeName:              os.Getenv("NODE_NAME"),
@@ -108,14 +106,7 @@ func NewProcessor(workloadMap bpf2go.KmeshCgroupSockWorkloadMaps) *Processor {
 		handlers:              map[string][]func(resp *service_discovery_v3.DeltaDiscoveryResponse) error{},
 		ResolvedDomainChanMap: make(map[string]chan *workloadapi.Workload),
 		dnsMapMutex:           &sync.RWMutex{},
-		dnsPendingTasksChan:   make(chan *dnsPendingTask, 1024),
 	}
-
-	for i := 0; i < 4; i++ {
-		go p.runDNSResultWatcher()
-	}
-
-	return p
 }
 
 func (p *Processor) WithResourceHandlers(typeUrl string, h ...func(resp *service_discovery_v3.DeltaDiscoveryResponse) error) *Processor {
@@ -1021,38 +1012,24 @@ func (p *Processor) processWorkloadDNSAsync(workload *workloadapi.Workload) {
 		uid:      uid,
 		workload: workload,
 		resCh:    ch,
-		deadline: time.Now().Add(dnsResolveTimeout),
 	}
 
-	select {
-	case p.dnsPendingTasksChan <- task:
-	default:
-		log.Warnf("dnsPendingTasksChan is full, dropping task for %s/%s/%s", workload.Namespace, workload.Name, uid)
-		p.dnsMapMutex.Lock()
-		delete(p.ResolvedDomainChanMap, uid)
-		p.dnsMapMutex.Unlock()
-	}
-}
-
-func (p *Processor) runDNSResultWatcher() {
-	for task := range p.dnsPendingTasksChan {
-		p.handlePendingDNSTask(task)
-	}
+	// Start waiting for the result immediately to avoid queue-induced timeouts.
+	go p.handlePendingDNSTask(task)
 }
 
 func (p *Processor) handlePendingDNSTask(task *dnsPendingTask) {
-	timeout := time.Until(task.deadline)
-	if timeout <= 0 {
-		p.cleanupAndTimeoutDNSTask(task)
-		return
-	}
-
-	timer := time.NewTimer(timeout)
+	timer := time.NewTimer(dnsResolveTimeout)
 	defer timer.Stop()
 
 	select {
 	case <-timer.C:
-		p.cleanupAndTimeoutDNSTask(task)
+		log.Warnf("DNS resolution timeout for workload %s/%s/%s, skip handling", task.workload.Namespace, task.workload.Name, task.uid)
+		p.dnsMapMutex.Lock()
+		if existingCh, ok := p.ResolvedDomainChanMap[task.uid]; ok && existingCh == task.resCh {
+			delete(p.ResolvedDomainChanMap, task.uid)
+		}
+		p.dnsMapMutex.Unlock()
 
 	case newWorkload, ok := <-task.resCh:
 		p.dnsMapMutex.Lock()
@@ -1078,15 +1055,6 @@ func (p *Processor) handlePendingDNSTask(task *dnsPendingTask) {
 			log.Errorf("handle workload %s failed, err: %v", newWorkload.ResourceName(), err)
 		}
 	}
-}
-
-func (p *Processor) cleanupAndTimeoutDNSTask(task *dnsPendingTask) {
-	log.Warnf("DNS resolution timeout for workload %s/%s/%s, skip handling", task.workload.Namespace, task.workload.Name, task.uid)
-	p.dnsMapMutex.Lock()
-	if existingCh, ok := p.ResolvedDomainChanMap[task.uid]; ok && existingCh == task.resCh {
-		delete(p.ResolvedDomainChanMap, task.uid)
-	}
-	p.dnsMapMutex.Unlock()
 }
 
 // After restart, we can get the removed addresses by comparing the

--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -52,6 +52,13 @@ const (
 	dnsResolveTimeout = 3 * time.Second
 )
 
+type dnsPendingTask struct {
+	uid      string
+	workload *workloadapi.Workload
+	resCh    chan *workloadapi.Workload
+	deadline time.Time
+}
+
 type Processor struct {
 	ack *service_discovery_v3.DeltaDiscoveryRequest
 	req *service_discovery_v3.DeltaDiscoveryRequest
@@ -79,6 +86,7 @@ type Processor struct {
 	DnsResolverChan       chan *workloadapi.Workload
 	ResolvedDomainChanMap map[string]chan *workloadapi.Workload
 	dnsMapMutex           *sync.RWMutex
+	dnsPendingTasksChan   chan *dnsPendingTask
 	// Callback to remove workload from DNS cache when workload is deleted
 	onWorkloadDeleted func(workloadName string)
 }
@@ -86,7 +94,7 @@ type Processor struct {
 func NewProcessor(workloadMap bpf2go.KmeshCgroupSockWorkloadMaps) *Processor {
 	serviceCache := cache.NewServiceCache()
 
-	return &Processor{
+	p := &Processor{
 		hashName:              utils.NewHashName(),
 		bpf:                   bpf.NewCache(workloadMap),
 		nodeName:              os.Getenv("NODE_NAME"),
@@ -100,7 +108,14 @@ func NewProcessor(workloadMap bpf2go.KmeshCgroupSockWorkloadMaps) *Processor {
 		handlers:              map[string][]func(resp *service_discovery_v3.DeltaDiscoveryResponse) error{},
 		ResolvedDomainChanMap: make(map[string]chan *workloadapi.Workload),
 		dnsMapMutex:           &sync.RWMutex{},
+		dnsPendingTasksChan:   make(chan *dnsPendingTask, 1024),
 	}
+
+	for i := 0; i < 4; i++ {
+		go p.runDNSResultWatcher()
+	}
+
+	return p
 }
 
 func (p *Processor) WithResourceHandlers(typeUrl string, h ...func(resp *service_discovery_v3.DeltaDiscoveryResponse) error) *Processor {
@@ -972,17 +987,14 @@ func (p *Processor) handleServicesAndWorkloads(services []*workloadapi.Service, 
 }
 
 func (p *Processor) processWorkloadDNSAsync(workload *workloadapi.Workload) {
+	if p.dnsMapMutex == nil || p.ResolvedDomainChanMap == nil {
+		log.Errorf("dnsMapMutex or ResolvedDomainChanMap is nil, skip handling workload %s/%s", workload.Namespace, workload.Name)
+		return
+	}
+
 	uid := workload.GetUid()
 
-	if p.dnsMapMutex == nil {
-		p.dnsMapMutex = &sync.RWMutex{}
-	}
-
 	p.dnsMapMutex.Lock()
-	if p.ResolvedDomainChanMap == nil {
-		p.ResolvedDomainChanMap = make(map[string]chan *workloadapi.Workload)
-	}
-
 	// Deduplication: if workload is already pending DNS resolution, skip re-enqueuing
 	if _, pending := p.ResolvedDomainChanMap[uid]; pending {
 		p.dnsMapMutex.Unlock()
@@ -1005,30 +1017,76 @@ func (p *Processor) processWorkloadDNSAsync(workload *workloadapi.Workload) {
 		return
 	}
 
-	go func(uid string, wl *workloadapi.Workload, resCh chan *workloadapi.Workload) {
-		timer := time.NewTimer(dnsResolveTimeout)
-		defer timer.Stop()
+	task := &dnsPendingTask{
+		uid:      uid,
+		workload: workload,
+		resCh:    ch,
+		deadline: time.Now().Add(dnsResolveTimeout),
+	}
 
-		select {
-		case <-timer.C:
-			log.Warnf("DNS resolution timeout for workload %s/%s/%s, skip handling", wl.Namespace, wl.Name, uid)
-			p.dnsMapMutex.Lock()
-			if existingCh, ok := p.ResolvedDomainChanMap[uid]; ok && existingCh == resCh {
-				delete(p.ResolvedDomainChanMap, uid)
-			}
-			p.dnsMapMutex.Unlock()
+	select {
+	case p.dnsPendingTasksChan <- task:
+	default:
+		log.Warnf("dnsPendingTasksChan is full, dropping task for %s/%s/%s", workload.Namespace, workload.Name, uid)
+		p.dnsMapMutex.Lock()
+		delete(p.ResolvedDomainChanMap, uid)
+		p.dnsMapMutex.Unlock()
+	}
+}
 
-		case newWorkload, ok := <-resCh:
-			if !ok || newWorkload == nil || newWorkload.GetAddresses() == nil {
-				log.Warnf("workload %s/%s resolved addresses is nil or channel closed, skip handling", wl.Namespace, wl.Name)
-				return
-			}
-			log.Infof("workload %s/%s addresses resolved: %v", newWorkload.Namespace, newWorkload.Name, newWorkload.Addresses)
-			if err := p.handleWorkload(newWorkload); err != nil {
-				log.Errorf("handle workload %s failed, err: %v", newWorkload.ResourceName(), err)
-			}
+func (p *Processor) runDNSResultWatcher() {
+	for task := range p.dnsPendingTasksChan {
+		p.handlePendingDNSTask(task)
+	}
+}
+
+func (p *Processor) handlePendingDNSTask(task *dnsPendingTask) {
+	timeout := time.Until(task.deadline)
+	if timeout <= 0 {
+		p.cleanupAndTimeoutDNSTask(task)
+		return
+	}
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		p.cleanupAndTimeoutDNSTask(task)
+
+	case newWorkload, ok := <-task.resCh:
+		p.dnsMapMutex.Lock()
+		existingCh, exists := p.ResolvedDomainChanMap[task.uid]
+		isCurrent := exists && existingCh == task.resCh
+		if isCurrent {
+			delete(p.ResolvedDomainChanMap, task.uid)
 		}
-	}(uid, workload, ch)
+		p.dnsMapMutex.Unlock()
+
+		if !isCurrent {
+			log.Debugf("stale or superseded DNS resolution for workload %s/%s/%s, skipping", task.workload.Namespace, task.workload.Name, task.uid)
+			return
+		}
+
+		if !ok || newWorkload == nil || newWorkload.GetAddresses() == nil {
+			log.Warnf("workload %s/%s resolved addresses is nil or channel closed, skip handling", task.workload.Namespace, task.workload.Name)
+			return
+		}
+
+		log.Infof("workload %s/%s addresses resolved: %v", newWorkload.Namespace, newWorkload.Name, newWorkload.Addresses)
+		if err := p.handleWorkload(newWorkload); err != nil {
+			log.Errorf("handle workload %s failed, err: %v", newWorkload.ResourceName(), err)
+		}
+	}
+}
+
+func (p *Processor) cleanupAndTimeoutDNSTask(task *dnsPendingTask) {
+	log.Warnf("DNS resolution timeout for workload %s/%s/%s, skip handling", task.workload.Namespace, task.workload.Name, task.uid)
+	p.dnsMapMutex.Lock()
+	if existingCh, ok := p.ResolvedDomainChanMap[task.uid]; ok && existingCh == task.resCh {
+		delete(p.ResolvedDomainChanMap, task.uid)
+	}
+	p.dnsMapMutex.Unlock()
 }
 
 // After restart, we can get the removed addresses by comparing the

--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -1033,17 +1033,10 @@ func (p *Processor) handlePendingDNSTask(task *dnsPendingTask) {
 
 	case newWorkload, ok := <-task.resCh:
 		p.dnsMapMutex.Lock()
-		existingCh, exists := p.ResolvedDomainChanMap[task.uid]
-		isCurrent := exists && existingCh == task.resCh
-		if isCurrent {
+		if existingCh, exists := p.ResolvedDomainChanMap[task.uid]; exists && existingCh == task.resCh {
 			delete(p.ResolvedDomainChanMap, task.uid)
 		}
 		p.dnsMapMutex.Unlock()
-
-		if !isCurrent {
-			log.Debugf("stale or superseded DNS resolution for workload %s/%s/%s, skipping", task.workload.Namespace, task.workload.Name, task.uid)
-			return
-		}
 
 		if !ok || newWorkload == nil || newWorkload.GetAddresses() == nil {
 			log.Warnf("workload %s/%s resolved addresses is nil or channel closed, skip handling", task.workload.Namespace, task.workload.Name)

--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -78,6 +78,7 @@ type Processor struct {
 
 	DnsResolverChan       chan *workloadapi.Workload
 	ResolvedDomainChanMap map[string]chan *workloadapi.Workload
+	dnsMapMutex           *sync.RWMutex
 	// Callback to remove workload from DNS cache when workload is deleted
 	onWorkloadDeleted func(workloadName string)
 }
@@ -86,17 +87,19 @@ func NewProcessor(workloadMap bpf2go.KmeshCgroupSockWorkloadMaps) *Processor {
 	serviceCache := cache.NewServiceCache()
 
 	return &Processor{
-		hashName:      utils.NewHashName(),
-		bpf:           bpf.NewCache(workloadMap),
-		nodeName:      os.Getenv("NODE_NAME"),
-		WorkloadCache: cache.NewWorkloadCache(),
-		ServiceCache:  serviceCache,
-		EndpointCache: cache.NewEndpointCache(),
-		WaypointCache: cache.NewWaypointCache(serviceCache),
-		locality:      bpf.NewLocalityCache(),
-		addressDone:   make(chan struct{}, 1),
-		authzDone:     make(chan struct{}, 1),
-		handlers:      map[string][]func(resp *service_discovery_v3.DeltaDiscoveryResponse) error{},
+		hashName:              utils.NewHashName(),
+		bpf:                   bpf.NewCache(workloadMap),
+		nodeName:              os.Getenv("NODE_NAME"),
+		WorkloadCache:         cache.NewWorkloadCache(),
+		ServiceCache:          serviceCache,
+		EndpointCache:         cache.NewEndpointCache(),
+		WaypointCache:         cache.NewWaypointCache(serviceCache),
+		locality:              bpf.NewLocalityCache(),
+		addressDone:           make(chan struct{}, 1),
+		authzDone:             make(chan struct{}, 1),
+		handlers:              map[string][]func(resp *service_discovery_v3.DeltaDiscoveryResponse) error{},
+		ResolvedDomainChanMap: make(map[string]chan *workloadapi.Workload),
+		dnsMapMutex:           &sync.RWMutex{},
 	}
 }
 
@@ -958,33 +961,74 @@ func (p *Processor) handleServicesAndWorkloads(services []*workloadapi.Service, 
 				continue
 			}
 
-			uid := workload.GetUid()
-			p.ResolvedDomainChanMap[uid] = make(chan *workloadapi.Workload)
-			p.DnsResolverChan <- workload
-			log.Infof("waiting for DNS resolution: %s/%s/%s", workload.Namespace, workload.Name, uid)
-
-			select {
-			case <-time.After(dnsResolveTimeout):
-				log.Warnf("DNS resolution timeout for workload %s/%s/%s, skip handling", workload.Namespace, workload.Name, uid)
-				if ch, ok := p.ResolvedDomainChanMap[uid]; ok {
-					close(ch)
-					delete(p.ResolvedDomainChanMap, uid)
-				}
-				continue
-			case newWorkload := <-p.ResolvedDomainChanMap[uid]:
-				if newWorkload == nil || newWorkload.GetAddresses() == nil {
-					log.Warnf("workload %s/%s resolved addresses is nil, skip handling", workload.Namespace, workload.Name)
-					continue
-				}
-				log.Infof("workload %s/%s addresses resolved: %v", newWorkload.Namespace, newWorkload.Name, newWorkload.Addresses)
-				workload = newWorkload
-			}
+			p.processWorkloadDNSAsync(workload)
+			continue
 		}
 
 		if err := p.handleWorkload(workload); err != nil {
 			log.Errorf("handle workload %s failed, err: %v", workload.ResourceName(), err)
 		}
 	}
+}
+
+func (p *Processor) processWorkloadDNSAsync(workload *workloadapi.Workload) {
+	uid := workload.GetUid()
+
+	if p.dnsMapMutex == nil {
+		p.dnsMapMutex = &sync.RWMutex{}
+	}
+
+	p.dnsMapMutex.Lock()
+	if p.ResolvedDomainChanMap == nil {
+		p.ResolvedDomainChanMap = make(map[string]chan *workloadapi.Workload)
+	}
+
+	// Deduplication: if workload is already pending DNS resolution, skip re-enqueuing
+	if _, pending := p.ResolvedDomainChanMap[uid]; pending {
+		p.dnsMapMutex.Unlock()
+		log.Debugf("workload %s/%s/%s is already pending DNS resolution, skipping duplicate queue", workload.Namespace, workload.Name, uid)
+		return
+	}
+
+	ch := make(chan *workloadapi.Workload, 1)
+	p.ResolvedDomainChanMap[uid] = ch
+	p.dnsMapMutex.Unlock()
+
+	select {
+	case p.DnsResolverChan <- workload:
+		log.Infof("enqueued workload for async DNS resolution: %s/%s/%s", workload.Namespace, workload.Name, uid)
+	default:
+		log.Warnf("DnsResolverChan is full, dropping workload DNS resolution for %s/%s/%s", workload.Namespace, workload.Name, uid)
+		p.dnsMapMutex.Lock()
+		delete(p.ResolvedDomainChanMap, uid)
+		p.dnsMapMutex.Unlock()
+		return
+	}
+
+	go func(uid string, wl *workloadapi.Workload, resCh chan *workloadapi.Workload) {
+		timer := time.NewTimer(dnsResolveTimeout)
+		defer timer.Stop()
+
+		select {
+		case <-timer.C:
+			log.Warnf("DNS resolution timeout for workload %s/%s/%s, skip handling", wl.Namespace, wl.Name, uid)
+			p.dnsMapMutex.Lock()
+			if existingCh, ok := p.ResolvedDomainChanMap[uid]; ok && existingCh == resCh {
+				delete(p.ResolvedDomainChanMap, uid)
+			}
+			p.dnsMapMutex.Unlock()
+
+		case newWorkload, ok := <-resCh:
+			if !ok || newWorkload == nil || newWorkload.GetAddresses() == nil {
+				log.Warnf("workload %s/%s resolved addresses is nil or channel closed, skip handling", wl.Namespace, wl.Name)
+				return
+			}
+			log.Infof("workload %s/%s addresses resolved: %v", newWorkload.Namespace, newWorkload.Name, newWorkload.Addresses)
+			if err := p.handleWorkload(newWorkload); err != nil {
+				log.Errorf("handle workload %s failed, err: %v", newWorkload.ResourceName(), err)
+			}
+		}
+	}(uid, workload, ch)
 }
 
 // After restart, we can get the removed addresses by comparing the


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes a major pipeline bottleneck where DNS resolution for workloads with `Addresses == nil` was performed synchronously inside `handleServicesAndWorkloads()`. 

Previously, each DNS-pending workload blocked the main xDS processing loop for up to 3 seconds (`dnsResolveTimeout`). Under heavy workload churn, this caused compounding delays, delaying xDS updates for resolved workloads behind it in the batch and risking connection drops.

This PR redesigns DNS resolution to be non-blocking:
1. `handleServicesAndWorkloads()` enqueues DNS-pending workloads asynchronously and continues batch processing immediately.
2. A background worker goroutine handles resolution and feeds resolved workloads back to `handleWorkload()`.
3. Adds deduplication to prevent duplicate enqueuing for the same workload UID while resolution is in-flight.
4. Synchronizes `ResolvedDomainChanMap` accesses between `Processor` and `dnsController` using `dnsMapMutex`.

**Special notes for your reviewer**:
- Added `TestAsyncDNSResolution_NonBlocking` and `TestAsyncDNSResolution_AppliedOnResolution` in `pkg/controller/workload/dns_test.go`.

**Does this PR introduce a user-facing change?**:
```release-note
fix: process workload DNS resolution asynchronously to prevent xDS batch delays
