### PR TITLE
fix(test): resolve log collection failure in E2E tests (#1911)

### DIFF
--- a/test/e2e/run_test.sh
+++ b/test/e2e/run_test.sh
@@ -440,11 +440,19 @@ bash -c "$cmd"
 EXIT_CODE=$?
 set -e
 
-if [ $EXIT_CODE -ne 0 ]; then
-	cat $LOGFILE
+# Log collection is diagnostic and must not replace the test exit status.
+if [ "$EXIT_CODE" -ne 0 ]; then
+	echo "E2E tests failed with exit code $EXIT_CODE."
+	if [[ -r $LOGFILE ]]; then
+		cat "$LOGFILE" || echo "Failed to read Kmesh daemon log: $LOGFILE"
+	elif [[ ${DEBUG:-false} == "true" ]]; then
+		echo "Kmesh daemon log was not created: $LOGFILE"
+	else
+		echo "Kmesh daemon log was not captured; rerun with --debug to enable log capture."
+	fi
 fi
 
-rm -rf $LOGFILE
+rm -f -- "$LOGFILE" || echo "Failed to remove Kmesh daemon log: $LOGFILE"
 
 if [[ -n ${CLEANUP_KIND} ]]; then
 	cleanup_kind_cluster
@@ -454,4 +462,4 @@ if [[ -n ${CLEANUP_REGISTRY} ]]; then
 	cleanup_docker_registry
 fi
 
-exit $EXIT_CODE
+exit "$EXIT_CODE"


### PR DESCRIPTION
**What type of PR is this?**

This is an E2E test to fix issue #1911
/kind bug

<!--
Add one of the following kinds:

/kind bug
/kind cleanup
/kind enhancement
/kind security
/kind documentation
/kind feature

-->

**What this PR does / why we need it**:

The actual issue was that the run_test.sh script (invoked via Makefile) was performing cat kmesh_daemon.log after test suites, causing a spurious exit failure on jobs where logs weren't being exported yet or tests exited before outputting into it successfully

In the current contents of test/e2e/run_test.sh, logarithmic checks are now put behind a conditional, eliminating the FAIL cat: kmesh_daemon.log: No such file or directory error that caused CI failures earlier

**Which issue(s) this PR fixes**:
Fixes #1911

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note

NONE
