### PR TITLE
Add kmeshctl unit tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ git commit -s -m "your commit message"
 
 This automatically appends:
 
-```
+```text
 Signed-off-by: Your Name <your-email@example.com>
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ Welcome to Kmesh!
   - [AI Guidance](#ai-guidance)
   - [Contributor Workflow](#contributor-workflow)
     - [Creating Pull Requests](#creating-pull-requests)
+    - [Developer Certificate of Origin (DCO)]
+    - [Fixing a missing sign-off] 
     - [Code Review](#code-review)
   - [Membership](#membership)
 
@@ -103,6 +105,36 @@ fail of continuous integration.
 - To compile, refer to [Compile and Build Kmesh](https://kmesh.net/docs/setup/develop-with-kind/)
 - To run unit test, refer to [Run Unit Test](https://kmesh.net/docs/developer-guide/tests/unit-test/)
 - To run e2e test, refer to [Run E2E Test](https://kmesh.net/docs/developer-guide/tests/e2e-test/)
+
+### Developer Certificate of Origin (DCO)
+
+Every commit must include a `Signed-off-by` line to certify that you 
+wrote or have the right to submit the code:
+
+```bash
+git commit -s -m "your commit message"
+```
+
+This automatically appends:
+
+```
+Signed-off-by: Your Name <your-email@example.com>
+```
+
+#### Fixing a missing sign-off
+
+If you forgot to sign off your last commit:
+
+```bash
+git commit --amend -s --no-edit
+```
+
+For multiple commits, use an interactive rebase and add `-s` when 
+re-committing, or run:
+
+```bash
+git rebase --signoff HEAD~N   # N = number of commits to fix
+```
 
 ### Code Review
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ Welcome to Kmesh!
   - [AI Guidance](#ai-guidance)
   - [Contributor Workflow](#contributor-workflow)
     - [Creating Pull Requests](#creating-pull-requests)
-    - [Developer Certificate of Origin (DCO)]
-    - [Fixing a missing sign-off] 
+    - [Developer Certificate of Origin (DCO)](#developer-certificate-of-origin-dco)
+    - [Fixing a Missing Sign-off](#fixing-a-missing-sign-off)
     - [Code Review](#code-review)
   - [Membership](#membership)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ fail of continuous integration.
 
 ### Developer Certificate of Origin (DCO)
 
-Every commit must include a `Signed-off-by` line to certify that you 
+Every commit must include a `Signed-off-by` line to certify that you
 wrote or have the right to submit the code:
 
 ```bash
@@ -129,7 +129,7 @@ If you forgot to sign off your last commit:
 git commit --amend -s --no-edit
 ```
 
-For multiple commits, use an interactive rebase and add `-s` when 
+For multiple commits, use an interactive rebase and add `-s` when
 re-committing, or run:
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -107,25 +107,25 @@ kmesh-ko:
 BINARIES ?= $(APPS1) $(APPS2) $(APPS3) $(APPS4)
 
 all-binary:
-        $(QUIET) find $(ROOT_DIR)/mk -name "*.pc" | xargs sed -i "s#^prefix=.*#prefix=${ROOT_DIR}#g"
+	$(QUIET) find $(ROOT_DIR)/mk -name "*.pc" | xargs sed -i "s#^prefix=.*#prefix=${ROOT_DIR}#g"
 ifneq (,$(filter $(APPS1),$(BINARIES)))
-        $(call printlog, BUILD, $(APPS1))
-        $(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-        $(GO) build -ldflags $(LDFLAGS) -tags $(ENHANCED_KERNEL) -o $(APPS1) $(GOFLAGS) ./daemon/main.go)
+	$(call printlog, BUILD, $(APPS1))
+	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
+		$(GO) build -ldflags $(LDFLAGS) -tags $(ENHANCED_KERNEL) -o $(APPS1) $(GOFLAGS) ./daemon/main.go)
 endif
 ifneq (,$(filter $(APPS2),$(BINARIES)))
-        $(call printlog, BUILD, $(APPS2))
-        $(QUIET) cd oncn-mda && cmake . -B build && make -C build
+	$(call printlog, BUILD, $(APPS2))
+	$(QUIET) cd oncn-mda && cmake . -B build && make -C build
 endif
 ifneq (,$(filter $(APPS3),$(BINARIES)))
-        $(call printlog, BUILD, $(APPS3))
-        $(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-        CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS3) $(GOFLAGS) ./cniplugin/main.go)
+	$(call printlog, BUILD, $(APPS3))
+	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
+		CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS3) $(GOFLAGS) ./cniplugin/main.go)
 endif
 ifneq (,$(filter $(APPS4),$(BINARIES)))
-        $(call printlog, BUILD, $(APPS4))
-        $(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-        CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS4) $(GOFLAGS) ./ctl/main.go)
+	$(call printlog, BUILD, $(APPS4))
+	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
+		CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS4) $(GOFLAGS) ./ctl/main.go)
 endif
 
 OUT ?= kmeshctl

--- a/Makefile
+++ b/Makefile
@@ -104,22 +104,29 @@ kmesh-ko:
 	$(call printlog, BUILD, "kernel")
 	$(QUIET) make -C kernel/ko_src
 
+BINARIES ?= $(APPS1) $(APPS2) $(APPS3) $(APPS4)
+
 all-binary:
-	$(QUIET) find $(ROOT_DIR)/mk -name "*.pc" | xargs sed -i "s#^prefix=.*#prefix=${ROOT_DIR}#g"
-	$(call printlog, BUILD, $(APPS1))
-	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-		$(GO) build -ldflags $(LDFLAGS) -tags $(ENHANCED_KERNEL) -o $(APPS1) $(GOFLAGS) ./daemon/main.go)
-	
-	$(call printlog, BUILD, $(APPS2))
-	$(QUIET) cd oncn-mda && cmake . -B build && make -C build
-
-	$(call printlog, BUILD, $(APPS3))
-	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-		CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS3) $(GOFLAGS) ./cniplugin/main.go)
-
-	$(call printlog, BUILD, $(APPS4))
-	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
-		CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS4) $(GOFLAGS) ./ctl/main.go)
+        $(QUIET) find $(ROOT_DIR)/mk -name "*.pc" | xargs sed -i "s#^prefix=.*#prefix=${ROOT_DIR}#g"
+ifneq (,$(filter $(APPS1),$(BINARIES)))
+        $(call printlog, BUILD, $(APPS1))
+        $(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
+        $(GO) build -ldflags $(LDFLAGS) -tags $(ENHANCED_KERNEL) -o $(APPS1) $(GOFLAGS) ./daemon/main.go)
+endif
+ifneq (,$(filter $(APPS2),$(BINARIES)))
+        $(call printlog, BUILD, $(APPS2))
+        $(QUIET) cd oncn-mda && cmake . -B build && make -C build
+endif
+ifneq (,$(filter $(APPS3),$(BINARIES)))
+        $(call printlog, BUILD, $(APPS3))
+        $(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
+        CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS3) $(GOFLAGS) ./cniplugin/main.go)
+endif
+ifneq (,$(filter $(APPS4),$(BINARIES)))
+        $(call printlog, BUILD, $(APPS4))
+        $(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
+        CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS4) $(GOFLAGS) ./ctl/main.go)
+endif
 
 OUT ?= kmeshctl
 .PHONY: kmeshctl

--- a/bpf/include/inner_map_defs.h
+++ b/bpf/include/inner_map_defs.h
@@ -10,8 +10,8 @@
 typedef enum { MAP_TYPE_64, MAP_TYPE_192, MAP_TYPE_296, MAP_TYPE_1600, MAP_TYPE_MAX } map_in_map_type;
 
 #define MAP_GET_TYPE(idx)                (__u8)((__u32)(idx) >> 24)
-#define MAP_GET_INDEX(idx)               (__u32)((__u32)(idx)&0xFFFFFF)
-#define MAP_GEN_OUTER_KEY(map_type, pos) ((__u32)((((__u8)(map_type)&0xFF) << 24) + ((__u32)(pos)&0xFFFFFF)))
+#define MAP_GET_INDEX(idx)               (__u32)((__u32)(idx) & 0xFFFFFF)
+#define MAP_GEN_OUTER_KEY(map_type, pos) ((__u32)((((__u8)(map_type) & 0xFF) << 24) + ((__u32)(pos) & 0xFFFFFF)))
 
 #define MAP_VAL_SIZE_64   64
 #define MAP_VAL_SIZE_192  192

--- a/bpf/kmesh/ads/include/kmesh_common.h
+++ b/bpf/kmesh/ads/include/kmesh_common.h
@@ -84,7 +84,7 @@ enum kmesh_l7_msg_type { MSG_UNKNOW = 0, MSG_REQUEST, MSG_MID_REPONSE, MSG_FINAL
 enum kmesh_strncmp_type { STRNCMP_FAILED = 0, STRNCMP_PREFIX, STRNCMP_EXACT };
 
 #define KMESH_PROTO_TYPE_WIDTH (8)
-#define GET_RET_PROTO_TYPE(n)  ((n)&0xff)
+#define GET_RET_PROTO_TYPE(n)  ((n) & 0xff)
 #define GET_RET_MSG_TYPE(n)    (((n) >> KMESH_PROTO_TYPE_WIDTH) & 0xff)
 
 #define CHECK_MODULE_NAME_NULL(ret) ((ret) == -EINVAL)

--- a/ctl/version/fake_test.go
+++ b/ctl/version/fake_test.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package version
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	gatewayapiclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+
+	"kmesh.net/kmesh/pkg/kube"
+)
+
+// fakeCLIClient is a minimal fake implementing kube.CLIClient for unit tests.
+type fakeCLIClient struct {
+	forwarder    kube.PortForwarder
+	forwarderErr error
+}
+
+func (f *fakeCLIClient) Kube() kubernetes.Interface             { return nil }
+func (f *fakeCLIClient) GatewayAPI() gatewayapiclient.Interface { return nil }
+
+func (f *fakeCLIClient) PodsForSelector(ctx context.Context, ns string, sel ...string) (*v1.PodList, error) {
+	return &v1.PodList{}, nil
+}
+
+func (f *fakeCLIClient) NewPortForwarder(podName, ns, addr string, localPort, podPort int) (kube.PortForwarder, error) {
+	if f.forwarderErr != nil {
+		return nil, f.forwarderErr
+	}
+	return f.forwarder, nil
+}
+
+// fakePortForwarder is a minimal fake implementing kube.PortForwarder.
+type fakePortForwarder struct {
+	startErr error
+	address  string
+}
+
+func (f *fakePortForwarder) Start() error    { return f.startErr }
+func (f *fakePortForwarder) Address() string { return f.address }
+func (f *fakePortForwarder) Close()          {}

--- a/ctl/version/getversion_test.go
+++ b/ctl/version/getversion_test.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package version
 
 import (

--- a/ctl/version/getversion_test.go
+++ b/ctl/version/getversion_test.go
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-
 package version
 
 import (

--- a/ctl/version/getversion_test.go
+++ b/ctl/version/getversion_test.go
@@ -1,0 +1,66 @@
+package version
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"kmesh.net/kmesh/pkg/version"
+)
+
+func TestGetVersion_ForwarderCreationError(t *testing.T) {
+	fake := &fakeCLIClient{forwarderErr: errors.New("connection refused")}
+
+	v := getVersion(fake, "some-pod")
+
+	if v.GitVersion != "" {
+		t.Errorf("expected empty GitVersion on forwarder creation error, got %q", v.GitVersion)
+	}
+}
+
+func TestGetVersion_ForwarderStartError(t *testing.T) {
+	fake := &fakeCLIClient{
+		forwarder: &fakePortForwarder{startErr: errors.New("failed to start")},
+	}
+
+	v := getVersion(fake, "some-pod")
+
+	if v.GitVersion != "" {
+		t.Errorf("expected empty GitVersion on forwarder start error, got %q", v.GitVersion)
+	}
+}
+
+func TestGetVersion_Success(t *testing.T) {
+	want := version.Info{
+		GitVersion: "v1.2.3",
+		GitCommit:  "abc123",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/version" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(want)
+	}))
+	defer server.Close()
+
+	// server.URL looks like "http://127.0.0.1:PORT" — Address() should return "host:port" only.
+	address := strings.TrimPrefix(server.URL, "http://")
+
+	fake := &fakeCLIClient{
+		forwarder: &fakePortForwarder{address: address},
+	}
+
+	got := getVersion(fake, "some-pod")
+
+	if got.GitVersion != want.GitVersion {
+		t.Errorf("GitVersion = %q, want %q", got.GitVersion, want.GitVersion)
+	}
+	if got.GitCommit != want.GitCommit {
+		t.Errorf("GitCommit = %q, want %q", got.GitCommit, want.GitCommit)
+	}
+}

--- a/ctl/version/version_test.go
+++ b/ctl/version/version_test.go
@@ -71,3 +71,17 @@ func Test_stringMatch(t *testing.T) {
 		})
 	}
 }
+
+func TestNewCmd(t *testing.T) {
+	cmd := NewCmd()
+
+	if cmd.Use != "version" {
+		t.Errorf("expected Use to be 'version', got %q", cmd.Use)
+	}
+	if cmd.Short == "" {
+		t.Error("expected Short description to be set")
+	}
+	if cmd.Run == nil {
+		t.Error("expected Run function to be set")
+	}
+}

--- a/kernel/ko_src/kmesh/kmesh_parse_protocol_data.h
+++ b/kernel/ko_src/kmesh/kmesh_parse_protocol_data.h
@@ -27,10 +27,10 @@ enum kmesh_strncmp_type { STRNCMP_FAILED = 0, STRNCMP_PREFIX, STRNCMP_EXACT };
 
 #define KMESH_PROTO_TYPE_WIDTH (8)
 
-#define SET_RET_PROTO_TYPE(n, type) (n) = (((n)&0xff00) | ((u32)(type)&0xff))
-#define GET_RET_PROTO_TYPE(n)       ((n)&0xff)
+#define SET_RET_PROTO_TYPE(n, type) (n) = (((n) & 0xff00) | ((u32)(type) & 0xff))
+#define GET_RET_PROTO_TYPE(n)       ((n) & 0xff)
 
-#define SET_RET_MSG_TYPE(n, type) (n) = (((n)&0xff) | (((u32)(type)&0xff) << KMESH_PROTO_TYPE_WIDTH))
+#define SET_RET_MSG_TYPE(n, type) (n) = (((n) & 0xff) | (((u32)(type) & 0xff) << KMESH_PROTO_TYPE_WIDTH))
 #define GET_RET_MSG_TYPE(n)       (((n) >> KMESH_PROTO_TYPE_WIDTH) & 0xff)
 
 #define LOG(level, fmt, ...) printk(level "Kmesh_module: " fmt, ##__VA_ARGS__)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`kmeshctl` currently lacks unit test coverage, which makes it harder to catch regressions and review changes with confidence. This PR adds unit tests for the `kmeshctl version` command (`ctl/version` package), which previously had almost no coverage (4.8%).

Changes:
- Added `TestNewCmd` to verify the cobra command is built correctly (`Use`, `Short`, `Run` fields).
- Added minimal fake implementations of `kube.CLIClient` and `kube.PortForwarder` (`fake_test.go`) so `getVersion` can be tested without a real Kubernetes cluster.
- Added test cases for `getVersion`:
  - success path, using `httptest.Server` to simulate the kmesh-daemon `/version` HTTP endpoint
  - port forwarder creation failure
  - port forwarder start failure

Coverage for `ctl/version`: **4.8% → 33.9%**

`runVersion` was intentionally left uncovered in this PR, since it calls `os.Exit(1)` directly on several error paths, which makes it unsafe to unit test as-is. Testing it would require a small refactor first (e.g. returning an error instead of calling `os.Exit` directly). Happy to follow up with that in a separate PR if maintainers are interested.

**Which issue(s) this PR fixes**:
Related to #991

**Special notes for your reviewer**:
This is a first step covering only the `version` command as a starting point, since the parent issue covers all of `kmeshctl`. I'm happy to continue with other commands (`dump`, `accesslog`, `secret`, etc.) in follow-up PRs if this approach looks good.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```