### PR TITLE
fix(consistenthash): honor requested tableSize in maglev getLookupTable

### DIFF
--- a/pkg/consistenthash/maglev/maglev.go
+++ b/pkg/consistenthash/maglev/maglev.go
@@ -155,8 +155,8 @@ func getOffsetAndSkip(address string, m uint64) (uint64, uint64) {
 	return offset, skip
 }
 
-func getPermutation(b Backend) uint64 {
-	return (b.offset + (b.skip * b.next)) % maglevTableSize
+func getPermutation(b Backend, tableSize uint64) uint64 {
+	return (b.offset + (b.skip * b.next)) % tableSize
 }
 
 func getLookupTable(cluster *cluster_v2.Cluster, tableSize uint64) ([]int, error) {
@@ -178,7 +178,7 @@ func getLookupTable(cluster *cluster_v2.Cluster, tableSize uint64) ([]int, error
 	backends := make([]Backend, 0, len(flatEps))
 
 	for i, ep := range flatEps {
-		epOffset, epSkip := getOffsetAndSkip(ep.GetAddress().String(), maglevTableSize)
+		epOffset, epSkip := getOffsetAndSkip(ep.GetAddress().String(), tableSize)
 		b := Backend{
 			ep:     ep,
 			index:  i,
@@ -204,10 +204,10 @@ func getLookupTable(cluster *cluster_v2.Cluster, tableSize uint64) ([]int, error
 		j := int(n) % length
 		b := backends[j]
 		for {
-			c := getPermutation(b)
+			c := getPermutation(b, tableSize)
 			for lookUpTable[c] >= 0 {
 				b.next++
-				c = getPermutation(b)
+				c = getPermutation(b, tableSize)
 			}
 			lookUpTable[c] = b.index
 			b.next++

--- a/pkg/consistenthash/maglev/maglev.go
+++ b/pkg/consistenthash/maglev/maglev.go
@@ -164,6 +164,10 @@ func getLookupTable(cluster *cluster_v2.Cluster, tableSize uint64) ([]int, error
 	clusterName := cluster.GetName()
 	localityLbEps := loadAssignment.GetEndpoints()
 
+	if tableSize == 0 {
+		return nil, fmt.Errorf("maglev table size must be non-zero for cluster:%v", clusterName)
+	}
+
 	if len(localityLbEps) == 0 {
 		return nil, fmt.Errorf("current cluster:%v has no any lb endpoints", clusterName)
 	}

--- a/pkg/consistenthash/maglev/maglev_sizeparam_test.go
+++ b/pkg/consistenthash/maglev/maglev_sizeparam_test.go
@@ -49,3 +49,13 @@ func TestGetLookupTable_RespectsRequestedTableSize(t *testing.T) {
 		}
 	}
 }
+
+// TestGetLookupTable_RejectsZeroTableSize verifies getLookupTable returns an
+// error instead of panicking with a divide-by-zero when asked for a zero-sized
+// table (e.g. a caller invoking it before InitMaglevMap has set a real size).
+func TestGetLookupTable_RejectsZeroTableSize(t *testing.T) {
+	cluster := newCluster()
+	if _, err := getLookupTable(cluster, 0); err == nil {
+		t.Fatal("expected an error for zero tableSize, got nil")
+	}
+}

--- a/pkg/consistenthash/maglev/maglev_sizeparam_test.go
+++ b/pkg/consistenthash/maglev/maglev_sizeparam_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package maglev
+
+import "testing"
+
+// TestGetLookupTable_RespectsRequestedTableSize verifies that getLookupTable
+// builds its permutation math against the tableSize argument it was given,
+// not against the mutable package-level maglevTableSize. In production,
+// maglevTableSize is only set once CreateLB -> InitMaglevMap has run against
+// a live BPF pin; any caller that invokes getLookupTable before that (or with
+// a tableSize that legitimately differs from the global, e.g. during a
+// reconfigure) must not crash the process.
+func TestGetLookupTable_RespectsRequestedTableSize(t *testing.T) {
+	// Simulate the global being out of sync with the requested size --
+	// exactly what happens if InitMaglevMap has not run yet (global stays
+	// at its zero value) or a caller asks for a different table size.
+	old := maglevTableSize
+	defer func() { maglevTableSize = old }()
+	maglevTableSize = 0
+
+	cluster := newCluster()
+	const requestedSize = 1201 // arbitrary, independent of the global
+
+	table, err := getLookupTable(cluster, requestedSize)
+	if err != nil {
+		t.Fatalf("getLookupTable returned error: %v", err)
+	}
+	if len(table) != requestedSize {
+		t.Fatalf("expected table of length %d, got %d", requestedSize, len(table))
+	}
+	for i, backendID := range table {
+		if backendID < 0 {
+			t.Fatalf("slot %d was never assigned a backend", i)
+		}
+	}
+}


### PR DESCRIPTION
getLookupTable(cluster, tableSize) sized its output slice with the tableSize argument but computed every offset/skip/permutation with the package-level maglevTableSize global instead. When the global is unset (0) this panics with an integer divide-by-zero in getOffsetAndSkip; when it merely differs from the requested size it panics with an index-out-of-range write in the lookup loop. Pass tableSize through to getOffsetAndSkip and getPermutation so the hash space always matches the table being built.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`getLookupTable(cluster, tableSize)` sizes its output slice with the `tableSize` argument but computed every offset/skip/permutation with the package-level `maglevTableSize` global instead. When the global is unset (0) this panics with an integer divide-by-zero in `getOffsetAndSkip`; when it merely differs from the requested size it panics with an index-out-of-range write in the lookup loop. This threads `tableSize` through `getOffsetAndSkip` and `getPermutation` so the hash space always matches the table being built.

Added `TestGetLookupTable_RespectsRequestedTableSize` covering the pre-init / divergent-size case; the existing `TestGetLookupTable` still passes with an unchanged backend distribution, so the normal path is unaffected.

**Which issue(s) this PR fixes**:

NONE (no tracking issue filed — happy to open one if preferred)

**Special notes for your reviewer**:

#1141 refactors this same file for a different issue (#1137, test isolation) and incidentally touches this inconsistency, but it is a stale unmerged rewrite. This is a minimal standalone fix, not a duplicate of that scope.

**Does this PR introduce a user-facing change?**:
release-note
NONE