### PR TITLE
feat: support selective binary build via BINARIES variable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ git commit -s -m "your commit message"
 
 This automatically appends:
 
-```
+```text
 Signed-off-by: Your Name <your-email@example.com>
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ Welcome to Kmesh!
   - [AI Guidance](#ai-guidance)
   - [Contributor Workflow](#contributor-workflow)
     - [Creating Pull Requests](#creating-pull-requests)
+    - [Developer Certificate of Origin (DCO)]
+    - [Fixing a missing sign-off] 
     - [Code Review](#code-review)
   - [Membership](#membership)
 
@@ -103,6 +105,36 @@ fail of continuous integration.
 - To compile, refer to [Compile and Build Kmesh](https://kmesh.net/docs/setup/develop-with-kind/)
 - To run unit test, refer to [Run Unit Test](https://kmesh.net/docs/developer-guide/tests/unit-test/)
 - To run e2e test, refer to [Run E2E Test](https://kmesh.net/docs/developer-guide/tests/e2e-test/)
+
+### Developer Certificate of Origin (DCO)
+
+Every commit must include a `Signed-off-by` line to certify that you 
+wrote or have the right to submit the code:
+
+```bash
+git commit -s -m "your commit message"
+```
+
+This automatically appends:
+
+```
+Signed-off-by: Your Name <your-email@example.com>
+```
+
+#### Fixing a missing sign-off
+
+If you forgot to sign off your last commit:
+
+```bash
+git commit --amend -s --no-edit
+```
+
+For multiple commits, use an interactive rebase and add `-s` when 
+re-committing, or run:
+
+```bash
+git rebase --signoff HEAD~N   # N = number of commits to fix
+```
 
 ### Code Review
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ Welcome to Kmesh!
   - [AI Guidance](#ai-guidance)
   - [Contributor Workflow](#contributor-workflow)
     - [Creating Pull Requests](#creating-pull-requests)
-    - [Developer Certificate of Origin (DCO)]
-    - [Fixing a missing sign-off] 
+    - [Developer Certificate of Origin (DCO)](#developer-certificate-of-origin-dco)
+    - [Fixing a Missing Sign-off](#fixing-a-missing-sign-off)
     - [Code Review](#code-review)
   - [Membership](#membership)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ fail of continuous integration.
 
 ### Developer Certificate of Origin (DCO)
 
-Every commit must include a `Signed-off-by` line to certify that you 
+Every commit must include a `Signed-off-by` line to certify that you
 wrote or have the right to submit the code:
 
 ```bash
@@ -129,7 +129,7 @@ If you forgot to sign off your last commit:
 git commit --amend -s --no-edit
 ```
 
-For multiple commits, use an interactive rebase and add `-s` when 
+For multiple commits, use an interactive rebase and add `-s` when
 re-committing, or run:
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,8 @@ TMP_FILES := config/kmesh_marcos_def.h \
 	mk/bpf.pc \
 	bpf/include/bpf_helper_defs_ext.h \
 
+ALL_BINARIES := $(APPS1) $(APPS2) $(APPS3) $(APPS4)
+BINARIES ?= $(ALL_BINARIES)
 .PHONY: all kmesh-bpf kmesh-ko all-binary
 all: kmesh-bpf kmesh-ko all-binary
 
@@ -106,20 +108,25 @@ kmesh-ko:
 
 all-binary:
 	$(QUIET) find $(ROOT_DIR)/mk -name "*.pc" | xargs sed -i "s#^prefix=.*#prefix=${ROOT_DIR}#g"
+ifneq (,$(filter $(APPS1),$(BINARIES)))
 	$(call printlog, BUILD, $(APPS1))
 	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
 		$(GO) build -ldflags $(LDFLAGS) -tags $(ENHANCED_KERNEL) -o $(APPS1) $(GOFLAGS) ./daemon/main.go)
-	
+endif
+ifneq (,$(filter $(APPS2),$(BINARIES)))
 	$(call printlog, BUILD, $(APPS2))
 	$(QUIET) cd oncn-mda && cmake . -B build && make -C build
-
+endif
+ifneq (,$(filter $(APPS3),$(BINARIES)))
 	$(call printlog, BUILD, $(APPS3))
 	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
 		CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS3) $(GOFLAGS) ./cniplugin/main.go)
-
+endif
+ifneq (,$(filter $(APPS4),$(BINARIES)))
 	$(call printlog, BUILD, $(APPS4))
 	$(QUIET) (export PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(ROOT_DIR)mk; \
 		CGO_ENABLED=0 $(GO) build -ldflags $(GOLDFLAGS) -o $(APPS4) $(GOFLAGS) ./ctl/main.go)
+endif
 
 OUT ?= kmeshctl
 .PHONY: kmeshctl


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Kmesh currently builds all 4 binaries (`kmesh-daemon`, `mdacore`, `kmesh-cni`,
`kmeshctl`) every time `make build` / `make all-binary` is run. This slows
down local development when a contributor only needs to work on one
component.

This PR introduces a `BINARIES` make variable that allows selectively
building only the desired binaries, e.g.:

    BINARIES=kmeshctl make build

When `BINARIES` is not set, the behavior is unchanged and all binaries are
built as before, so this is fully backward compatible.

**Which issue(s) this PR fixes**:
Fixes #892

**Special notes for your reviewer**:
- The `all-binary` target now wraps each binary's build step in a
  `ifneq (,$(filter <binary>,$(BINARIES)))` / `endif` block.
- Added `ALL_BINARIES` (list of all 4 binaries) and `BINARIES ?= $(ALL_BINARIES)`
  as the default.
- Tested locally with:
  - `make all-binary` (default) → builds all 4 binaries, unchanged behavior.
  - `BINARIES=kmeshctl make all-binary` → builds only `kmeshctl`.
  - `BINARIES="kmesh-daemon kmeshctl" make all-binary` → builds both, skips
    the other two.

**Does this PR introduce a user-facing change?**:
Yes, a new optional `BINARIES` variable for `make build`/`make all-binary`.

```release-note
Added a `BINARIES` variable to `make build`/`make all-binary` to allow
selectively building specific binaries, e.g. `BINARIES=kmeshctl make build`.
Defaults to building all binaries when unset.
```