### PR TITLE
refactor(ctl): add structured fetch helpers as MCP groundwork

### DIFF
--- a/ctl/authz/authz.go
+++ b/ctl/authz/authz.go
@@ -17,26 +17,28 @@
 package authz
 
 import (
-	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
 	"kmesh.net/kmesh/ctl/utils"
 	"kmesh.net/kmesh/pkg/kube"
-	"kmesh.net/kmesh/pkg/logger"
 )
 
 const (
 	patternAuthz = "/authz"
 )
 
-var log = logger.NewLoggerScope("kmeshctl/authz")
+// PodAuthzStatus is the structured authz status for one daemon pod.
+type PodAuthzStatus struct {
+	Pod     string `json:"pod"`
+	Enabled bool   `json:"enabled"`
+}
 
 // NewCmd returns the root authz command with its subcommands.
 func NewCmd() *cobra.Command {
@@ -59,10 +61,12 @@ func NewEnableCmd() *cobra.Command {
 		Short:   "Enable xdp authz eBPF program for Kmesh's authz offloading",
 		Example: "kmeshctl authz enable\nkmeshctl authz enable pod1 pod2",
 		Args:    cobra.ArbitraryArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			// If no pod names are given, apply to all kmesh daemon pods.
-			SetAuthzForPods(args, "true")
-			log.Info("Authorization has been enabled.")
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := SetAuthzForPods(args, "true"); err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "Authorization has been enabled.")
+			return nil
 		},
 	}
 	return cmd
@@ -75,9 +79,12 @@ func NewDisableCmd() *cobra.Command {
 		Short:   "Disable xdp authz eBPF program for Kmesh's authz offloading",
 		Example: "kmeshctl authz disable\nkmeshctl authz disable pod1 pod2",
 		Args:    cobra.ArbitraryArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			SetAuthzForPods(args, "false")
-			log.Info("Authorization has been disabled.")
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := SetAuthzForPods(args, "false"); err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "Authorization has been disabled.")
+			return nil
 		},
 	}
 	return cmd
@@ -90,159 +97,163 @@ func NewStatusCmd() *cobra.Command {
 		Short:   "Display the current authorization status",
 		Example: "kmeshctl authz status\nkmeshctl authz status pod1 pod2",
 		Args:    cobra.ArbitraryArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			cli, err := utils.CreateKubeClient()
 			if err != nil {
-				log.Errorf("failed to create cli client: %v", err)
-				os.Exit(1)
+				return fmt.Errorf("failed to create cli client: %w", err)
 			}
 
-			// Determine which pods to query.
-			var podNames []string
-			if len(args) == 0 {
-				podList, err := cli.PodsForSelector(context.TODO(), utils.KmeshNamespace, utils.KmeshLabel)
-				if err != nil {
-					log.Errorf("failed to get kmesh podList: %v", err)
-					os.Exit(1)
-				}
-				for _, pod := range podList.Items {
-					podNames = append(podNames, pod.GetName())
-				}
-			} else {
-				podNames = args
+			statuses, err := ListAuthzStatus(cli, args)
+			if err != nil {
+				return err
 			}
 
-			// Prepare a slice of podStatuses. We can pre-allocate since we know how many pods we'll check.
-			type podStatus struct {
-				Pod    string
-				Status string
-			}
-			statuses := make([]podStatus, 0, len(podNames))
-
-			// Collect the status for each pod.
-			for _, podName := range podNames {
-				status, err := fetchAuthzStatus(cli, podName)
-				if err != nil {
-					log.Errorf("failed to get authz status for pod %s: %v", podName, err)
-					continue
-				}
-				statuses = append(statuses, podStatus{Pod: podName, Status: status})
-			}
-
-			// Output the results in a table format.
-			var buf bytes.Buffer
-			tw := tabwriter.NewWriter(&buf, 0, 0, 2, ' ', 0)
+			out := cmd.OutOrStdout()
+			tw := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 			fmt.Fprintln(tw, "POD\tAUTHORIZATION STATUS")
 			for _, s := range statuses {
-				fmt.Fprintf(tw, "%s\t%s\n", s.Pod, s.Status)
+				status := "disabled"
+				if s.Enabled {
+					status = "enabled"
+				}
+				fmt.Fprintf(tw, "%s\t%s\n", s.Pod, status)
 			}
-			tw.Flush()
-			fmt.Print(buf.String())
+			return tw.Flush()
 		},
 	}
 	return cmd
 }
 
+// ListAuthzStatus returns authz status for the given pods, or all daemon pods if podNames is empty.
+func ListAuthzStatus(cli kube.CLIClient, podNames []string) ([]PodAuthzStatus, error) {
+	if len(podNames) == 0 {
+		podList, err := utils.ListDaemonPods(context.TODO(), cli, "")
+		if err != nil {
+			return nil, err
+		}
+		for _, pod := range podList.Items {
+			podNames = append(podNames, pod.GetName())
+		}
+	}
+
+	statuses := make([]PodAuthzStatus, 0, len(podNames))
+	for _, podName := range podNames {
+		status, err := GetAuthzStatus(cli, podName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get authz status for pod %s: %w", podName, err)
+		}
+		statuses = append(statuses, status)
+	}
+	return statuses, nil
+}
+
 // SetAuthzForPods applies the authz setting (enable/disable) for the given pod(s).
 // If no pod names are specified, it applies the setting to all kmesh daemon pods.
-func SetAuthzForPods(podNames []string, info string) {
+func SetAuthzForPods(podNames []string, info string) error {
 	cli, err := utils.CreateKubeClient()
 	if err != nil {
-		log.Errorf("failed to create cli client: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create cli client: %w", err)
 	}
 
 	if len(podNames) == 0 {
-		// Apply to all kmesh daemon pods.
-		podList, err := cli.PodsForSelector(context.TODO(), utils.KmeshNamespace, utils.KmeshLabel)
+		podList, err := utils.ListDaemonPods(context.TODO(), cli, "")
 		if err != nil {
-			log.Errorf("failed to get kmesh podList: %v", err)
-			os.Exit(1)
+			return err
 		}
 		for _, pod := range podList.Items {
-			SetAuthzPerKmeshDaemon(cli, pod.GetName(), info)
+			if err := SetAuthzPerKmeshDaemon(cli, pod.GetName(), info); err != nil {
+				return err
+			}
 		}
-	} else {
-		// Process for specified pods.
-		for _, podName := range podNames {
-			SetAuthzPerKmeshDaemon(cli, podName, info)
+		return nil
+	}
+
+	for _, podName := range podNames {
+		if err := SetAuthzPerKmeshDaemon(cli, podName, info); err != nil {
+			return err
 		}
 	}
+	return nil
 }
 
 // SetAuthzPerKmeshDaemon sends a POST request to a specific kmesh daemon pod
 // to set the authz flag based on the info parameter ("true" or "false").
-func SetAuthzPerKmeshDaemon(cli kube.CLIClient, podName, info string) {
+func SetAuthzPerKmeshDaemon(cli kube.CLIClient, podName, info string) error {
 	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
 	if err != nil {
-		log.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %w", podName, err)
 	}
 	if err := fw.Start(); err != nil {
-		log.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		os.Exit(1)
+		return fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %w", podName, err)
 	}
 	defer fw.Close()
 
 	url := fmt.Sprintf("http://%s%s?enable=%s", fw.Address(), patternAuthz, info)
-
 	req, err := http.NewRequest(http.MethodPost, url, nil)
 	if err != nil {
-		log.Errorf("Error creating request: %v", err)
-		return
+		return fmt.Errorf("error creating request: %w", err)
 	}
-
 	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{}
-	resp, err := client.Do(req)
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		log.Errorf("failed to make HTTP request: %v", err)
-		return
+		return fmt.Errorf("failed to make HTTP request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		log.Errorf("Error: received status code %d", resp.StatusCode)
-		return
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("received status code %d, body: %s", resp.StatusCode, body)
 	}
+	return nil
 }
 
-// fetchAuthzStatus sends a GET request to a specific kmesh daemon pod
-// to retrieve the current authz status and returns it.
-func fetchAuthzStatus(cli kube.CLIClient, podName string) (string, error) {
+// FetchAuthzStatus GETs /authz and returns structured status.
+func FetchAuthzStatus(url string) (enabled bool, err error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return false, fmt.Errorf("error creating request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("failed to make HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return false, fmt.Errorf("received status code %d, body: %s", resp.StatusCode, bodyBytes)
+	}
+
+	var status struct {
+		Enabled bool `json:"enabled"`
+	}
+	if err := json.Unmarshal(bodyBytes, &status); err != nil {
+		return false, fmt.Errorf("failed to unmarshal authz status: %w", err)
+	}
+	return status.Enabled, nil
+}
+
+// GetAuthzStatus port-forwards to a daemon pod and fetches authz status.
+func GetAuthzStatus(cli kube.CLIClient, podName string) (PodAuthzStatus, error) {
 	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
 	if err != nil {
-		return "", fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
+		return PodAuthzStatus{}, fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %w", podName, err)
 	}
 	if err := fw.Start(); err != nil {
-		return "", fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
+		return PodAuthzStatus{}, fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %w", podName, err)
 	}
 	defer fw.Close()
 
 	url := fmt.Sprintf("http://%s%s", fw.Address(), patternAuthz)
-
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	enabled, err := FetchAuthzStatus(url)
 	if err != nil {
-		return "", fmt.Errorf("error creating request: %v", err)
+		return PodAuthzStatus{}, err
 	}
-
-	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{}
-	resp, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to make HTTP request: %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("received status code %d", resp.StatusCode)
-	}
-
-	bodyBytes, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", fmt.Errorf("failed to read response body: %v", err)
-	}
-
-	status := string(bodyBytes)
-	return status, nil
+	return PodAuthzStatus{Pod: podName, Enabled: enabled}, nil
 }

--- a/ctl/authz/fetch_test.go
+++ b/ctl/authz/fetch_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package authz
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchAuthzStatus(t *testing.T) {
+	t.Run("enabled", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodGet, r.Method)
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]bool{"enabled": true}))
+		}))
+		defer server.Close()
+
+		enabled, err := FetchAuthzStatus(server.URL)
+		require.NoError(t, err)
+		assert.True(t, enabled)
+	})
+
+	t.Run("method not allowed style error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}))
+		defer server.Close()
+
+		_, err := FetchAuthzStatus(server.URL)
+		require.Error(t, err)
+	})
+}

--- a/ctl/dump/dump.go
+++ b/ctl/dump/dump.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"os"
 	"strings"
 	"text/tabwriter"
 
@@ -33,14 +32,12 @@ import (
 	adminv2 "kmesh.net/kmesh/api/v2/admin"
 	"kmesh.net/kmesh/ctl/utils"
 	"kmesh.net/kmesh/pkg/constants"
-	"kmesh.net/kmesh/pkg/logger"
+	"kmesh.net/kmesh/pkg/kube"
 )
 
 const (
 	configDumpPrefix = "/debug/config_dump"
 )
-
-var log = logger.NewLoggerScope("kmeshctl/dump")
 
 func NewCmd() *cobra.Command {
 	var outputFormat string
@@ -57,8 +54,8 @@ kmeshctl dump <kmesh-daemon-pod> dual-engine
 # Output as raw JSON:
 kmeshctl dump <kmesh-daemon-pod> kernel-native -o json`,
 		Args: cobra.ExactArgs(2),
-		Run: func(cmd *cobra.Command, args []string) {
-			_ = RunDump(cmd, args, outputFormat)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunDump(cmd, args, outputFormat)
 		},
 	}
 
@@ -66,69 +63,98 @@ kmeshctl dump <kmesh-daemon-pod> kernel-native -o json`,
 	return cmd
 }
 
-func RunDump(cmd *cobra.Command, args []string, outputFormat string) error {
-	podName := args[0]
-	mode := args[1]
-	if mode != constants.KernelNativeMode && mode != constants.DualEngineMode {
-		log.Errorf("Error: Argument must be 'kernel-native' or 'dual-engine'")
-		os.Exit(1)
-	}
-
-	cli, err := utils.CreateKubeClient()
-	if err != nil {
-		log.Errorf("failed to create cli client: %v", err)
-		os.Exit(1)
-	}
-
-	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
-	if err != nil {
-		log.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		os.Exit(1)
-	}
-	if err := fw.Start(); err != nil {
-		log.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
-	}
-
-	url := fmt.Sprintf("http://%s%s/%s", fw.Address(), configDumpPrefix, mode)
+// FetchConfigDump GETs a daemon config dump URL and returns the raw body.
+func FetchConfigDump(url string) ([]byte, error) {
 	resp, err := http.Get(url)
 	if err != nil {
-		log.Errorf("failed to make HTTP request: %v", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to make HTTP request(%s): %w", url, err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Errorf("failed to read HTTP response body: %v", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("failed to read HTTP response body(%s): %w", url, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("received status code %d from %s, body: %s", resp.StatusCode, url, body)
+	}
+	return body, nil
+}
+
+// GetConfigDump port-forwards to a daemon pod and fetches /debug/config_dump/<mode>.
+func GetConfigDump(client kube.CLIClient, podName, mode string) ([]byte, error) {
+	if mode != constants.KernelNativeMode && mode != constants.DualEngineMode {
+		return nil, fmt.Errorf("mode must be %q or %q", constants.KernelNativeMode, constants.DualEngineMode)
+	}
+	fw, err := utils.CreateKmeshPortForwarder(client, podName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %w", podName, err)
+	}
+	if err := fw.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %w", podName, err)
+	}
+	defer fw.Close()
+
+	url := fmt.Sprintf("http://%s%s/%s", fw.Address(), configDumpPrefix, mode)
+	return FetchConfigDump(url)
+}
+
+// GetBpfMaps port-forwards to a daemon pod and fetches /debug/config_dump/bpf/<mode>.
+func GetBpfMaps(client kube.CLIClient, podName, mode string) ([]byte, error) {
+	if mode != constants.KernelNativeMode && mode != constants.DualEngineMode {
+		return nil, fmt.Errorf("mode must be %q or %q", constants.KernelNativeMode, constants.DualEngineMode)
+	}
+	fw, err := utils.CreateKmeshPortForwarder(client, podName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %w", podName, err)
+	}
+	if err := fw.Start(); err != nil {
+		return nil, fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %w", podName, err)
+	}
+	defer fw.Close()
+
+	url := fmt.Sprintf("http://%s%s/bpf/%s", fw.Address(), configDumpPrefix, mode)
+	return FetchConfigDump(url)
+}
+
+func RunDump(cmd *cobra.Command, args []string, outputFormat string) error {
+	podName := args[0]
+	mode := args[1]
+	cli, err := utils.CreateKubeClient()
+	if err != nil {
+		return fmt.Errorf("failed to create cli client: %w", err)
 	}
 
+	body, err := GetConfigDump(cli, podName, mode)
+	if err != nil {
+		return err
+	}
+
+	out := cmd.OutOrStdout()
 	if outputFormat == "json" {
-		fmt.Println(string(body))
+		fmt.Fprintln(out, string(body))
 		return nil
 	}
 
 	switch mode {
 	case constants.KernelNativeMode:
-		printKernelNativeTable(body)
+		printKernelNativeTable(out, body)
 	case constants.DualEngineMode:
-		printDualEngineTable(body)
+		printDualEngineTable(out, body)
 	}
-
 	return nil
 }
 
 // printKernelNativeTable parses and displays kernel-native config dump as tables.
 // Static and dynamic resources of the same type are consolidated under a single header.
-func printKernelNativeTable(body []byte) {
+func printKernelNativeTable(out io.Writer, body []byte) {
 	configDump := &adminv2.ConfigDump{}
 	if err := protojson.Unmarshal(body, configDump); err != nil {
-		log.Errorf("failed to parse config dump: %v, falling back to raw output", err)
-		fmt.Println(string(body))
+		fmt.Fprintf(out, "failed to parse config dump: %v, falling back to raw output\n%s\n", err, string(body))
 		return
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
 	static, dynamic := configDump.GetStaticResources(), configDump.GetDynamicResources()
 
 	// Clusters
@@ -145,7 +171,7 @@ func printKernelNativeTable(body []byte) {
 			}
 		}
 		_ = w.Flush()
-		fmt.Println()
+		fmt.Fprintln(out)
 	}
 
 	// Listeners
@@ -176,7 +202,7 @@ func printKernelNativeTable(body []byte) {
 			printListeners(dynamic)
 		}
 		_ = w.Flush()
-		fmt.Println()
+		fmt.Fprintln(out)
 	}
 
 	// Routes
@@ -196,7 +222,7 @@ func printKernelNativeTable(body []byte) {
 			printRoutes(dynamic)
 		}
 		_ = w.Flush()
-		fmt.Println()
+		fmt.Fprintln(out)
 	}
 }
 
@@ -230,15 +256,14 @@ type policyEntry struct {
 }
 
 // printDualEngineTable parses and displays dual-engine config dump as tables.
-func printDualEngineTable(body []byte) {
+func printDualEngineTable(out io.Writer, body []byte) {
 	var dump workloadDump
 	if err := json.Unmarshal(body, &dump); err != nil {
-		log.Errorf("failed to parse workload dump: %v, falling back to raw output", err)
-		fmt.Println(string(body))
+		fmt.Fprintf(out, "failed to parse workload dump: %v, falling back to raw output\n%s\n", err, string(body))
 		return
 	}
 
-	w := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
 
 	if len(dump.Workloads) > 0 {
 		fmt.Fprintln(w, "NAME\tNAMESPACE\tADDRESSES\tPROTOCOL\tSTATUS")
@@ -252,7 +277,7 @@ func printDualEngineTable(body []byte) {
 			)
 		}
 		_ = w.Flush()
-		fmt.Println()
+		fmt.Fprintln(out)
 	}
 
 	if len(dump.Services) > 0 {
@@ -266,7 +291,7 @@ func printDualEngineTable(body []byte) {
 			)
 		}
 		_ = w.Flush()
-		fmt.Println()
+		fmt.Fprintln(out)
 	}
 
 	if len(dump.Policies) > 0 {
@@ -280,7 +305,7 @@ func printDualEngineTable(body []byte) {
 			)
 		}
 		_ = w.Flush()
-		fmt.Println()
+		fmt.Fprintln(out)
 	}
 }
 

--- a/ctl/dump/fetch_test.go
+++ b/ctl/dump/fetch_test.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dump
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchConfigDump(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		want := map[string]any{"ok": true}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(want))
+		}))
+		defer server.Close()
+
+		body, err := FetchConfigDump(server.URL)
+		require.NoError(t, err)
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(body, &got))
+		assert.Equal(t, true, got["ok"])
+	})
+
+	t.Run("non-200", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("Invalid Client Mode"))
+		}))
+		defer server.Close()
+
+		_, err := FetchConfigDump(server.URL)
+		require.Error(t, err)
+	})
+}

--- a/ctl/health/health.go
+++ b/ctl/health/health.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package health
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"kmesh.net/kmesh/ctl/utils"
+	"kmesh.net/kmesh/pkg/kube"
+)
+
+const patternReady = "/debug/ready"
+
+// FetchDaemonHealth GETs a daemon /debug/ready URL.
+// ready is true when the response is HTTP 200 and the body trims to "OK".
+func FetchDaemonHealth(url string) (ready bool, body string, err error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to make HTTP request(%s): %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to read HTTP response body(%s): %w", url, err)
+	}
+	body = string(raw)
+	if resp.StatusCode != http.StatusOK {
+		return false, body, fmt.Errorf("received status code %d from %s, body: %s", resp.StatusCode, url, body)
+	}
+	return strings.TrimSpace(body) == "OK", body, nil
+}
+
+// GetDaemonHealth port-forwards to a kmesh-daemon pod and checks /debug/ready.
+func GetDaemonHealth(client kube.CLIClient, podName string) (bool, error) {
+	fw, err := utils.CreateKmeshPortForwarder(client, podName)
+	if err != nil {
+		return false, fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %w", podName, err)
+	}
+	if err := fw.Start(); err != nil {
+		return false, fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %w", podName, err)
+	}
+	defer fw.Close()
+
+	url := fmt.Sprintf("http://%s%s", fw.Address(), patternReady)
+	ready, _, err := FetchDaemonHealth(url)
+	return ready, err
+}

--- a/ctl/health/health_test.go
+++ b/ctl/health/health_test.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package health
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchDaemonHealth(t *testing.T) {
+	t.Run("ready", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/debug/ready", r.URL.Path)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("OK"))
+		}))
+		defer server.Close()
+
+		ready, body, err := FetchDaemonHealth(server.URL + "/debug/ready")
+		require.NoError(t, err)
+		assert.True(t, ready)
+		assert.Equal(t, "OK", body)
+	})
+
+	t.Run("non-200", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = w.Write([]byte("not ready"))
+		}))
+		defer server.Close()
+
+		ready, _, err := FetchDaemonHealth(server.URL + "/debug/ready")
+		require.Error(t, err)
+		assert.False(t, ready)
+	})
+}

--- a/ctl/log/fetch_test.go
+++ b/ctl/log/fetch_test.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logs
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchLoggerNames(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		want := []string{"default", "bpf"}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(want))
+		}))
+		defer server.Close()
+
+		got, err := FetchLoggerNames(server.URL)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("non-200", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = w.Write([]byte("bad"))
+		}))
+		defer server.Close()
+
+		_, err := FetchLoggerNames(server.URL)
+		require.Error(t, err)
+	})
+}
+
+func TestFetchLoggerLevel(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		want := LoggerInfo{Name: "default", Level: "info"}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "default", r.URL.Query().Get("name"))
+			require.NoError(t, json.NewEncoder(w).Encode(want))
+		}))
+		defer server.Close()
+
+		got, err := FetchLoggerLevel(server.URL + "?name=default")
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("{"))
+		}))
+		defer server.Close()
+
+		_, err := FetchLoggerLevel(server.URL)
+		require.Error(t, err)
+	})
+}

--- a/ctl/log/log.go
+++ b/ctl/log/log.go
@@ -22,20 +22,16 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"kmesh.net/kmesh/ctl/utils"
-	"kmesh.net/kmesh/pkg/logger"
 )
 
 const (
 	patternLoggers = "/debug/loggers"
 )
-
-var log = logger.NewLoggerScope("kmeshctl/log")
 
 type LoggerInfo struct {
 	Name  string `json:"name,omitempty"`
@@ -55,8 +51,8 @@ kmeshctl log <kmesh-daemon-pod>
 # Get default logger's level:
 kmeshctl log <kmesh-daemon-pod> default`,
 		Args: cobra.MinimumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			RunGetOrSetLoggerLevel(cmd, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunGetOrSetLoggerLevel(cmd, args)
 		},
 	}
 	cmd.Flags().String("set", "", "Set the logger level (e.g., default:debug)")
@@ -87,34 +83,51 @@ func GetJson(url string, val any) error {
 	return nil
 }
 
-func GetLoggerNames(url string) {
+// FetchLoggerNames returns all logger names from the daemon /debug/loggers endpoint.
+func FetchLoggerNames(url string) ([]string, error) {
 	var loggerNames []string
 	if err := GetJson(url, &loggerNames); err != nil {
-		log.Errorf("failed to get logger names: %v", err)
-		return
+		return nil, err
 	}
-
-	fmt.Printf("Existing Loggers:\n")
-	for _, logger := range loggerNames {
-		fmt.Printf("\t%s\n", logger)
-	}
+	return loggerNames, nil
 }
 
-func GetLoggerLevel(url string) {
+// FetchLoggerLevel returns a single logger's level from /debug/loggers?name=...
+func FetchLoggerLevel(url string) (LoggerInfo, error) {
 	var loggerInfo LoggerInfo
 	if err := GetJson(url, &loggerInfo); err != nil {
-		log.Errorf("failed to get logger level: %v", err)
-		return
+		return LoggerInfo{}, err
 	}
-
-	fmt.Printf("Logger Name: %s\n", loggerInfo.Name)
-	fmt.Printf("Logger Level: %s\n", loggerInfo.Level)
+	return loggerInfo, nil
 }
 
-func SetLoggerLevel(url string, setFlag string) {
+func GetLoggerNames(out io.Writer, url string) error {
+	loggerNames, err := FetchLoggerNames(url)
+	if err != nil {
+		return fmt.Errorf("failed to get logger names: %w", err)
+	}
+
+	fmt.Fprintf(out, "Existing Loggers:\n")
+	for _, logger := range loggerNames {
+		fmt.Fprintf(out, "\t%s\n", logger)
+	}
+	return nil
+}
+
+func GetLoggerLevel(out io.Writer, url string) error {
+	loggerInfo, err := FetchLoggerLevel(url)
+	if err != nil {
+		return fmt.Errorf("failed to get logger level: %w", err)
+	}
+
+	fmt.Fprintf(out, "Logger Name: %s\n", loggerInfo.Name)
+	fmt.Fprintf(out, "Logger Level: %s\n", loggerInfo.Level)
+	return nil
+}
+
+func SetLoggerLevel(out io.Writer, url string, setFlag string) error {
 	if !strings.Contains(setFlag, ":") {
-		log.Errorf("Invalid set flag, which should be loggerName:loggerLevel (e.g. default:debug)")
-		os.Exit(1)
+		return fmt.Errorf("invalid set flag, which should be loggerName:loggerLevel (e.g. default:debug)")
 	}
 	splits := strings.Split(setFlag, ":")
 	loggerName := splits[0]
@@ -126,67 +139,61 @@ func SetLoggerLevel(url string, setFlag string) {
 	}
 	data, err := json.Marshal(loggerInfo)
 	if err != nil {
-		log.Errorf("Error marshaling logger info: %v", err)
-		return
+		return fmt.Errorf("error marshaling logger info: %w", err)
 	}
 
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(data))
 	if err != nil {
-		log.Errorf("Error creating request: %v", err)
-		return
+		return fmt.Errorf("error creating request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Errorf("failed to make HTTP request: %v", err)
-		return
+		return fmt.Errorf("failed to make HTTP request: %w", err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		log.Errorf("Error: received status code %d", resp.StatusCode)
-	}
-
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Errorf("failed to read HTTP response body: %v", err)
-		return
+		return fmt.Errorf("failed to read HTTP response body: %w", err)
 	}
-	fmt.Println(string(body))
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("received status code %d, Response body: %s", resp.StatusCode, body)
+	}
+
+	fmt.Fprintln(out, string(body))
+	return nil
 }
 
-func RunGetOrSetLoggerLevel(cmd *cobra.Command, args []string) {
+func RunGetOrSetLoggerLevel(cmd *cobra.Command, args []string) error {
 	podName := args[0]
 
 	cli, err := utils.CreateKubeClient()
 	if err != nil {
-		log.Errorf("failed to create cli client: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create cli client: %w", err)
 	}
 
 	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
 	if err != nil {
-		log.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %w", podName, err)
 	}
 	if err := fw.Start(); err != nil {
-		log.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		os.Exit(1)
+		return fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %w", podName, err)
 	}
 	defer fw.Close()
 
 	url := fmt.Sprintf("http://%s%s", fw.Address(), patternLoggers)
+	out := cmd.OutOrStdout()
 
 	setFlag, _ := cmd.Flags().GetString("set")
 	if setFlag == "" {
 		if len(args) >= 2 {
 			url += fmt.Sprintf("?name=%s", args[1])
-			GetLoggerLevel(url)
-		} else {
-			GetLoggerNames(url)
+			return GetLoggerLevel(out, url)
 		}
-	} else {
-		SetLoggerLevel(url, setFlag)
+		return GetLoggerNames(out, url)
 	}
+	return SetLoggerLevel(out, url, setFlag)
 }

--- a/ctl/monitoring/monitoring.go
+++ b/ctl/monitoring/monitoring.go
@@ -22,14 +22,12 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	"kmesh.net/kmesh/ctl/utils"
 	"kmesh.net/kmesh/pkg/kube"
-	"kmesh.net/kmesh/pkg/logger"
 )
 
 const (
@@ -46,8 +44,6 @@ const (
 	WORKLOAD   = "workload metrics"
 	CONNECTION = "connection metrics"
 )
-
-var log = logger.NewLoggerScope("kmeshctl/monitoring")
 
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -78,8 +74,8 @@ kmeshctl monitoring --connectionMetrics enable/disable
 #Enable/Disable services', workloads' and 'connections' metrics and accesslog generated from bpf in each node:
 kmeshctl monitoring --all enable/disable`,
 		Args: cobra.MaximumNArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			ControlMonitoring(cmd, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return ControlMonitoring(cmd, args)
 		},
 	}
 	cmd.Flags().String("accesslog", "", "Control accesslog enable or disable")
@@ -89,58 +85,58 @@ kmeshctl monitoring --all enable/disable`,
 	return cmd
 }
 
-func ControlMonitoring(cmd *cobra.Command, args []string) {
+func ControlMonitoring(cmd *cobra.Command, args []string) error {
 	client, err := utils.CreateKubeClient()
 	if err != nil {
-		log.Errorf("failed to create cli client: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create cli client: %w", err)
 	}
 	accesslogFlag, _ := cmd.Flags().GetString("accesslog")
 	allFlag, _ := cmd.Flags().GetString("all")
 	workloadMetricsFlag, _ := cmd.Flags().GetString("workloadMetrics")
 	connectionMetricsFlag, _ := cmd.Flags().GetString("connectionMetrics")
 	if accesslogFlag == "" && allFlag == "" && workloadMetricsFlag == "" && connectionMetricsFlag == "" {
-		log.Print("no parameters. Need --accesslog, --workloadMetrics, --connectionMetrics or --all")
-		return
+		return fmt.Errorf("no parameters; need --accesslog, --workloadMetrics, --connectionMetrics or --all")
+	}
+
+	apply := func(podName string) error {
+		if allFlag != "" {
+			if err := SetObservabilityPerKmeshDaemon(client, podName, allFlag, MONITORING, patternMonitoring); err != nil {
+				return err
+			}
+		}
+		if accesslogFlag != "" {
+			if err := SetObservabilityPerKmeshDaemon(client, podName, accesslogFlag, ACCESSLOG, patternAccesslog); err != nil {
+				return err
+			}
+		}
+		if workloadMetricsFlag != "" {
+			if err := SetObservabilityPerKmeshDaemon(client, podName, workloadMetricsFlag, WORKLOAD, patternWorkloadMetrics); err != nil {
+				return err
+			}
+		}
+		if connectionMetricsFlag != "" {
+			if err := SetObservabilityPerKmeshDaemon(client, podName, connectionMetricsFlag, CONNECTION, patternConnectionMetrics); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	podName, hasKmeshPod := getKmeshDaemonPod(args)
 	if hasKmeshPod {
-		// Processes triggers for specified kmesh daemon.
-		if allFlag != "" {
-			SetObservabilityPerKmeshDaemon(client, podName, allFlag, MONITORING, patternMonitoring)
-		}
-		if accesslogFlag != "" {
-			SetObservabilityPerKmeshDaemon(client, podName, accesslogFlag, ACCESSLOG, patternAccesslog)
-		}
-		if workloadMetricsFlag != "" {
-			SetObservabilityPerKmeshDaemon(client, podName, workloadMetricsFlag, WORKLOAD, patternWorkloadMetrics)
-		}
-		if connectionMetricsFlag != "" {
-			SetObservabilityPerKmeshDaemon(client, podName, connectionMetricsFlag, CONNECTION, patternConnectionMetrics)
-		}
-	} else {
-		// Perform operations on all kmesh daemons.
-		podList, err := client.PodsForSelector(context.TODO(), utils.KmeshNamespace, utils.KmeshLabel)
-		if err != nil {
-			log.Errorf("failed to get kmesh podList: %v", err)
-			os.Exit(1)
-		}
-		for _, pod := range podList.Items {
-			if allFlag != "" {
-				SetObservabilityPerKmeshDaemon(client, pod.GetName(), allFlag, MONITORING, patternMonitoring)
-			}
-			if accesslogFlag != "" {
-				SetObservabilityPerKmeshDaemon(client, pod.GetName(), accesslogFlag, ACCESSLOG, patternAccesslog)
-			}
-			if workloadMetricsFlag != "" {
-				SetObservabilityPerKmeshDaemon(client, pod.GetName(), workloadMetricsFlag, WORKLOAD, patternWorkloadMetrics)
-			}
-			if connectionMetricsFlag != "" {
-				SetObservabilityPerKmeshDaemon(client, pod.GetName(), connectionMetricsFlag, CONNECTION, patternConnectionMetrics)
-			}
+		return apply(podName)
+	}
+
+	podList, err := utils.ListDaemonPods(context.TODO(), client, "")
+	if err != nil {
+		return err
+	}
+	for _, pod := range podList.Items {
+		if err := apply(pod.GetName()); err != nil {
+			return err
 		}
 	}
+	return nil
 }
 
 func getKmeshDaemonPod(args []string) (string, bool) {
@@ -153,25 +149,22 @@ func getKmeshDaemonPod(args []string) (string, bool) {
 	return args[0], true
 }
 
-func SetObservabilityPerKmeshDaemon(cli kube.CLIClient, podName, info string, observablityType string, pattern string) {
+func SetObservabilityPerKmeshDaemon(cli kube.CLIClient, podName, info string, observablityType string, pattern string) error {
 	var status string
 	if info == "enable" {
 		status = "true"
 	} else if info == "disable" {
 		status = "false"
 	} else {
-		log.Errorf("Error: Argument must be 'enable' or 'disable'")
-		os.Exit(1)
+		return fmt.Errorf("argument must be 'enable' or 'disable', got %q", info)
 	}
 
 	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
 	if err != nil {
-		log.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %w", podName, err)
 	}
 	if err := fw.Start(); err != nil {
-		log.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		os.Exit(1)
+		return fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %w", podName, err)
 	}
 	defer fw.Close()
 
@@ -179,32 +172,29 @@ func SetObservabilityPerKmeshDaemon(cli kube.CLIClient, podName, info string, ob
 
 	req, err := http.NewRequest(http.MethodPost, url, nil)
 	if err != nil {
-		log.Errorf("Error creating request: %v", err)
-		return
+		return fmt.Errorf("error creating request: %w", err)
 	}
-
 	req.Header.Set("Content-Type", "application/json")
-	client := &http.Client{}
-	resp, err := client.Do(req)
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		log.Errorf("failed to make HTTP request: %v", err)
-		return
+		return fmt.Errorf("failed to make HTTP request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		log.Errorf("Error: received status code %d", resp.StatusCode)
 		if observablityType == MONITORING {
-			return
+			return fmt.Errorf("received status code %d enabling/disabling %s", resp.StatusCode, observablityType)
 		}
 		bodyBytes, readErr := io.ReadAll(resp.Body)
 		if readErr != nil {
-			log.Errorf("Error reading response body: %v", readErr)
-			return
+			return fmt.Errorf("received status code %d; also failed reading body: %w", resp.StatusCode, readErr)
 		}
 		bodyString := string(bodyBytes)
 		if resp.StatusCode == http.StatusBadRequest && bytes.Contains(bodyBytes, []byte(fmt.Sprintf("Kmesh monitoring is disable, cannot enable %s.", observablityType))) {
-			log.Errorf("failed to enable %s: %v. Need to start Kmesh's Monitoring. Please run `kmeshctl monitoring -h` for more help.", observablityType, bodyString)
+			return fmt.Errorf("failed to enable %s: %s; need to start Kmesh's Monitoring (see `kmeshctl monitoring -h`)", observablityType, bodyString)
 		}
+		return fmt.Errorf("received status code %d: %s", resp.StatusCode, bodyString)
 	}
+	return nil
 }

--- a/ctl/secret/secret.go
+++ b/ctl/secret/secret.go
@@ -22,7 +22,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"os"
+	"io"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -32,11 +32,7 @@ import (
 	"kmesh.net/kmesh/ctl/utils"
 	"kmesh.net/kmesh/pkg/controller/encryption"
 	"kmesh.net/kmesh/pkg/kube"
-	"kmesh.net/kmesh/pkg/logger"
 )
-
-var log = logger.NewLoggerScope("kmeshctl/secret")
-var clientset kube.CLIClient
 
 const (
 	SecretName        = "kmesh-ipsec"
@@ -46,8 +42,6 @@ const (
 )
 
 func NewCmd() *cobra.Command {
-	clientset = createKubeClientOrExit()
-
 	cmd := &cobra.Command{
 		Use:   "secret",
 		Short: "Use secrets to manage secret configuration data for IPsec",
@@ -57,7 +51,8 @@ kmeshctl secret get
 kmeshctl secret delete
 `,
 		Args: cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
 		},
 	}
 
@@ -70,8 +65,8 @@ kmeshctl secret create
 # Generate IPsec configuration with user-defined key:
 kmeshctl secret create --key=$(echo -n "{36-character user-defined key here}" | xxd -p -c 64)`,
 		Args: cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			CreateOrUpdateSecret(cmd, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return CreateOrUpdateSecret(cmd, args)
 		},
 	}
 
@@ -84,8 +79,12 @@ kmeshctl secret create --key=$(echo -n "{36-character user-defined key here}" | 
 		Example: `# Get IPsec key and configuration by kmeshctl. The results will be displayed in JSON format.
 kmeshctl secret get`,
 		Args: cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			GetSecret()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cli, err := utils.CreateKubeClient()
+			if err != nil {
+				return fmt.Errorf("failed to connect k8s client: %w", err)
+			}
+			return GetSecret(cli, cmd.OutOrStdout())
 		},
 	}
 
@@ -95,8 +94,12 @@ kmeshctl secret get`,
 		Short:   "Delete IPsec key and configuration by kmeshctl",
 		Example: `kmeshctl secret delete`,
 		Args:    cobra.NoArgs,
-		Run: func(cmd *cobra.Command, args []string) {
-			DeleteSecret()
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cli, err := utils.CreateKubeClient()
+			if err != nil {
+				return fmt.Errorf("failed to connect k8s client: %w", err)
+			}
+			return DeleteSecret(cli)
 		},
 	}
 
@@ -108,18 +111,13 @@ kmeshctl secret get`,
 	return cmd
 }
 
-func createKubeClientOrExit() kube.CLIClient {
+func CreateOrUpdateSecret(cmd *cobra.Command, args []string) error {
 	clientset, err := utils.CreateKubeClient()
 	if err != nil {
-		log.Errorf("failed to connect k8s client, %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to connect k8s client: %w", err)
 	}
-	return clientset
-}
 
-func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 	var ipSecKey, ipSecKeyOld encryption.IpSecKey
-	var err error
 
 	ipSecKey.AeadKeyName = AeadAlgoName
 
@@ -129,48 +127,39 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 
 	if !cmd.Flags().Changed("key") {
 		aeadKey = make([]byte, AeadKeyLength)
-		_, err := rand.Read(aeadKey)
-		if err != nil {
-			log.Errorf("failed to generate random key: %v", err)
-			os.Exit(1)
+		if _, err := rand.Read(aeadKey); err != nil {
+			return fmt.Errorf("failed to generate random key: %w", err)
 		}
 	} else {
 		aeadKey, err = hex.DecodeString(aeadKeyArg)
 		if err != nil {
-			log.Errorf("failed to decode hex string: %v, input: %v", err, aeadKeyArg)
-			os.Exit(1)
+			return fmt.Errorf("failed to decode hex string: %w, input: %v", err, aeadKeyArg)
 		}
 	}
 
 	if len(aeadKey) != AeadKeyLength {
-		log.Errorf("invalid key length: expected %d bytes, got %d bytes (key must be 256-bit + 32-bit salt)", AeadKeyLength, len(aeadKey))
-		os.Exit(1)
+		return fmt.Errorf("invalid key length: expected %d bytes, got %d bytes (key must be 256-bit + 32-bit salt)", AeadKeyLength, len(aeadKey))
 	}
 
 	ipSecKey.AeadKey = aeadKey
-
 	ipSecKey.Length = AeadAlgoICVLength
 
 	secretOld, err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Get(context.TODO(), SecretName, metav1.GetOptions{})
 	if err != nil {
 		if !apierrors.IsNotFound(err) {
-			log.Errorf("failed to get secret: %v, %v", SecretName, err)
-			os.Exit(1)
+			return fmt.Errorf("failed to get secret %v: %w", SecretName, err)
 		}
 		ipSecKey.Spi = 1
 	} else {
-		err = json.Unmarshal(secretOld.Data["ipSec"], &ipSecKeyOld)
-		if err != nil {
-			log.Errorf("failed to unmarshal secret: %v, %v", secretOld, err)
-			os.Exit(1)
+		if err := json.Unmarshal(secretOld.Data["ipSec"], &ipSecKeyOld); err != nil {
+			return fmt.Errorf("failed to unmarshal secret: %w", err)
 		}
 		ipSecKey.Spi = ipSecKeyOld.Spi + 1
 	}
 
 	secretData, err := json.Marshal(ipSecKey)
 	if err != nil {
-		log.Errorf("failed to convert ipsec key to secret data, %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to convert ipsec key to secret data: %w", err)
 	}
 
 	secret := &corev1.Secret{
@@ -184,44 +173,35 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 	}
 
 	if ipSecKey.Spi == 1 {
-		_, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Create(context.TODO(), secret, metav1.CreateOptions{})
-		if err != nil {
-			log.Errorf("failed to create %v secret, %v", SecretName, err)
-			os.Exit(1)
+		if _, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Create(context.TODO(), secret, metav1.CreateOptions{}); err != nil {
+			return fmt.Errorf("failed to create %v secret: %w", SecretName, err)
 		}
 	} else {
-		_, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
-		if err != nil {
-			log.Errorf("failed to update %v secret, %v", SecretName, err)
-			os.Exit(1)
+		if _, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Update(context.TODO(), secret, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to update %v secret: %w", SecretName, err)
 		}
 	}
+	return nil
 }
 
-func GetSecret() {
+func GetSecret(clientset kube.CLIClient, out io.Writer) error {
 	secret, err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Get(context.TODO(), SecretName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Errorf("secret %s not found", SecretName)
-			os.Exit(1)
+			return fmt.Errorf("secret %s not found", SecretName)
 		}
-		log.Errorf("failed to get secret: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to get secret: %w", err)
 	}
 
 	if secret.Data == nil || secret.Data["ipSec"] == nil {
-		log.Errorf("invalid secret data: missing ipSec field")
-		os.Exit(1)
+		return fmt.Errorf("invalid secret data: missing ipSec field")
 	}
 
-	// Parse the IPsec data
 	var ipSecKey encryption.IpSecKey
 	if err := json.Unmarshal(secret.Data["ipSec"], &ipSecKey); err != nil {
-		log.Errorf("failed to unmarshal secret data: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to unmarshal secret data: %w", err)
 	}
 
-	// Create a display structure with hex string key
 	displayKey := struct {
 		Spi         int    `json:"spi"`
 		AeadKeyName string `json:"aeadKeyName"`
@@ -236,25 +216,24 @@ func GetSecret() {
 
 	displayData, err := json.MarshalIndent(displayKey, "", "  ")
 	if err != nil {
-		log.Errorf("failed to marshal display data: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to marshal display data: %w", err)
 	}
 
-	fmt.Printf("Secret name: %s\n", SecretName)
-	fmt.Printf("Namespace: %s\n", utils.KmeshNamespace)
-	fmt.Printf("Created: %s\n", secret.CreationTimestamp.Format("2006-01-02 15:04:05"))
-	fmt.Println("IPsec Configuration:")
-	fmt.Println(string(displayData))
+	fmt.Fprintf(out, "Secret name: %s\n", SecretName)
+	fmt.Fprintf(out, "Namespace: %s\n", utils.KmeshNamespace)
+	fmt.Fprintf(out, "Created: %s\n", secret.CreationTimestamp.Format("2006-01-02 15:04:05"))
+	fmt.Fprintln(out, "IPsec Configuration:")
+	fmt.Fprintln(out, string(displayData))
+	return nil
 }
 
-func DeleteSecret() {
+func DeleteSecret(clientset kube.CLIClient) error {
 	err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Delete(context.TODO(), SecretName, metav1.DeleteOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Errorf("secret %s not found", SecretName)
-			os.Exit(1)
+			return fmt.Errorf("secret %s not found", SecretName)
 		}
-		log.Errorf("failed to delete secret: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to delete secret: %w", err)
 	}
+	return nil
 }

--- a/ctl/utils/pods.go
+++ b/ctl/utils/pods.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kmesh.net/kmesh/pkg/constants"
+	"kmesh.net/kmesh/pkg/kube"
+)
+
+// ListDaemonPods lists kmesh-daemon pods (app=kmesh) in the given namespace.
+// If namespace is empty, KmeshNamespace is used.
+func ListDaemonPods(ctx context.Context, cli kube.CLIClient, namespace string) (*corev1.PodList, error) {
+	if namespace == "" {
+		namespace = KmeshNamespace
+	}
+	podList, err := cli.PodsForSelector(ctx, namespace, KmeshLabel)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list kmesh daemon pods in %s: %w", namespace, err)
+	}
+	return podList, nil
+}
+
+// ListMeshNamespaces returns namespaces labeled with istio.io/dataplane-mode=kmesh.
+func ListMeshNamespaces(ctx context.Context, cli kube.CLIClient) ([]string, error) {
+	nsList, err := cli.Kube().CoreV1().Namespaces().List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", constants.DataPlaneModeLabel, constants.DataPlaneModeKmesh),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list mesh namespaces: %w", err)
+	}
+	names := make([]string, 0, len(nsList.Items))
+	for _, ns := range nsList.Items {
+		names = append(names, ns.Name)
+	}
+	return names, nil
+}

--- a/ctl/version/fetch_test.go
+++ b/ctl/version/fetch_test.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package version
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgversion "kmesh.net/kmesh/pkg/version"
+)
+
+func TestFetchVersion(t *testing.T) {
+	want := pkgversion.Info{
+		GitVersion: "v1.2.0",
+		GitCommit:  "abc123",
+	}
+
+	t.Run("success", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/version", r.URL.Path)
+			require.NoError(t, json.NewEncoder(w).Encode(want))
+		}))
+		defer server.Close()
+
+		got, err := FetchVersion(server.URL + "/version")
+		require.NoError(t, err)
+		assert.Equal(t, want.GitVersion, got.GitVersion)
+		assert.Equal(t, want.GitCommit, got.GitCommit)
+	})
+
+	t.Run("non-200", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte("boom"))
+		}))
+		defer server.Close()
+
+		_, err := FetchVersion(server.URL + "/version")
+		require.Error(t, err)
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("not-json"))
+		}))
+		defer server.Close()
+
+		_, err := FetchVersion(server.URL + "/version")
+		require.Error(t, err)
+	})
+}

--- a/ctl/version/version.go
+++ b/ctl/version/version.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"regexp"
 	"strings"
 
@@ -30,11 +29,8 @@ import (
 
 	"kmesh.net/kmesh/ctl/utils"
 	"kmesh.net/kmesh/pkg/kube"
-	"kmesh.net/kmesh/pkg/logger"
 	"kmesh.net/kmesh/pkg/version"
 )
-
-var log = logger.NewLoggerScope("kmeshctl/version")
 
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -45,19 +41,18 @@ kmeshctl version
 
 # Show version info of a specific kmesh daemon
 kmeshctl version <kmesh-daemon-pod>`,
-		Run: func(cmd *cobra.Command, args []string) {
-			runVersion(cmd, args)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVersion(cmd, args)
 		},
 	}
 	return cmd
 }
 
 // runVersion output the version info of kmeshctl or kmesh-daemon.
-func runVersion(cmd *cobra.Command, args []string) {
+func runVersion(cmd *cobra.Command, args []string) error {
 	cli, err := utils.CreateKubeClient()
 	if err != nil {
-		log.Errorf("failed to create kube client: %v", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create kube client: %w", err)
 	}
 
 	if len(args) == 0 {
@@ -70,13 +65,15 @@ func runVersion(cmd *cobra.Command, args []string) {
 
 		podList, err := cli.PodsForSelector(context.TODO(), utils.KmeshNamespace, utils.KmeshLabel)
 		if err != nil {
-			log.Errorf("failed to get kmesh daemon pods: %v", err)
-			os.Exit(1)
+			return fmt.Errorf("failed to get kmesh daemon pods: %w", err)
 		}
 
 		daemonVersions := map[string]int{}
 		for _, pod := range podList.Items {
-			v := getVersion(cli, pod.Name)
+			v, err := GetVersion(cli, pod.Name)
+			if err != nil {
+				return fmt.Errorf("failed to get version for pod %s: %w", pod.Name, err)
+			}
 			if v.GitVersion != "" {
 				if stringMatch(v.GitVersion) {
 					daemonVersions[v.GitVersion] = daemonVersions[v.GitVersion] + 1
@@ -91,53 +88,60 @@ func runVersion(cmd *cobra.Command, args []string) {
 			counts = append(counts, fmt.Sprintf("%s (%d daemons)", k, v))
 		}
 		cmd.Printf("%s\n", strings.Join(counts, ", "))
-		return
+		return nil
 	}
 
 	podName := args[0]
-	v := getVersion(cli, podName)
-	if v.GitVersion != "" {
-		data, err := json.MarshalIndent(&v, "", "  ")
-		if err != nil {
-			log.Errorf("Failed to marshal version info: %v", err)
-			os.Exit(1)
-		}
-		cmd.Printf("%s\n", string(data))
+	v, err := GetVersion(cli, podName)
+	if err != nil {
+		return fmt.Errorf("failed to get version for pod %s: %w", podName, err)
 	}
+	data, err := json.MarshalIndent(&v, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal version info: %w", err)
+	}
+	cmd.Printf("%s\n", string(data))
+	return nil
 }
 
-func getVersion(client kube.CLIClient, podName string) (version version.Info) {
-	fw, err := utils.CreateKmeshPortForwarder(client, podName)
-	if err != nil {
-		log.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		return
-	}
-	if err := fw.Start(); err != nil {
-		log.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
-		return
-	}
-	defer fw.Close()
-
-	url := fmt.Sprintf("http://%s/version", fw.Address())
+// FetchVersion GETs a daemon /version URL and returns structured version info.
+// It is safe for MCP and other callers that need typed data without CLI output.
+func FetchVersion(url string) (version.Info, error) {
 	resp, err := http.Get(url)
 	if err != nil {
-		log.Errorf("failed to make HTTP request: %v", err)
-		return
+		return version.Info{}, fmt.Errorf("failed to make HTTP request(%s): %w", url, err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Errorf("failed to read HTTP response body: %v", err)
-		return
+		return version.Info{}, fmt.Errorf("failed to read HTTP response body(%s): %w", url, err)
 	}
 
-	if err := json.Unmarshal(body, &version); err != nil {
-		log.Errorf("failed to unmarshal version info: %v", err)
-		return
+	if resp.StatusCode != http.StatusOK {
+		return version.Info{}, fmt.Errorf("received status code %d from %s, body: %s", resp.StatusCode, url, body)
 	}
 
-	return
+	var info version.Info
+	if err := json.Unmarshal(body, &info); err != nil {
+		return version.Info{}, fmt.Errorf("failed to unmarshal version info: %w", err)
+	}
+	return info, nil
+}
+
+// GetVersion port-forwards to a kmesh-daemon pod and fetches /version.
+func GetVersion(client kube.CLIClient, podName string) (version.Info, error) {
+	fw, err := utils.CreateKmeshPortForwarder(client, podName)
+	if err != nil {
+		return version.Info{}, fmt.Errorf("failed to create port forwarder for Kmesh daemon pod %s: %w", podName, err)
+	}
+	if err := fw.Start(); err != nil {
+		return version.Info{}, fmt.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %w", podName, err)
+	}
+	defer fw.Close()
+
+	url := fmt.Sprintf("http://%s/version", fw.Address())
+	return FetchVersion(url)
 }
 
 // match release version vx.y.z-(alpha)

--- a/ctl/waypoint/fetch.go
+++ b/ctl/waypoint/fetch.go
@@ -1,0 +1,129 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package waypoint
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"slices"
+
+	"istio.io/api/label"
+	"istio.io/istio/pilot/pkg/model/kstatus"
+	"istio.io/istio/pkg/config/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gateway "sigs.k8s.io/gateway-api/apis/v1"
+
+	"kmesh.net/kmesh/pkg/kube"
+)
+
+// WaypointInfo is a structured summary of a managed waypoint Gateway.
+type WaypointInfo struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	Revision  string `json:"revision"`
+	Programmed string `json:"programmed"`
+}
+
+// WaypointConditionStatus is a structured waypoint status row.
+type WaypointConditionStatus struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Type      string `json:"type"`
+	Reason    string `json:"reason"`
+	Message   string `json:"message"`
+}
+
+// ListWaypoints lists Gateways with the istio-waypoint GatewayClass.
+// If namespace is empty, all namespaces are listed.
+func ListWaypoints(kubeClient kube.CLIClient, namespace string) ([]WaypointInfo, error) {
+	gws, err := kubeClient.GatewayAPI().GatewayV1().Gateways(namespace).
+		List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := make([]gateway.Gateway, 0, len(gws.Items))
+	for _, gw := range gws.Items {
+		if gw.Spec.GatewayClassName != constants.WaypointGatewayClassName {
+			continue
+		}
+		filtered = append(filtered, gw)
+	}
+	slices.SortFunc(filtered, func(i, j gateway.Gateway) int {
+		if r := cmp.Compare(i.Namespace, j.Namespace); r != 0 {
+			return r
+		}
+		return cmp.Compare(i.Name, j.Name)
+	})
+
+	out := make([]WaypointInfo, 0, len(filtered))
+	for _, gw := range filtered {
+		programmed := kstatus.StatusFalse
+		rev := gw.Labels[label.IoIstioRev.Name]
+		if rev == "" {
+			rev = "default"
+		}
+		for _, cond := range gw.Status.Conditions {
+			if cond.Type == string(gateway.GatewayConditionProgrammed) {
+				programmed = string(cond.Status)
+			}
+		}
+		out = append(out, WaypointInfo{
+			Namespace: gw.Namespace,
+			Name:      gw.Name,
+			Revision:  rev,
+			Programmed: programmed,
+		})
+	}
+	return out, nil
+}
+
+// GetWaypointStatuses returns the Programmed condition snapshot for waypoints in a namespace.
+// Unlike the CLI status command, this does not poll/wait.
+func GetWaypointStatuses(kubeClient kube.CLIClient, namespace string) ([]WaypointConditionStatus, error) {
+	ns := namespaceOrDefault(namespace)
+	waypoints, err := ListWaypoints(kubeClient, ns)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]WaypointConditionStatus, 0, len(waypoints))
+	for _, wp := range waypoints {
+		gwc, err := kubeClient.GatewayAPI().GatewayV1().Gateways(wp.Namespace).Get(context.TODO(), wp.Name, metav1.GetOptions{})
+		if err != nil {
+			return nil, fmt.Errorf("failed to get waypoint %s/%s: %w", wp.Namespace, wp.Name, err)
+		}
+		var cond metav1.Condition
+		for _, c := range gwc.Status.Conditions {
+			if c.Type == string(gateway.GatewayConditionProgrammed) {
+				cond = c
+				break
+			}
+		}
+		out = append(out, WaypointConditionStatus{
+			Namespace: gwc.Namespace,
+			Name:      gwc.Name,
+			Status:    string(cond.Status),
+			Type:      cond.Type,
+			Reason:    cond.Reason,
+			Message:   cond.Message,
+		})
+	}
+	return out, nil
+}

--- a/ctl/waypoint/waypoint.go
+++ b/ctl/waypoint/waypoint.go
@@ -33,7 +33,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/cobra"
 	"istio.io/api/label"
-	"istio.io/istio/pilot/pkg/model/kstatus"
 	"istio.io/istio/pkg/config/constants"
 	"istio.io/istio/pkg/config/protocol"
 	"istio.io/istio/pkg/config/schema/gvk"
@@ -419,49 +418,25 @@ func NewCmd() *cobra.Command {
 			} else {
 				ns = namespaceOrDefault(namespace)
 			}
-			gws, err := kubeClient.GatewayAPI().GatewayV1().Gateways(ns).
-				List(context.Background(), metav1.ListOptions{})
+			filteredGws, err := ListWaypoints(kubeClient, ns)
 			if err != nil {
 				return err
 			}
-			if len(gws.Items) == 0 {
+			if len(filteredGws) == 0 {
 				fmt.Fprintln(writer, "No waypoints found.")
 				return nil
 			}
 			w := new(tabwriter.Writer).Init(writer, 0, 8, 5, ' ', 0)
-			slices.SortFunc(gws.Items, func(i, j gateway.Gateway) int {
-				if r := cmp.Compare(i.Namespace, j.Namespace); r != 0 {
-					return r
-				}
-				return cmp.Compare(i.Name, j.Name)
-			})
-			filteredGws := make([]gateway.Gateway, 0)
-			for _, gw := range gws.Items {
-				if gw.Spec.GatewayClassName != constants.WaypointGatewayClassName {
-					continue
-				}
-				filteredGws = append(filteredGws, gw)
-			}
 			if allNamespaces {
 				fmt.Fprintln(w, "NAMESPACE\tNAME\tREVISION\tPROGRAMMED")
 			} else {
 				fmt.Fprintln(w, "NAME\tREVISION\tPROGRAMMED")
 			}
 			for _, gw := range filteredGws {
-				programmed := kstatus.StatusFalse
-				rev := gw.Labels[label.IoIstioRev.Name]
-				if rev == "" {
-					rev = "default"
-				}
-				for _, cond := range gw.Status.Conditions {
-					if cond.Type == string(gateway.GatewayConditionProgrammed) {
-						programmed = string(cond.Status)
-					}
-				}
 				if allNamespaces {
-					_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", gw.Namespace, gw.Name, rev, programmed)
+					_, _ = fmt.Fprintf(w, "%s\t%s\t%s\t%s\n", gw.Namespace, gw.Name, gw.Revision, gw.Programmed)
 				} else {
-					_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", gw.Name, rev, programmed)
+					_, _ = fmt.Fprintf(w, "%s\t%s\t%s\n", gw.Name, gw.Revision, gw.Programmed)
 				}
 			}
 			return w.Flush()


### PR DESCRIPTION
**What type of PR is this?**

/kind enhancement

**What this PR does / why we need it**:

Groundwork for the Kmesh MCP server (#1800). Today many `kmeshctl` commands print tables and call `os.Exit` on failure. An MCP process reusing that code would get unstructured text or crash.

This PR extracts typed fetch helpers that return data + `error`, wires CLI through `RunE`, and adds unit tests for HTTP helpers. It does not add the `mcp/` server.

**Changes:**
- **version / log / dump / authz** — `Fetch*` / `Get*` helpers; `RunE`; no library `os.Exit`; Writer-based CLI output
- **waypoint** — `ListWaypoints`, `GetWaypointStatuses` (no wait); list command uses them
- **health** (new) — `FetchDaemonHealth` / `GetDaemonHealth` for `/debug/ready`
- **utils** — `ListDaemonPods`, `ListMeshNamespaces`
- **monitoring / secret** — same error/`RunE` cleanup
- **tests** — httptest coverage for version, log, dump, authz, health fetch paths

**Which issue(s) this PR fixes**:
Related to #1800

**Special notes for your reviewer**:

- Prefer merging the status-server PR first (mode on `/version`, GET `/authz`). Authz fetch expects `GET /authz` → `{"enabled": bool}`https://github.com/kmesh-net/kmesh/pull/1899
- Complementary to #1831 (Writer swap); this adds structured returns + error handling.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```