### PR TITLE
make sure inlinng is disabled for the go test command using in make test

### DIFF
--- a/hack/run-ut.sh
+++ b/hack/run-ut.sh
@@ -10,9 +10,9 @@ function get_go_test_command() {
 	fi
 
 	if [ -z "$TEST_TARGET" ]; then
-		echo "go test -p 1 -v -race -vet=off $TEST_PKG"
+		echo "go test -gcflags=all=-l -p 1 -v -race -vet=off $TEST_PKG"
 	else
-		echo "go test -p 1 -v -race -vet=off -run $TEST_TARGET $TEST_PKG"
+		echo "go test -gcflags=all=-l -p 1 -v -race -vet=off -run $TEST_TARGET $TEST_PKG"
 	fi
 }
 


### PR DESCRIPTION
**What type of PR is this?**

<!--
Add one of the following kinds:

/kind bug

-->

**What this PR does / why we need it**:

Unit tests run by 'make test' are currently failing with the attached output.

```
-- FAIL: TestGetCniConfigPath (0.00s)
    --- PASS: TestGetCniConfigPath/test1:_have_CniConfigName,_get_error_in_libcni.ConfListFromFile,_should_return_error (0.00s)
    --- PASS: TestGetCniConfigPath/test2:_have_CniConfigName,_no_Plugins,_should_return_error (0.00s)
    --- PASS: TestGetCniConfigPath/test3:_no_CniConfigName,_get_error_in_libcni.ConfFiles,_should_return_error (0.00s)
    --- PASS: TestGetCniConfigPath/test_4:_no_CniConfigName,_get_error_in_libcni.ConfListFromFile,_should_return_error (0.00s)
    --- PASS: TestGetCniConfigPath/test_5:_no_CniConfigName,_no_Plugins,_should_return_error (0.00s)
    --- FAIL: TestGetCniConfigPath/test_6:_have_CniConfigName,_get_CnifigPath_successful,_should_return_nil (0.00s)
    --- FAIL: TestGetCniConfigPath/test_7:_no_CniConfigName,_Successful,_should_return_nil (0.00s)
```

The cause was that the gomonkey patching was not being applied correctly in test 6 and 7, leading to actual functions being called.
This was fixed by disabling inlining in go test by adding the `-gcflags=all=-l` flag.

This matches the command that's used by the CI in main.yml.

``` 
sudo env LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib:$GITHUB_WORKSPACE/api/v2-c:$GITHUB_WORKSPACE/bpf/deserialization_to_bpf_map PKG_CONFIG_PATH=$GITHUB_WORKSPACE/mk go test -gcflags=all=-l -race -v -vet=off -coverprofile=coverage.out ./pkg/... 
```

**Which issue(s) this PR fixes**:
Fixes #1890

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
NONE
```
