### PR TITLE
fix: default ENHANCED_KERNEL to avoid empty -tags in go build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ git commit -s -m "your commit message"
 
 This automatically appends:
 
-```
+```text
 Signed-off-by: Your Name <your-email@example.com>
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ Welcome to Kmesh!
   - [AI Guidance](#ai-guidance)
   - [Contributor Workflow](#contributor-workflow)
     - [Creating Pull Requests](#creating-pull-requests)
+    - [Developer Certificate of Origin (DCO)]
+    - [Fixing a missing sign-off] 
     - [Code Review](#code-review)
   - [Membership](#membership)
 
@@ -103,6 +105,36 @@ fail of continuous integration.
 - To compile, refer to [Compile and Build Kmesh](https://kmesh.net/docs/setup/develop-with-kind/)
 - To run unit test, refer to [Run Unit Test](https://kmesh.net/docs/developer-guide/tests/unit-test/)
 - To run e2e test, refer to [Run E2E Test](https://kmesh.net/docs/developer-guide/tests/e2e-test/)
+
+### Developer Certificate of Origin (DCO)
+
+Every commit must include a `Signed-off-by` line to certify that you 
+wrote or have the right to submit the code:
+
+```bash
+git commit -s -m "your commit message"
+```
+
+This automatically appends:
+
+```
+Signed-off-by: Your Name <your-email@example.com>
+```
+
+#### Fixing a missing sign-off
+
+If you forgot to sign off your last commit:
+
+```bash
+git commit --amend -s --no-edit
+```
+
+For multiple commits, use an interactive rebase and add `-s` when 
+re-committing, or run:
+
+```bash
+git rebase --signoff HEAD~N   # N = number of commits to fix
+```
 
 ### Code Review
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ Welcome to Kmesh!
   - [AI Guidance](#ai-guidance)
   - [Contributor Workflow](#contributor-workflow)
     - [Creating Pull Requests](#creating-pull-requests)
-    - [Developer Certificate of Origin (DCO)]
-    - [Fixing a missing sign-off] 
+    - [Developer Certificate of Origin (DCO)](#developer-certificate-of-origin-dco)
+    - [Fixing a Missing Sign-off](#fixing-a-missing-sign-off)
     - [Code Review](#code-review)
   - [Membership](#membership)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ fail of continuous integration.
 
 ### Developer Certificate of Origin (DCO)
 
-Every commit must include a `Signed-off-by` line to certify that you 
+Every commit must include a `Signed-off-by` line to certify that you
 wrote or have the right to submit the code:
 
 ```bash
@@ -129,7 +129,7 @@ If you forgot to sign off your last commit:
 git commit --amend -s --no-edit
 ```
 
-For multiple commits, use an interactive rebase and add `-s` when 
+For multiple commits, use an interactive rebase and add `-s` when
 re-committing, or run:
 
 ```bash

--- a/mk/bpf.vars.mk
+++ b/mk/bpf.vars.mk
@@ -35,3 +35,9 @@ INSTALL_LIB ?= $(DESTDIR)/$(LIBDIR)
 EXTRA_GOFLAGS ?= -a
 EXTRA_CFLAGS ?= -O2 -Wall
 EXTRA_CDEFINE ?= -D__x86_64__
+
+# Fallback default when set_enhanced_kernel_env (kmesh_compile_env_pre.sh)
+# hasn't been sourced — e.g. when running `make all-binary` directly outside
+# of the official `make build` / Docker build flow. Prevents an empty
+# -tags value from breaking `go build`.
+ENHANCED_KERNEL ?= normal


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When `ENHANCED_KERNEL` hasn't been set (e.g. `set_enhanced_kernel_env` in
`kmesh_compile_env_pre.sh` wasn't sourced, such as when running
`make all-binary` directly outside the official `make build` / Docker
flow), the variable resolves to an empty string.

This breaks the build:

    go build -ldflags $(LDFLAGS) -tags $(ENHANCED_KERNEL) -o $(APPS1) ...

becomes effectively:

    go build -ldflags "..." -tags -o kmesh-daemon -a ./daemon/main.go

Since `-tags` requires a value, it consumes the next token (`-o`) as its
argument, and `kmesh-daemon` becomes a stray positional argument, causing:

    named files must be .go files: kmesh-daemon

This PR adds a safe fallback default in `mk/bpf.vars.mk`:

    ENHANCED_KERNEL ?= normal

This matches the same default `set_enhanced_kernel_env` already uses when
enhanced kernel headers aren't detected, so it doesn't change behavior for
the official build flow — it only prevents the empty-string case from
silently breaking `go build`.

**Which issue(s) this PR fixes**:
Fixes #1884

**Special notes for your reviewer**:
Verified locally:
- Before the fix: `make -n all-binary` shows `-tags -o kmesh-daemon` (empty tag value)
- After the fix: `make -n all-binary` shows `-tags normal` as expected
- Explicitly setting `ENHANCED_KERNEL=enhanced` still overrides correctly
  (the `?=` default doesn't clobber an already-set value)

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
```