### PR TITLE
fix(ctl): return errors instead of os.Exit in secret command

### DIFF
--- a/ctl/secret/secret.go
+++ b/ctl/secret/secret.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -31,10 +30,7 @@ import (
 
 	"kmesh.net/kmesh/ctl/utils"
 	"kmesh.net/kmesh/pkg/controller/encryption"
-	"kmesh.net/kmesh/pkg/logger"
 )
-
-var log = logger.NewLoggerScope("kmeshctl/secret")
 
 const (
 	SecretName        = "kmesh-ipsec"
@@ -66,8 +62,8 @@ kmeshctl secret create
 # Generate IPsec configuration with user-defined key:
 kmeshctl secret create --key=$(echo -n "{36-character user-defined key here}" | xxd -p -c 64)`,
 		Args: cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			CreateOrUpdateSecret(cmd, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return CreateOrUpdateSecret(cmd, args)
 		},
 	}
 
@@ -80,8 +76,8 @@ kmeshctl secret create --key=$(echo -n "{36-character user-defined key here}" | 
 		Example: `# Get IPsec key and configuration by kmeshctl. The results will be displayed in JSON format.
 kmeshctl secret get`,
 		Args: cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			GetSecret()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return GetSecret()
 		},
 	}
 
@@ -91,8 +87,8 @@ kmeshctl secret get`,
 		Short:   "Delete IPsec key and configuration by kmeshctl",
 		Example: `kmeshctl secret delete`,
 		Args:    cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			DeleteSecret()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return DeleteSecret()
 		},
 	}
 
@@ -104,34 +100,30 @@ kmeshctl secret get`,
 	return cmd
 }
 
-func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
+func CreateOrUpdateSecret(cmd *cobra.Command, args []string) error {
 	var ipSecKey, ipSecKeyOld encryption.IpSecKey
-	var err error
 
 	ipSecKey.AeadKeyName = AeadAlgoName
 
 	aeadKeyArg, _ := cmd.Flags().GetString("key")
 
 	var aeadKey []byte
+	var err error
 
 	if !cmd.Flags().Changed("key") {
 		aeadKey = make([]byte, AeadKeyLength)
-		_, err := rand.Read(aeadKey)
-		if err != nil {
-			log.Errorf("failed to generate random key: %v", err)
-			os.Exit(1)
+		if _, err := rand.Read(aeadKey); err != nil {
+			return fmt.Errorf("failed to generate random key: %w", err)
 		}
 	} else {
 		aeadKey, err = hex.DecodeString(aeadKeyArg)
 		if err != nil {
-			log.Errorf("failed to decode hex string: %v, input: %v", err, aeadKeyArg)
-			os.Exit(1)
+			return fmt.Errorf("failed to decode hex string: %w, input: %v", err, aeadKeyArg)
 		}
 	}
 
 	if len(aeadKey) != AeadKeyLength {
-		log.Errorf("invalid key length: expected %d bytes, got %d bytes (key must be 256-bit + 32-bit salt)", AeadKeyLength, len(aeadKey))
-		os.Exit(1)
+		return fmt.Errorf("invalid key length: expected %d bytes, got %d bytes (key must be 256-bit + 32-bit salt)", AeadKeyLength, len(aeadKey))
 	}
 
 	ipSecKey.AeadKey = aeadKey
@@ -140,30 +132,26 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 
 	clientset, err := utils.CreateKubeClient()
 	if err != nil {
-		log.Errorf("failed to connect k8s client, %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to connect k8s client, %w", err)
 	}
 
 	secretOld, err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Get(context.TODO(), SecretName, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			log.Errorf("failed to get secret: %v, %v", SecretName, err)
-			os.Exit(1)
+			return fmt.Errorf("failed to get secret %s: %w", SecretName, err)
 		}
 		ipSecKey.Spi = 1
 	} else {
 		err = json.Unmarshal(secretOld.Data["ipSec"], &ipSecKeyOld)
 		if err != nil {
-			log.Errorf("failed to unmarshal secret: %v, %v", secretOld, err)
-			os.Exit(1)
+			return fmt.Errorf("failed to unmarshal secret %s: %w", SecretName, err)
 		}
 		ipSecKey.Spi = ipSecKeyOld.Spi + 1
 	}
 
 	secretData, err := json.Marshal(ipSecKey)
 	if err != nil {
-		log.Errorf("failed to convert ipsec key to secret data, %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to convert ipsec key to secret data, %w", err)
 	}
 
 	secret := &corev1.Secret{
@@ -179,45 +167,39 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 	if ipSecKey.Spi == 1 {
 		_, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Create(context.TODO(), secret, metav1.CreateOptions{})
 		if err != nil {
-			log.Errorf("failed to create %v secret, %v", SecretName, err)
-			os.Exit(1)
+			return fmt.Errorf("failed to create secret %s: %w", SecretName, err)
 		}
 	} else {
 		_, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
 		if err != nil {
-			log.Errorf("failed to update %v secret, %v", SecretName, err)
-			os.Exit(1)
+			return fmt.Errorf("failed to update secret %s: %w", SecretName, err)
 		}
 	}
+	return nil
 }
 
-func GetSecret() {
+func GetSecret() error {
 	clientset, err := utils.CreateKubeClient()
 	if err != nil {
-		log.Errorf("failed to connect k8s client, %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to connect k8s client, %w", err)
 	}
 
 	secret, err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Get(context.TODO(), SecretName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Errorf("secret %s not found", SecretName)
-			os.Exit(1)
+			return fmt.Errorf("secret %s not found", SecretName)
 		}
-		log.Errorf("failed to get secret: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to get secret: %w", err)
 	}
 
 	if secret.Data == nil || secret.Data["ipSec"] == nil {
-		log.Errorf("invalid secret data: missing ipSec field")
-		os.Exit(1)
+		return fmt.Errorf("invalid secret data: missing ipSec field")
 	}
 
 	// Parse the IPsec data
 	var ipSecKey encryption.IpSecKey
 	if err := json.Unmarshal(secret.Data["ipSec"], &ipSecKey); err != nil {
-		log.Errorf("failed to unmarshal secret data: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to unmarshal secret data: %w", err)
 	}
 
 	// Create a display structure with hex string key
@@ -235,8 +217,7 @@ func GetSecret() {
 
 	displayData, err := json.MarshalIndent(displayKey, "", "  ")
 	if err != nil {
-		log.Errorf("failed to marshal display data: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to marshal display data: %w", err)
 	}
 
 	fmt.Printf("Secret name: %s\n", SecretName)
@@ -244,22 +225,21 @@ func GetSecret() {
 	fmt.Printf("Created: %s\n", secret.CreationTimestamp.Format("2006-01-02 15:04:05"))
 	fmt.Println("IPsec Configuration:")
 	fmt.Println(string(displayData))
+	return nil
 }
 
-func DeleteSecret() {
+func DeleteSecret() error {
 	clientset, err := utils.CreateKubeClient()
 	if err != nil {
-		log.Errorf("failed to connect k8s client, %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to connect k8s client, %w", err)
 	}
 
 	err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Delete(context.TODO(), SecretName, metav1.DeleteOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Errorf("secret %s not found", SecretName)
-			os.Exit(1)
+			return fmt.Errorf("secret %s not found", SecretName)
 		}
-		log.Errorf("failed to delete secret: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to delete secret: %w", err)
 	}
+	return nil
 }

--- a/ctl/secret/secret.go
+++ b/ctl/secret/secret.go
@@ -31,12 +31,10 @@ import (
 
 	"kmesh.net/kmesh/ctl/utils"
 	"kmesh.net/kmesh/pkg/controller/encryption"
-	"kmesh.net/kmesh/pkg/kube"
 	"kmesh.net/kmesh/pkg/logger"
 )
 
 var log = logger.NewLoggerScope("kmeshctl/secret")
-var clientset kube.CLIClient
 
 const (
 	SecretName        = "kmesh-ipsec"
@@ -46,8 +44,6 @@ const (
 )
 
 func NewCmd() *cobra.Command {
-	clientset = createKubeClientOrExit()
-
 	cmd := &cobra.Command{
 		Use:   "secret",
 		Short: "Use secrets to manage secret configuration data for IPsec",
@@ -108,15 +104,6 @@ kmeshctl secret get`,
 	return cmd
 }
 
-func createKubeClientOrExit() kube.CLIClient {
-	clientset, err := utils.CreateKubeClient()
-	if err != nil {
-		log.Errorf("failed to connect k8s client, %v", err)
-		os.Exit(1)
-	}
-	return clientset
-}
-
 func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 	var ipSecKey, ipSecKeyOld encryption.IpSecKey
 	var err error
@@ -150,6 +137,12 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 	ipSecKey.AeadKey = aeadKey
 
 	ipSecKey.Length = AeadAlgoICVLength
+
+	clientset, err := utils.CreateKubeClient()
+	if err != nil {
+		log.Errorf("failed to connect k8s client, %v", err)
+		os.Exit(1)
+	}
 
 	secretOld, err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Get(context.TODO(), SecretName, metav1.GetOptions{})
 	if err != nil {
@@ -199,6 +192,12 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 }
 
 func GetSecret() {
+	clientset, err := utils.CreateKubeClient()
+	if err != nil {
+		log.Errorf("failed to connect k8s client, %v", err)
+		os.Exit(1)
+	}
+
 	secret, err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Get(context.TODO(), SecretName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -248,7 +247,13 @@ func GetSecret() {
 }
 
 func DeleteSecret() {
-	err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Delete(context.TODO(), SecretName, metav1.DeleteOptions{})
+	clientset, err := utils.CreateKubeClient()
+	if err != nil {
+		log.Errorf("failed to connect k8s client, %v", err)
+		os.Exit(1)
+	}
+
+	err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Delete(context.TODO(), SecretName, metav1.DeleteOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Errorf("secret %s not found", SecretName)

--- a/ctl/secret/secret_test.go
+++ b/ctl/secret/secret_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package secret
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestNewCmd(t *testing.T) {
+	cmd := NewCmd()
+	if cmd.Use != "secret" {
+		t.Fatalf("Use = %q, want %q", cmd.Use, "secret")
+	}
+
+	wantSubcommands := map[string]bool{"create": false, "get": false, "delete": false}
+	for _, sub := range cmd.Commands() {
+		name := sub.Name()
+		if _, ok := wantSubcommands[name]; ok {
+			wantSubcommands[name] = true
+		}
+		if sub.RunE == nil {
+			t.Errorf("subcommand %q: RunE must be set so errors propagate instead of being silently swallowed", name)
+		}
+		if name == "create" && sub.Flags().Lookup("key") == nil {
+			t.Error("create subcommand: --key flag not defined")
+		}
+	}
+	for name, found := range wantSubcommands {
+		if !found {
+			t.Errorf("expected subcommand %q not found", name)
+		}
+	}
+}
+
+func keyCmd(t *testing.T, key string) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.Flags().StringP("key", "k", "", "key of the encryption")
+	if key != "" {
+		if err := cmd.Flags().Set("key", key); err != nil {
+			t.Fatalf("failed to set --key: %v", err)
+		}
+	}
+	return cmd
+}
+
+func TestCreateOrUpdateSecret_InvalidHex(t *testing.T) {
+	cmd := keyCmd(t, "not-valid-hex!!")
+	if err := CreateOrUpdateSecret(cmd, nil); err == nil {
+		t.Fatal("CreateOrUpdateSecret(invalid hex key) = nil error, want a validation error")
+	}
+}
+
+func TestCreateOrUpdateSecret_InvalidKeyLength(t *testing.T) {
+	cmd := keyCmd(t, "ab") // valid hex, far short of AeadKeyLength bytes
+	if err := CreateOrUpdateSecret(cmd, nil); err == nil {
+		t.Fatal("CreateOrUpdateSecret(wrong-length key) = nil error, want a validation error")
+	}
+}


### PR DESCRIPTION


**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

This PR converts the 16 `os.Exit(1)` calls in `ctl/secret` to returned errors and switches the `create`, `get`, and `delete` subcommands from `Run` to `RunE`. This follows the convention already used in `ctl/waypoint/waypoint.go`, which returns errors and lets Cobra print 
the root command already sets `SilenceUsage: true`, so output is a single `Error: ...` line with exit code 1, unchanged from today.

This PR also removes the package-level `clientset` variable and `createKubeClientOrExit()`. `NewCmd()` previously created a Kubernetes client at command-construction time, before any subcommand ran and `ctl/common.GetRootCommand()` builds the full command tree on every `kmeshctl` invocation, so this happened even for unrelated commands. Each function now
creates its own client, matching every other package under `ctl/`.

**Which issue(s) this PR fixes**:
Fixes #1892 

**Special notes for your reviewer**:
Scoped to `ctl/secret` deliberately. The same `os.Exit` pattern exists in the sibling commands, but those are already covered by open PRs.

**Does this PR introduce a user-facing change?**:

```release-note
None
```
