### PR TITLE
fix(utils): make HashName ring probe reach the final slot

### DIFF
--- a/pkg/utils/hash_name.go
+++ b/pkg/utils/hash_name.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"hash"
 	"hash/fnv"
-	"math"
 	"os"
 
 	"sigs.k8s.io/yaml"
@@ -99,8 +98,11 @@ func (h *HashName) Hash(str string) uint32 {
 
 	h.hash.Reset()
 	h.hash.Write([]byte(str))
-	// Using linear probing to solve hash conflicts
-	for num = h.hash.Sum32(); num < math.MaxUint32; num++ {
+	// Using linear probing to solve hash conflicts. num is a uint32, so num++
+	// naturally wraps math.MaxUint32 back to 0, making the probe sequence a full
+	// ring without a separate bound check (the old `num < math.MaxUint32` bound
+	// skipped the final slot and made the wraparound below unreachable dead code).
+	for num = h.hash.Sum32(); ; num++ {
 		// Create a new item if we find an empty slot
 		if _, exists := h.numToStr[num]; !exists {
 			h.numToStr[num] = str
@@ -110,10 +112,6 @@ func (h *HashName) Hash(str string) uint32 {
 				log.Errorf("error flushing when calling Hash: %v", err)
 			}
 			break
-		}
-		// It's a ring
-		if num == math.MaxUint32 {
-			num = 0
 		}
 	}
 

--- a/pkg/utils/hash_name_ring_test.go
+++ b/pkg/utils/hash_name_ring_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"math"
+	"testing"
+)
+
+// fixedHash32 is a hash.Hash32 whose Sum32 always returns a fixed value, so the
+// linear-probing loop in Hash() can be driven onto an exact slot deterministically
+// (brute-forcing a real FNV32a preimage for 0xFFFFFFFF is infeasible).
+type fixedHash32 struct{ v uint32 }
+
+func (f fixedHash32) Write(p []byte) (int, error) { return len(p), nil }
+func (f fixedHash32) Sum(b []byte) []byte         { return b }
+func (f fixedHash32) Reset()                      {}
+func (f fixedHash32) Size() int                   { return 4 }
+func (f fixedHash32) BlockSize() int              { return 1 }
+func (f fixedHash32) Sum32() uint32               { return f.v }
+
+// TestHash_MaxUint32SlotIsRegistered verifies that when linear probing lands on
+// the top slot (math.MaxUint32), Hash() actually records it in numToStr/strToNum
+// instead of returning an unregistered id. The old `num < math.MaxUint32` loop
+// bound skipped the final slot entirely, so Hash returned MaxUint32 without ever
+// writing the maps, breaking the round-trip (NumToStr/StrToNum disagree).
+func TestHash_MaxUint32SlotIsRegistered(t *testing.T) {
+	h := &HashName{
+		numToStr: make(map[uint32]string),
+		strToNum: make(map[string]uint32),
+		hash:     fixedHash32{v: math.MaxUint32},
+	}
+	const key = "hits-the-max-slot"
+
+	got := h.Hash(key)
+	if got != math.MaxUint32 {
+		t.Fatalf("Hash(%q) = %d, want %d", key, got, uint32(math.MaxUint32))
+	}
+	if h.NumToStr(math.MaxUint32) != key {
+		t.Fatalf("NumToStr(MaxUint32) = %q, want %q — top slot was returned but never registered", h.NumToStr(math.MaxUint32), key)
+	}
+	if h.StrToNum(key) != math.MaxUint32 {
+		t.Fatalf("StrToNum(%q) = %d, want %d — reverse map never registered", key, h.StrToNum(key), uint32(math.MaxUint32))
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it:**

HashName.Hash used `for num = h.hash.Sum32(); num < math.MaxUint32; num++`, so the loop exited before ever testing slot math.MaxUint32 and the `if num == math.MaxUint32 { num = 0 }` wraparound was unreachable dead code. When linear probing lands on the top slot while it's free, Hash returned math.MaxUint32 without recording it in numToStr/strToNum, so NumToStr and StrToNum disagree for that id. Since Hash derives the BPF-map keys for workload/service/policy ids, that's a real (if rare) correctness gap.

num is a uint32, so num++ already wraps math.MaxUint32 back to 0, so dropping the bound turns the probe sequence into a true ring and removes the now-dead wraparound. Added a regression test that fakes the hash to force the probe onto the top slot and asserts the id round-trips.

**Which issue(s) this PR fixes:**

Fixes #1904

**Does this PR introduce a user-facing change?:**

```release-note
NONE
```
