### PR TITLE
fix(build): default ENHANCED_KERNEL when make all-binary is run directly

### DIFF
--- a/mk/bpf.vars.mk
+++ b/mk/bpf.vars.mk
@@ -35,3 +35,9 @@ INSTALL_LIB ?= $(DESTDIR)/$(LIBDIR)
 EXTRA_GOFLAGS ?= -a
 EXTRA_CFLAGS ?= -O2 -Wall
 EXTRA_CDEFINE ?= -D__x86_64__
+
+KERNEL_HEADER_LINUX_BPF ?= $(ROOT_DIR)config/linux-bpf.h
+ifeq ($(wildcard $(KERNEL_HEADER_LINUX_BPF)),)
+KERNEL_HEADER_LINUX_BPF := /usr/include/linux/bpf.h
+endif
+ENHANCED_KERNEL ?= $(shell grep -q "FN(parse_header_msg)" $(KERNEL_HEADER_LINUX_BPF) 2>/dev/null && echo enhanced || echo normal)


### PR DESCRIPTION
**What type of PR is this?**

ENHANCED_KERNEL is usually set by kmesh_compile_env_pre.sh (via make prepare-dev or the Docker-based ./kmesh_compile.sh build). If someone runs make all-binary or make build directly, that step is skipped, leaving ENHANCED_KERNEL empty. As a result, go build -tags $(ENHANCED_KERNEL) treats the following -o as the tag value, causing the build to fail with:

named files must be .go files: kmesh-daemon

This adds a fallback in mk/bpf.vars.mk that performs the same header check used by set_enhanced_kernel_env(), but only when ENHANCED_KERNEL hasn't already been set. The existing environment-script path still takes priority. Verified with make -n all-binary; the generated go build command now correctly uses -tags normal (or enhanced when supported).

<!--
Add one of the following kinds:

/kind bug

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

```