### PR TITLE
fix: CompareIpByte skips invalid IP bytes instead of using zero-value IP

### DIFF
--- a/pkg/nets/nets.go
+++ b/pkg/nets/nets.go
@@ -135,16 +135,16 @@ func CompareIpByte(a, b [][]byte) [][]byte {
 		ip, ok := netip.AddrFromSlice(item)
 		if !ok {
 			log.Error("cannot compared IP: Unsupported data types")
+			continue
 		}
-
 		aSet[ip.String()] = item
 	}
-
 	var bMissing [][]byte
 	for _, item := range b {
 		ip, ok := netip.AddrFromSlice(item)
 		if !ok {
 			log.Error("cannot compared IP: Unsupported data types")
+			continue
 		}
 		if _, ok := aSet[ip.String()]; !ok {
 			bMissing = append(bMissing, item)

--- a/pkg/nets/nets_test.go
+++ b/pkg/nets/nets_test.go
@@ -110,6 +110,22 @@ func TestCompareIpByte(t *testing.T) {
 				{3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3},
 			},
 		},
+		{
+			name: "invalid IP bytes are skipped, not treated as matching",
+			args: args{
+				newData: [][]byte{
+					{1, 1, 1, 1},
+					{9, 9, 9},
+				},
+				oldData: [][]byte{
+					{3, 3, 3, 3},
+					{9, 9, 9, 9, 9},
+				},
+			},
+			want: [][]byte{
+				{3, 3, 3, 3},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #1908

CompareIpByte logged an error on invalid IP bytes but didn't stop - the zero-value IP's String() ("invalid IP") was used as a map key anyway, so multiple malformed entries would collide under the same key, and a malformed entry in one side could incorrectly match against one left over from the other side.

Added continue after the error log in both loops, so malformed entries are skipped entirely instead of participating in the comparison.

Added a test case covering malformed entries mixed with valid ones on both sides, verifying the diff result only reflects genuine IP comparisons.