### PR TITLE
Adding kmeshctl unit tests

### DIFF
--- a/ctl/version/fake_test.go
+++ b/ctl/version/fake_test.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package version
+
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	gatewayapiclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
+
+	"kmesh.net/kmesh/pkg/kube"
+)
+
+// fakeCLIClient is a minimal fake implementing kube.CLIClient for unit tests.
+type fakeCLIClient struct {
+	forwarder    kube.PortForwarder
+	forwarderErr error
+}
+
+func (f *fakeCLIClient) Kube() kubernetes.Interface             { return nil }
+func (f *fakeCLIClient) GatewayAPI() gatewayapiclient.Interface { return nil }
+
+func (f *fakeCLIClient) PodsForSelector(ctx context.Context, ns string, sel ...string) (*v1.PodList, error) {
+	return &v1.PodList{}, nil
+}
+
+func (f *fakeCLIClient) NewPortForwarder(podName, ns, addr string, localPort, podPort int) (kube.PortForwarder, error) {
+	if f.forwarderErr != nil {
+		return nil, f.forwarderErr
+	}
+	return f.forwarder, nil
+}
+
+// fakePortForwarder is a minimal fake implementing kube.PortForwarder.
+type fakePortForwarder struct {
+	startErr error
+	address  string
+}
+
+func (f *fakePortForwarder) Start() error    { return f.startErr }
+func (f *fakePortForwarder) Address() string { return f.address }
+func (f *fakePortForwarder) Close()          {}

--- a/ctl/version/getversion_test.go
+++ b/ctl/version/getversion_test.go
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package version
 
 import (

--- a/ctl/version/getversion_test.go
+++ b/ctl/version/getversion_test.go
@@ -1,3 +1,20 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 package version
 
 import (

--- a/ctl/version/getversion_test.go
+++ b/ctl/version/getversion_test.go
@@ -1,0 +1,66 @@
+package version
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"kmesh.net/kmesh/pkg/version"
+)
+
+func TestGetVersion_ForwarderCreationError(t *testing.T) {
+	fake := &fakeCLIClient{forwarderErr: errors.New("connection refused")}
+
+	v := getVersion(fake, "some-pod")
+
+	if v.GitVersion != "" {
+		t.Errorf("expected empty GitVersion on forwarder creation error, got %q", v.GitVersion)
+	}
+}
+
+func TestGetVersion_ForwarderStartError(t *testing.T) {
+	fake := &fakeCLIClient{
+		forwarder: &fakePortForwarder{startErr: errors.New("failed to start")},
+	}
+
+	v := getVersion(fake, "some-pod")
+
+	if v.GitVersion != "" {
+		t.Errorf("expected empty GitVersion on forwarder start error, got %q", v.GitVersion)
+	}
+}
+
+func TestGetVersion_Success(t *testing.T) {
+	want := version.Info{
+		GitVersion: "v1.2.3",
+		GitCommit:  "abc123",
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/version" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(want)
+	}))
+	defer server.Close()
+
+	// server.URL looks like "http://127.0.0.1:PORT" — Address() should return "host:port" only.
+	address := strings.TrimPrefix(server.URL, "http://")
+
+	fake := &fakeCLIClient{
+		forwarder: &fakePortForwarder{address: address},
+	}
+
+	got := getVersion(fake, "some-pod")
+
+	if got.GitVersion != want.GitVersion {
+		t.Errorf("GitVersion = %q, want %q", got.GitVersion, want.GitVersion)
+	}
+	if got.GitCommit != want.GitCommit {
+		t.Errorf("GitCommit = %q, want %q", got.GitCommit, want.GitCommit)
+	}
+}

--- a/ctl/version/version_test.go
+++ b/ctl/version/version_test.go
@@ -71,3 +71,17 @@ func Test_stringMatch(t *testing.T) {
 		})
 	}
 }
+
+func TestNewCmd(t *testing.T) {
+	cmd := NewCmd()
+
+	if cmd.Use != "version" {
+		t.Errorf("expected Use to be 'version', got %q", cmd.Use)
+	}
+	if cmd.Short == "" {
+		t.Error("expected Short description to be set")
+	}
+	if cmd.Run == nil {
+		t.Error("expected Run function to be set")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`kmeshctl` currently lacks unit test coverage, which makes it harder to catch regressions and review changes with confidence. This PR adds unit tests for the `kmeshctl version` command (`ctl/version` package), which previously had almost no coverage (4.8%).

Changes:
- Added `TestNewCmd` to verify the cobra command is built correctly (`Use`, `Short`, `Run` fields).
- Added minimal fake implementations of `kube.CLIClient` and `kube.PortForwarder` (`fake_test.go`) so `getVersion` can be tested without a real Kubernetes cluster.
- Added test cases for `getVersion`:
  - success path, using `httptest.Server` to simulate the kmesh-daemon `/version` HTTP endpoint
  - port forwarder creation failure
  - port forwarder start failure

Coverage for `ctl/version`: **4.8% → 33.9%**

`runVersion` was intentionally left uncovered in this PR, since it calls `os.Exit(1)` directly on several error paths, which makes it unsafe to unit test as-is. Testing it would require a small refactor first (e.g. returning an error instead of calling `os.Exit` directly). Happy to follow up with that in a separate PR if maintainers are interested.

**Which issue(s) this PR fixes**:
Fixes : #991

**Special notes for your reviewer**:
This is a first step covering only the `version` command as a starting point, since the parent issue covers all of `kmeshctl`. I'm happy to continue with other commands (`dump`, `accesslog`, `secret`, etc.) in follow-up PRs if this approach looks good.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```