### PR TITLE
fix(nets): use htons/ntohs semantics for port byte-order conversion

### DIFF
--- a/pkg/controller/ads/cache.go
+++ b/pkg/controller/ads/cache.go
@@ -163,7 +163,7 @@ func newApiSocketAddress(address *config_core_v3.Address) *core_v2.SocketAddress
 
 	return &core_v2.SocketAddress{
 		Protocol: core_v2.SocketAddress_Protocol(addr.GetProtocol()),
-		Port:     nets.ConvertPortToBigEndian(addr.GetPortValue()),
+		Port:     nets.ConvertPortToNetworkOrder(addr.GetPortValue()),
 		Ipv4:     nets.ConvertIpToUint32(addr.GetAddress()),
 	}
 }

--- a/pkg/controller/ads/cache_test.go
+++ b/pkg/controller/ads/cache_test.go
@@ -384,7 +384,7 @@ func TestNewApiSocketAddress(t *testing.T) {
 			},
 		}
 		kmeshSocketAddr := newApiSocketAddress(addr)
-		port := nets.ConvertPortToBigEndian(addr.GetSocketAddress().GetPortValue())
+		port := nets.ConvertPortToNetworkOrder(addr.GetSocketAddress().GetPortValue())
 		assert.Equal(t, port, kmeshSocketAddr.Port)
 		address := addr.GetSocketAddress().Address
 		ipv4 := nets.ConvertIpToUint32(address)

--- a/pkg/controller/workload/workload_processor.go
+++ b/pkg/controller/workload/workload_processor.go
@@ -491,7 +491,7 @@ func (p *Processor) updateWorkloadInBackendMap(workload *workloadapi.Workload) e
 
 	if waypoint := workload.GetWaypoint(); waypoint != nil && waypoint.GetAddress() != nil {
 		nets.CopyIpByteFromSlice(&bv.WaypointAddr, waypoint.GetAddress().Address)
-		bv.WaypointPort = nets.ConvertPortToBigEndian(waypoint.GetHboneMtlsPort())
+		bv.WaypointPort = nets.ConvertPortToNetworkOrder(waypoint.GetHboneMtlsPort())
 	}
 
 	for serviceName := range workload.GetServices() {
@@ -754,7 +754,7 @@ func (p *Processor) updateServiceMap(service, oldService *workloadapi.Service) e
 
 	if waypoint != nil && waypoint.GetAddress() != nil {
 		nets.CopyIpByteFromSlice(&newServiceInfo.WaypointAddr, waypoint.GetAddress().Address)
-		newServiceInfo.WaypointPort = nets.ConvertPortToBigEndian(waypoint.GetHboneMtlsPort())
+		newServiceInfo.WaypointPort = nets.ConvertPortToNetworkOrder(waypoint.GetHboneMtlsPort())
 	}
 
 	for i, port := range ports {
@@ -763,15 +763,15 @@ func (p *Processor) updateServiceMap(service, oldService *workloadapi.Service) e
 			break
 		}
 
-		newServiceInfo.ServicePort[i] = nets.ConvertPortToBigEndian(port.ServicePort)
+		newServiceInfo.ServicePort[i] = nets.ConvertPortToNetworkOrder(port.ServicePort)
 		if strings.Contains(serviceName, "waypoint") {
-			newServiceInfo.TargetPort[i] = nets.ConvertPortToBigEndian(KmeshWaypointPort)
+			newServiceInfo.TargetPort[i] = nets.ConvertPortToNetworkOrder(KmeshWaypointPort)
 		} else if port.TargetPort == 0 {
 			// NOTE: Target port could be unset in service entry, in which case it should
 			// be consistent with the Service Port.
-			newServiceInfo.TargetPort[i] = nets.ConvertPortToBigEndian(port.ServicePort)
+			newServiceInfo.TargetPort[i] = nets.ConvertPortToNetworkOrder(port.ServicePort)
 		} else {
-			newServiceInfo.TargetPort[i] = nets.ConvertPortToBigEndian(port.TargetPort)
+			newServiceInfo.TargetPort[i] = nets.ConvertPortToNetworkOrder(port.TargetPort)
 		}
 	}
 

--- a/pkg/controller/workload/workload_processor_test.go
+++ b/pkg/controller/workload/workload_processor_test.go
@@ -275,7 +275,7 @@ func checkServiceMap(t *testing.T, p *Processor, svcId uint32, fakeSvc *workload
 		assert.Equal(t, true, test.EqualIp(sv.WaypointAddr, waypointAddr))
 	}
 
-	assert.Equal(t, sv.WaypointPort, nets.ConvertPortToBigEndian(fakeSvc.Waypoint.GetHboneMtlsPort()))
+	assert.Equal(t, sv.WaypointPort, nets.ConvertPortToNetworkOrder(fakeSvc.Waypoint.GetHboneMtlsPort()))
 }
 
 func checkNotExistInEndpointMap(t *testing.T, p *Processor, fakeSvc *workloadapi.Service, backendUid []uint32) {
@@ -311,7 +311,7 @@ func checkBackendMap(t *testing.T, p *Processor, workloadID uint32, wl *workload
 	if waypointAddr != nil {
 		assert.Equal(t, true, test.EqualIp(bv.WaypointAddr, waypointAddr))
 	}
-	assert.Equal(t, bv.WaypointPort, nets.ConvertPortToBigEndian(wl.GetWaypoint().GetHboneMtlsPort()))
+	assert.Equal(t, bv.WaypointPort, nets.ConvertPortToNetworkOrder(wl.GetWaypoint().GetHboneMtlsPort()))
 }
 
 func checkFrontEndMapWithNetworkMode(t *testing.T, ip []byte, p *Processor, networkMode workloadapi.NetworkMode) (upstreamId uint32) {

--- a/pkg/nets/nets.go
+++ b/pkg/nets/nets.go
@@ -45,23 +45,38 @@ func ConvertIpToUint32(ip string) uint32 {
 	return 0
 }
 
-// ConvertPortToBigEndian convert uint32 to network order
-func ConvertPortToBigEndian(little uint32) uint32 {
-	// first convert to uint16, then convert the byte order,
-	// finally switch back to uint32
-	tmp := make([]byte, 2)
-	little16 := uint16(little)
-	binary.BigEndian.PutUint16(tmp, little16)
-	big16 := binary.LittleEndian.Uint16(tmp)
-	return uint32(big16)
+// ConvertPortToNetworkOrder converts a host order port to the network order
+// value stored in the bpf maps, i.e. htons().
+//
+// Map values are marshalled with the host's native byte order, and the datapath
+// compares them directly against ctx->user_port, which the kernel keeps in
+// network byte order. The conversion is therefore only a byte swap on a little
+// endian host and must be an identity on a big endian one, so the native order
+// has to be resolved at runtime rather than assumed.
+func ConvertPortToNetworkOrder(port uint32) uint32 {
+	return convertPortToNetworkOrder(port, binary.NativeEndian)
 }
 
-// ConvertPortToLittleEndian convert port to host order
-func ConvertPortToLittleEndian(big uint32) uint32 {
-	tmp := make([]byte, 2)
-	binary.LittleEndian.PutUint16(tmp, uint16(big))
-	little16 := binary.BigEndian.Uint16(tmp)
-	return uint32(little16)
+// ConvertPortToHostOrder converts a network order port read back from the bpf
+// maps to host order, i.e. ntohs(). It is the exact inverse of
+// ConvertPortToNetworkOrder and must be kept in sync with it.
+func ConvertPortToHostOrder(port uint32) uint32 {
+	return convertPortToHostOrder(port, binary.NativeEndian)
+}
+
+// convertPortToNetworkOrder and convertPortToHostOrder take the native byte
+// order as a parameter so that the big endian path stays reachable from tests
+// running on a little endian host.
+func convertPortToNetworkOrder(port uint32, native binary.ByteOrder) uint32 {
+	var tmp [2]byte
+	binary.BigEndian.PutUint16(tmp[:], uint16(port))
+	return uint32(native.Uint16(tmp[:]))
+}
+
+func convertPortToHostOrder(port uint32, native binary.ByteOrder) uint32 {
+	var tmp [2]byte
+	native.PutUint16(tmp[:], uint16(port))
+	return uint32(binary.BigEndian.Uint16(tmp[:]))
 }
 
 func CopyIpByteFromSlice(dst *[16]byte, src []byte) {

--- a/pkg/nets/nets_test.go
+++ b/pkg/nets/nets_test.go
@@ -17,6 +17,7 @@
 package nets
 
 import (
+	"encoding/binary"
 	"net/netip"
 	"testing"
 
@@ -119,7 +120,7 @@ func TestCompareIpByte(t *testing.T) {
 	}
 }
 
-func TestConvertPortToLittleEndian(t *testing.T) {
+func TestConvertPortToHostOrder(t *testing.T) {
 	tests := []struct {
 		input    uint32
 		expected uint32
@@ -129,11 +130,58 @@ func TestConvertPortToLittleEndian(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		input := ConvertPortToBigEndian(test.input)
-		actual := ConvertPortToLittleEndian(input)
+		input := ConvertPortToNetworkOrder(test.input)
+		actual := ConvertPortToHostOrder(input)
 		if actual != test.expected {
-			t.Errorf("ConvertPortToLittleEndian(%#x) = %#x; expected %#x", test.input, actual, test.expected)
+			t.Errorf("ConvertPortToHostOrder(%#x) = %#x; expected %#x", test.input, actual, test.expected)
 		}
+	}
+}
+
+// TestConvertPortByteOrder pins htons/ntohs semantics on both host byte orders.
+// The big endian cases are the regression guard: converting a port there must be
+// an identity, because network order and host order already agree.
+func TestConvertPortByteOrder(t *testing.T) {
+	tests := []struct {
+		name string
+		port uint32
+		// network order value as seen on a little endian host, i.e. byte swapped
+		wantOnLittleEndian uint32
+		// network order value as seen on a big endian host, i.e. unchanged
+		wantOnBigEndian uint32
+	}{
+		{"zero", 0, 0, 0},
+		{"http", 80, 0x5000, 80},
+		{"https", 443, 0xbb01, 443},
+		{"hbone", 15008, 0xa03a, 15008},
+		{"byte symmetric", 0x3c3c, 0x3c3c, 0x3c3c},
+		{"max", 65535, 65535, 65535},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantOnLittleEndian, convertPortToNetworkOrder(tt.port, binary.LittleEndian))
+			assert.Equal(t, tt.wantOnBigEndian, convertPortToNetworkOrder(tt.port, binary.BigEndian))
+
+			assert.Equal(t, tt.port, convertPortToHostOrder(tt.wantOnLittleEndian, binary.LittleEndian))
+			assert.Equal(t, tt.port, convertPortToHostOrder(tt.wantOnBigEndian, binary.BigEndian))
+		})
+	}
+}
+
+// TestConvertPortMatchesMapEncoding asserts the invariant the datapath relies on:
+// the bytes a port occupies in a bpf map, marshalled in the host's native order,
+// must spell the port in network byte order.
+func TestConvertPortMatchesMapEncoding(t *testing.T) {
+	for _, port := range []uint32{80, 443, 15008, 65535} {
+		var onWire [2]byte
+		binary.NativeEndian.PutUint16(onWire[:], uint16(ConvertPortToNetworkOrder(port)))
+
+		var want [2]byte
+		binary.BigEndian.PutUint16(want[:], uint16(port))
+
+		assert.Equal(t, want, onWire, "port %d is not in network order on the wire", port)
+		assert.Equal(t, port, ConvertPortToHostOrder(ConvertPortToNetworkOrder(port)))
 	}
 }
 

--- a/pkg/status/api.go
+++ b/pkg/status/api.go
@@ -271,7 +271,7 @@ func (wd WorkloadBpfDump) WithBackends(backends []bpfcache.BackendValue) Workloa
 			Ip:           nets.IpString(backend.Ip),
 			ServiceCount: backend.ServiceCount,
 			WaypointAddr: waypointAddr,
-			WaypointPort: nets.ConvertPortToLittleEndian(backend.WaypointPort),
+			WaypointPort: nets.ConvertPortToHostOrder(backend.WaypointPort),
 		}
 		services := make([]string, 0, len(backend.Services))
 		for _, s := range backend.Services {
@@ -321,7 +321,7 @@ func (wd WorkloadBpfDump) WithServices(services []bpfcache.ServiceValue) Workloa
 			EndpointCount: []uint32{},
 			LbPolicy:      workloadapi.LoadBalancing_Mode_name[int32(s.LbPolicy)],
 			WaypointAddr:  waypointAddr,
-			WaypointPort:  nets.ConvertPortToLittleEndian(s.WaypointPort),
+			WaypointPort:  nets.ConvertPortToHostOrder(s.WaypointPort),
 		}
 
 		for _, c := range s.EndpointCount {
@@ -332,14 +332,14 @@ func (wd WorkloadBpfDump) WithServices(services []bpfcache.ServiceValue) Workloa
 			if p == 0 {
 				continue
 			}
-			svc.ServicePort = append(svc.ServicePort, nets.ConvertPortToLittleEndian(p))
+			svc.ServicePort = append(svc.ServicePort, nets.ConvertPortToHostOrder(p))
 		}
 
 		for _, p := range s.TargetPort {
 			if p == 0 {
 				continue
 			}
-			svc.TargetPort = append(svc.TargetPort, nets.ConvertPortToLittleEndian(p))
+			svc.TargetPort = append(svc.TargetPort, nets.ConvertPortToHostOrder(p))
 		}
 
 		converted = append(converted, svc)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`ConvertPortToBigEndian` and `ConvertPortToLittleEndian` byte-swapped unconditionally instead of implementing `htons`/`ntohs`.

`binary.BigEndian` and `binary.LittleEndian` are fixed byte orders, not host-dependent ones, so the swap happened on every architecture including big-endian. Port values reach the bpf maps through `cilium/ebpf`, which marshals struct fields in the host's **native** byte order, and the datapath then reads them as network order:

- `svc_dnat()` compares `service_v->service_port[i]` directly against `ctx->user_port`, which the kernel keeps in network byte order (`bpf/kmesh/workload/include/backend.h#L35`)
- the waypoint port is logged through `bpf_ntohs()` (`backend.h#L69`, `frontend.h#L45`)

On a big-endian host network order and host order already agree, so the conversion has to be an identity there. Swapping unconditionally would write `0x5000` instead of `80` for port 80, and `svc_dnat()` would never match a service port.

This PR resolves the native byte order at runtime with `binary.NativeEndian` so both helpers implement real `htons`/`ntohs`. Both directions are changed together — fixing only one would break the write/read-back round trip and surface as wrong ports in `kmeshctl dump`.

The helpers are also renamed to `ConvertPortToNetworkOrder` / `ConvertPortToHostOrder` so the names describe the intent rather than the mechanism, updating the 11 call sites across both modes (`pkg/controller/workload/workload_processor.go` for Dual-Engine, `pkg/controller/ads/cache.go` for Kernel-Native, `pkg/status/api.go` for the read-back path).

**Behaviour is unchanged on every architecture Kmesh currently builds for.** This is a latent portability fix, not a behavioural change on x86_64/arm64.

**Which issue(s) this PR fixes**:
Fixes #1858

**Special notes for your reviewer**:

A few things worth knowing while reviewing:

- **`bits.ReverseBytes16` would not have fixed this.** It is also an unconditional swap, so it is a readability improvement that preserves the bug. `binary.NativeEndian` (Go 1.21+; `go.mod` is already on 1.24.2) is what gives the real semantics.
- **Why the extra `binary.ByteOrder` parameter on the unexported helpers.** On little-endian the old and new implementations return identical values, and CI only runs on `ubuntu-22.04` x86_64. Without injecting the byte order there is no way to exercise the big-endian path in CI at all, and the fix would be permanently untestable. `TestConvertPortByteOrder` uses this to assert that the conversion is an identity on big-endian — that test fails against the old implementation and passes against the new one, on any host.
- `pkg/auth/rbac.go#L53-L63` already detects native byte order at init with `unsafe.Pointer` for exactly this reason. That `init()` could be simplified to `binary.NativeEndian` too, but I left it out to keep this diff reviewable.
- **Open question from the issue, still open:** does Kmesh intend to support big-endian targets? `mk/bpf.vars.mk` hardcodes `EXTRA_CDEFINE ?= -D__x86_64__`, so today it looks like "no", though `bpf2go` does emit `_bpfeb.go` variants. If big-endian is explicitly out of scope, I'm happy to scope this down to just the rename and drop the `NativeEndian` change — just say the word.

Testing done:

- `./hack/run-ut.sh --docker` (in `ghcr.io/kmesh-net/kmesh-build:latest`): `pkg/nets`, `pkg/controller/ads`, `pkg/controller/workload`, `pkg/controller/workload/bpfcache`, `pkg/controller/workload/cache` all pass
- `pkg/status` shows 4 failures locally (`TestServer_dumpAdsBpfMap`, `TestServer_dumpWorkloadBpfMap`, `TestServerMetricHandler`, `TestServerMonitoringHandler`), all from `bpf Load failed: load program: argument list too long`. **These reproduce identically on unmodified `main` at c88ef300** in the same container — it is my local arm64 host kernel, not this change. Flagging so nobody chases it.
- Confirmed the new test fails against the old implementation before it passes against the new one
- `GOOS=linux GOARCH=s390x go build ./pkg/nets/` compiles
- `make copyright-check`, `gofmt -l -s`, `go vet` all clean; no codegen affected, so `make gen-check` is a no-op

I used an AI assistant to help with the investigation and to draft the code and this description. I have reviewed and verified every change myself, including running the tests above, and can explain the reasoning behind each one.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
