### PR TITLE
fix(ctl): support custom Kmesh namespace

### DIFF
--- a/ctl/common/common.go
+++ b/ctl/common/common.go
@@ -24,6 +24,7 @@ import (
 	logcmd "kmesh.net/kmesh/ctl/log"
 	"kmesh.net/kmesh/ctl/monitoring"
 	"kmesh.net/kmesh/ctl/secret"
+	"kmesh.net/kmesh/ctl/utils"
 	"kmesh.net/kmesh/ctl/version"
 	"kmesh.net/kmesh/ctl/waypoint"
 )
@@ -37,6 +38,7 @@ func GetRootCommand() *cobra.Command {
 			DisableDefaultCmd: true,
 		},
 	}
+	rootCmd.PersistentFlags().StringVar(&utils.KmeshNamespace, "kmesh-namespace", utils.KmeshNamespace, "Namespace where Kmesh is installed")
 
 	rootCmd.AddCommand(logcmd.NewCmd())
 	rootCmd.AddCommand(dump.NewCmd())

--- a/ctl/common/common_test.go
+++ b/ctl/common/common_test.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"testing"
+
+	"kmesh.net/kmesh/ctl/utils"
+)
+
+func TestKmeshNamespaceFlag(t *testing.T) {
+	oldNamespace := utils.KmeshNamespace
+	t.Cleanup(func() {
+		utils.KmeshNamespace = oldNamespace
+	})
+
+	cmd := GetRootCommand()
+	if err := cmd.PersistentFlags().Set("kmesh-namespace", "kmesh-test"); err != nil {
+		t.Fatal(err)
+	}
+	if utils.KmeshNamespace != "kmesh-test" {
+		t.Errorf("KmeshNamespace = %q, want %q", utils.KmeshNamespace, "kmesh-test")
+	}
+}

--- a/ctl/utils/utils.go
+++ b/ctl/utils/utils.go
@@ -23,13 +23,14 @@ import (
 )
 
 const (
-	KmeshNamespace = "kmesh-system"
 	KmeshLabel     = "app=kmesh"
 	KmeshAdminPort = 15200
 )
 
+var KmeshNamespace = "kmesh-system"
+
 func CreateKubeClient() (kube.CLIClient, error) {
-	cli, err := kube.NewCLIClient()
+	cli, err := kube.NewCLIClientWithNamespace(KmeshNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create kube client: %v", err)
 	}

--- a/docs/ctl/kmeshctl.md
+++ b/docs/ctl/kmeshctl.md
@@ -5,7 +5,8 @@ Kmesh command line tools to operate and debug Kmesh
 ### Options
 
 ```bash
-  -h, --help   help for kmeshctl
+  -h, --help                     help for kmeshctl
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
 ```
 
 ### SEE ALSO

--- a/docs/ctl/kmeshctl_authz.md
+++ b/docs/ctl/kmeshctl_authz.md
@@ -8,6 +8,12 @@ Manage xdp authz eBPF program for Kmesh's authz offloading
   -h, --help   help for authz
 ```
 
+### Options inherited from parent commands
+
+```bash
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+```
+
 ### SEE ALSO
 
 * [kmeshctl](kmeshctl.md) - Kmesh command line tools to operate and debug Kmesh

--- a/docs/ctl/kmeshctl_authz_disable.md
+++ b/docs/ctl/kmeshctl_authz_disable.md
@@ -19,6 +19,12 @@ kmeshctl authz disable pod1 pod2
   -h, --help   help for disable
 ```
 
+### Options inherited from parent commands
+
+```bash
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+```
+
 ### SEE ALSO
 
 * [kmeshctl authz](kmeshctl_authz.md) - Manage xdp authz eBPF program for Kmesh's authz offloading

--- a/docs/ctl/kmeshctl_authz_enable.md
+++ b/docs/ctl/kmeshctl_authz_enable.md
@@ -19,6 +19,12 @@ kmeshctl authz enable pod1 pod2
   -h, --help   help for enable
 ```
 
+### Options inherited from parent commands
+
+```bash
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+```
+
 ### SEE ALSO
 
 * [kmeshctl authz](kmeshctl_authz.md) - Manage xdp authz eBPF program for Kmesh's authz offloading

--- a/docs/ctl/kmeshctl_authz_status.md
+++ b/docs/ctl/kmeshctl_authz_status.md
@@ -19,6 +19,12 @@ kmeshctl authz status pod1 pod2
   -h, --help   help for status
 ```
 
+### Options inherited from parent commands
+
+```bash
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+```
+
 ### SEE ALSO
 
 * [kmeshctl authz](kmeshctl_authz.md) - Manage xdp authz eBPF program for Kmesh's authz offloading

--- a/docs/ctl/kmeshctl_dump.md
+++ b/docs/ctl/kmeshctl_dump.md
@@ -26,6 +26,12 @@ kmeshctl dump <kmesh-daemon-pod> kernel-native -o json
   -o, --output string   Output format: table or json (default "table")
 ```
 
+### Options inherited from parent commands
+
+```bash
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+```
+
 ### SEE ALSO
 
 * [kmeshctl](kmeshctl.md) - Kmesh command line tools to operate and debug Kmesh

--- a/docs/ctl/kmeshctl_log.md
+++ b/docs/ctl/kmeshctl_log.md
@@ -26,6 +26,12 @@ kmeshctl log <kmesh-daemon-pod> default
       --set string   Set the logger level (e.g., default:debug)
 ```
 
+### Options inherited from parent commands
+
+```bash
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+```
+
 ### SEE ALSO
 
 * [kmeshctl](kmeshctl.md) - Kmesh command line tools to operate and debug Kmesh

--- a/docs/ctl/kmeshctl_monitoring.md
+++ b/docs/ctl/kmeshctl_monitoring.md
@@ -45,6 +45,12 @@ kmeshctl monitoring --all enable/disable
       --workloadMetrics string     Control workload granularity metrics enable or disable
 ```
 
+### Options inherited from parent commands
+
+```bash
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+```
+
 ### SEE ALSO
 
 * [kmeshctl](kmeshctl.md) - Kmesh command line tools to operate and debug Kmesh

--- a/docs/ctl/kmeshctl_secret.md
+++ b/docs/ctl/kmeshctl_secret.md
@@ -22,6 +22,12 @@ kmeshctl secret delete
   -h, --help   help for secret
 ```
 
+### Options inherited from parent commands
+
+```bash
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+```
+
 ### SEE ALSO
 
 * [kmeshctl](kmeshctl.md) - Kmesh command line tools to operate and debug Kmesh

--- a/docs/ctl/kmeshctl_secret_create.md
+++ b/docs/ctl/kmeshctl_secret_create.md
@@ -22,6 +22,12 @@ kmeshctl secret create --key=$(echo -n "{36-character user-defined key here}" | 
   -k, --key string   key of the encryption
 ```
 
+### Options inherited from parent commands
+
+```bash
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+```
+
 ### SEE ALSO
 
 * [kmeshctl secret](kmeshctl_secret.md) - Use secrets to manage secret configuration data for IPsec

--- a/docs/ctl/kmeshctl_secret_delete.md
+++ b/docs/ctl/kmeshctl_secret_delete.md
@@ -18,6 +18,12 @@ kmeshctl secret delete
   -h, --help   help for delete
 ```
 
+### Options inherited from parent commands
+
+```bash
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+```
+
 ### SEE ALSO
 
 * [kmeshctl secret](kmeshctl_secret.md) - Use secrets to manage secret configuration data for IPsec

--- a/docs/ctl/kmeshctl_secret_get.md
+++ b/docs/ctl/kmeshctl_secret_get.md
@@ -19,6 +19,12 @@ kmeshctl secret get
   -h, --help   help for get
 ```
 
+### Options inherited from parent commands
+
+```bash
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+```
+
 ### SEE ALSO
 
 * [kmeshctl secret](kmeshctl_secret.md) - Use secrets to manage secret configuration data for IPsec

--- a/docs/ctl/kmeshctl_version.md
+++ b/docs/ctl/kmeshctl_version.md
@@ -22,6 +22,12 @@ kmeshctl version <kmesh-daemon-pod>
   -h, --help   help for version
 ```
 
+### Options inherited from parent commands
+
+```bash
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+```
+
 ### SEE ALSO
 
 * [kmeshctl](kmeshctl.md) - Kmesh command line tools to operate and debug Kmesh

--- a/docs/ctl/kmeshctl_waypoint.md
+++ b/docs/ctl/kmeshctl_waypoint.md
@@ -32,6 +32,12 @@ kmeshctl waypoint [flags]
   -n, --namespace string   Kubernetes namespace
 ```
 
+### Options inherited from parent commands
+
+```bash
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+```
+
 ### SEE ALSO
 
 * [kmeshctl](kmeshctl.md) - Kmesh command line tools to operate and debug Kmesh

--- a/docs/ctl/kmeshctl_waypoint_apply.md
+++ b/docs/ctl/kmeshctl_waypoint_apply.md
@@ -37,9 +37,10 @@ kmeshctl waypoint apply [flags]
 ### Options inherited from parent commands
 
 ```bash
-      --image string       image of the waypoint
-      --name string        name of the waypoint (default "waypoint")
-  -n, --namespace string   Kubernetes namespace
+      --image string             image of the waypoint
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+      --name string              name of the waypoint (default "waypoint")
+  -n, --namespace string         Kubernetes namespace
 ```
 
 ### SEE ALSO

--- a/docs/ctl/kmeshctl_waypoint_delete.md
+++ b/docs/ctl/kmeshctl_waypoint_delete.md
@@ -36,9 +36,10 @@ kmeshctl waypoint delete [flags]
 ### Options inherited from parent commands
 
 ```bash
-      --image string       image of the waypoint
-      --name string        name of the waypoint (default "waypoint")
-  -n, --namespace string   Kubernetes namespace
+      --image string             image of the waypoint
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+      --name string              name of the waypoint (default "waypoint")
+  -n, --namespace string         Kubernetes namespace
 ```
 
 ### SEE ALSO

--- a/docs/ctl/kmeshctl_waypoint_generate.md
+++ b/docs/ctl/kmeshctl_waypoint_generate.md
@@ -31,9 +31,10 @@ kmeshctl waypoint generate [flags]
 ### Options inherited from parent commands
 
 ```bash
-      --image string       image of the waypoint
-      --name string        name of the waypoint (default "waypoint")
-  -n, --namespace string   Kubernetes namespace
+      --image string             image of the waypoint
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+      --name string              name of the waypoint (default "waypoint")
+  -n, --namespace string         Kubernetes namespace
 ```
 
 ### SEE ALSO

--- a/docs/ctl/kmeshctl_waypoint_list.md
+++ b/docs/ctl/kmeshctl_waypoint_list.md
@@ -30,9 +30,10 @@ kmeshctl waypoint list [flags]
 ### Options inherited from parent commands
 
 ```bash
-      --image string       image of the waypoint
-      --name string        name of the waypoint (default "waypoint")
-  -n, --namespace string   Kubernetes namespace
+      --image string             image of the waypoint
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+      --name string              name of the waypoint (default "waypoint")
+  -n, --namespace string         Kubernetes namespace
 ```
 
 ### SEE ALSO

--- a/docs/ctl/kmeshctl_waypoint_status.md
+++ b/docs/ctl/kmeshctl_waypoint_status.md
@@ -29,9 +29,10 @@ kmeshctl waypoint status [flags]
 ### Options inherited from parent commands
 
 ```bash
-      --image string       image of the waypoint
-      --name string        name of the waypoint (default "waypoint")
-  -n, --namespace string   Kubernetes namespace
+      --image string             image of the waypoint
+      --kmesh-namespace string   Namespace where Kmesh is installed (default "kmesh-system")
+      --name string              name of the waypoint (default "waypoint")
+  -n, --namespace string         Kubernetes namespace
 ```
 
 ### SEE ALSO

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -60,7 +60,11 @@ type CLIClient interface {
 }
 
 func NewCLIClient(opts ...ClientOption) (CLIClient, error) {
-	return newClientInternal(opts...)
+	return newClientInternal(KmeshNamespace, opts...)
+}
+
+func NewCLIClientWithNamespace(namespace string, opts ...ClientOption) (CLIClient, error) {
+	return newClientInternal(namespace, opts...)
 }
 
 type ClientOption func(CLIClient) CLIClient
@@ -111,16 +115,20 @@ func newPortForwarder(cliClient *client, podName string, ns string, localAddress
 	}, nil
 }
 
-func newClientInternal(opts ...ClientOption) (*client, error) {
-	var c client
-	var err error
-
-	// Initialize config flags with namespace
+func newConfigFlags(namespace string) *genericclioptions.ConfigFlags {
 	configFlags := genericclioptions.NewConfigFlags(true).
 		WithDeprecatedPasswordFlag().
 		WithDiscoveryBurst(300).
 		WithDiscoveryQPS(50.0)
-	configFlags.Namespace = ptr.To(KmeshNamespace)
+	configFlags.Namespace = ptr.To(namespace)
+	return configFlags
+}
+
+func newClientInternal(namespace string, opts ...ClientOption) (*client, error) {
+	var c client
+	var err error
+
+	configFlags := newConfigFlags(namespace)
 	c.clientFactory = configFlags
 
 	c.config, err = configFlags.ToRESTConfig()

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kube
+
+import "testing"
+
+func TestNewConfigFlagsNamespace(t *testing.T) {
+	configFlags := newConfigFlags("kmesh-test")
+	if configFlags.Namespace == nil {
+		t.Fatal("namespace is nil")
+	}
+	if namespace := *configFlags.Namespace; namespace != "kmesh-test" {
+		t.Errorf("namespace = %q, want %q", namespace, "kmesh-test")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Adds a global `--kmesh-namespace` flag to `kmeshctl`, with `kmesh-system` kept as the default.

The selected namespace is used for daemon discovery, secret operations and daemon port-forwarding. This allows `kmeshctl` to work with Helm installations deployed outside `kmesh-system`.

**Which issue(s) this PR fixes**:

Fixes #1882

**Special notes for your reviewer**:

The existing waypoint `--namespace` flag is unchanged. It selects the workload namespace, while `--kmesh-namespace` selects the namespace where Kmesh itself is installed.

This includes the namespace part of #1879. The `localAddress` issue remains separate.

**Does this PR introduce a user-facing change?**:

```release-note
kmeshctl now supports a global --kmesh-namespace flag for Kmesh installations outside kmesh-system.