### PR TITLE
test: fix IPv6 cgroup sock setup

### DIFF
--- a/test/bpf_ut/bpftest/workload_test.go
+++ b/test/bpf_ut/bpftest/workload_test.go
@@ -2616,7 +2616,7 @@ func testCgroupSock(t *testing.T) {
 						})
 						startLogReader(coll)
 						//add tail call
-						registerTailCall(t, coll, "km_cgr_tailcall", 0, "cgroup_connect6_tail")
+						registerTailCall(t, coll, "km_cgr_tail6", constants.TailCallConnect6Index, "cgroup_connect6_tail")
 						// record_kmesh_managed_netns_cookie
 						enableAddr := "[" + constants.ControlCommandIp6 + "]" + ":" + strconv.Itoa(int(constants.OperEnableControl))
 						net.DialTimeout("tcp6", enableAddr, 2*time.Second)
@@ -2678,7 +2678,7 @@ func testCgroupSock(t *testing.T) {
 						})
 						startLogReader(coll)
 						//add tail call
-						registerTailCall(t, coll, "km_cgr_tailcall", 0, "cgroup_connect6_tail")
+						registerTailCall(t, coll, "km_cgr_tail6", constants.TailCallConnect6Index, "cgroup_connect6_tail")
 						// record_kmesh_managed_netns_cookie
 						localIP := get_local_ipv6(t)
 						clientPort := 12345
@@ -2804,7 +2804,7 @@ func testCgroupSock(t *testing.T) {
 						})
 						startLogReader(coll)
 						//add tail call
-						registerTailCall(t, coll, "km_cgr_tailcall", 0, "cgroup_connect6_tail")
+						registerTailCall(t, coll, "km_cgr_tail6", constants.TailCallConnect6Index, "cgroup_connect6_tail")
 						// record_kmesh_managed_netns_cookie
 						localIP := get_local_ipv6(t)
 						clientPort := 12345
@@ -2943,7 +2943,7 @@ func testCgroupSock(t *testing.T) {
 						})
 						startLogReader(coll)
 						//add tail call
-						registerTailCall(t, coll, "km_cgr_tailcall", 0, "cgroup_connect6_tail")
+						registerTailCall(t, coll, "km_cgr_tail6", constants.TailCallConnect6Index, "cgroup_connect6_tail")
 						// record_kmesh_managed_netns_cookie
 						localIP := get_local_ipv6(t)
 						clientPort := 12345
@@ -3075,7 +3075,7 @@ func testCgroupSock(t *testing.T) {
 						})
 						startLogReader(coll)
 						//add tail call
-						registerTailCall(t, coll, "km_cgr_tailcall", 0, "cgroup_connect6_tail")
+						registerTailCall(t, coll, "km_cgr_tail6", constants.TailCallConnect6Index, "cgroup_connect6_tail")
 						// record_kmesh_managed_netns_cookie
 						localIP := get_local_ipv6(t)
 						clientPort := 12345
@@ -3285,7 +3285,7 @@ func testCgroupSock(t *testing.T) {
 						mount_cgroup2(t, cgroupPath)
 						defer syscall.Unmount(cgroupPath, 0)
 						//load the eBPF program
-						coll, lk := load_bpf_prog_to_cgroup(t, objFilePath, "cgroup_connect4_prog", cgroupPath)
+						coll, lk := load_bpf_prog_to_cgroup(t, objFilePath, "cgroup_connect6_prog", cgroupPath)
 						defer coll.Close()
 						defer lk.Close()
 						// Set the BPF configuration
@@ -3295,7 +3295,7 @@ func testCgroupSock(t *testing.T) {
 						})
 						startLogReader(coll)
 						//add tail call
-						registerTailCall(t, coll, "km_cgr_tailcall", 0, "cgroup_connect6_tail")
+						registerTailCall(t, coll, "km_cgr_tail6", constants.TailCallConnect6Index, "cgroup_connect6_tail")
 						// record_kmesh_managed_netns_cookie
 						localIP := get_local_ipv6(t)
 						clientPort := 12345
@@ -3505,7 +3505,7 @@ func testCgroupSock(t *testing.T) {
 						mount_cgroup2(t, cgroupPath)
 						defer syscall.Unmount(cgroupPath, 0)
 						//load the eBPF program
-						coll, lk := load_bpf_prog_to_cgroup(t, objFilePath, "cgroup_connect4_prog", cgroupPath)
+						coll, lk := load_bpf_prog_to_cgroup(t, objFilePath, "cgroup_connect6_prog", cgroupPath)
 						defer coll.Close()
 						defer lk.Close()
 						// Set the BPF configuration
@@ -3515,7 +3515,7 @@ func testCgroupSock(t *testing.T) {
 						})
 						startLogReader(coll)
 						//add tail call
-						registerTailCall(t, coll, "km_cgr_tailcall", 0, "cgroup_connect6_tail")
+						registerTailCall(t, coll, "km_cgr_tail6", constants.TailCallConnect6Index, "cgroup_connect6_tail")
 						// record_kmesh_managed_netns_cookie
 						localIP := get_local_ipv6(t)
 						clientPort := 12345


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes the IPv6 cgroup-sock BPF test setup. The tests were still registering `cgroup_connect6_tail` in the IPv4 map, and two IPv6 cases attached the connect4 program.

**Which issue(s) this PR fixes**:

Related to #1808

**Special notes for your reviewer**:

The privileged eBPF tests could not be run locally. Formatting and source checks pass; runtime coverage is left to CI.

AI tools assisted with the investigation. I reviewed and verified the final change.

**Does this PR introduce a user-facing change?**:

```release-note
NONE