### PR TITLE
feat(status): expose mode on /version and GET /authz

### DIFF
--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -116,6 +116,9 @@ func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs, loade
 
 func (s *Server) version(w http.ResponseWriter, r *http.Request) {
 	v := version.Get()
+	if s.config != nil && s.config.BpfConfig != nil {
+		v.Mode = s.config.BpfConfig.Mode
+	}
 
 	data, err := json.MarshalIndent(&v, "", "  ")
 	if err != nil {
@@ -329,12 +332,37 @@ func (s *Server) connectionMetricHandler(w http.ResponseWriter, r *http.Request)
 	w.WriteHeader(http.StatusOK)
 }
 
+type AuthzStatus struct {
+	Enabled bool `json:"enabled"`
+}
+
 func (s *Server) authzHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
+	switch r.Method {
+	case http.MethodGet:
+		s.getAuthzStatus(w)
+	case http.MethodPost:
+		s.setAuthzStatus(w, r)
+	default:
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) getAuthzStatus(w http.ResponseWriter) {
+	enabled := false
+	if s.loader != nil {
+		enabled = s.loader.GetAuthzOffload() == constants.ENABLED
+	}
+	data, err := json.MarshalIndent(AuthzStatus{Enabled: enabled}, "", "  ")
+	if err != nil {
+		log.Errorf("Failed to marshal authz status: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
+}
 
+func (s *Server) setAuthzStatus(w http.ResponseWriter, r *http.Request) {
 	authzInfo := r.URL.Query().Get("enable")
 	enabled, err := strconv.ParseBool(authzInfo)
 	if err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -38,6 +38,9 @@ type Info struct {
 	GoVersion    string `json:"goVersion"`
 	Compiler     string `json:"compiler"`
 	Platform     string `json:"platform"`
+	// Mode is the daemon dataplane mode (kernel-native|dual-engine).
+	// Empty for kmeshctl client version responses.
+	Mode string `json:"mode,omitempty"`
 }
 
 // String returns a Go-syntax representation of the Info.


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

Expose daemon dataplane `mode` on `GET /version` and add `GET /authz` returning `{"enabled": bool}`.

Today dump/BPF callers must guess `kernel-native` vs `dual-engine`, and `kmeshctl authz status` GETs `/authz` but the status server only allowed POST. This is groundwork for the MCP server (#1800) so tools like `get_version`, `config_dump`, and `get_authz_status` can use structured status APIs.

**Which issue(s) this PR fixes**:
Related to #1800

**Special notes for your reviewer**:

- `mode` is filled from `BpfConfig.Mode` (default `dual-engine`); omitted for client-only version info via `omitempty`
- POST `/authz?enable=` behavior unchanged

**Does this PR introduce a user-facing change?**:
```release-note
status server: /version includes dataplane mode; GET /authz returns authz offload enabled status
```