### PR TITLE
fix(status): omit waypoint in service dump when none is configured

### DIFF
--- a/pkg/status/api.go
+++ b/pkg/status/api.go
@@ -164,7 +164,10 @@ func ConvertService(s *workloadapi.Service) *Service {
 		Hostname:  s.Hostname,
 		Addresses: vips,
 		Ports:     s.Ports,
-		Waypoint:  &Waypoint{Destination: waypoint},
+	}
+
+	if waypoint != "" {
+		out.Waypoint = &Waypoint{Destination: waypoint}
 	}
 
 	if s.LoadBalancing != nil {

--- a/pkg/status/api_test.go
+++ b/pkg/status/api_test.go
@@ -1,0 +1,126 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package status
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"kmesh.net/kmesh/api/v2/workloadapi"
+)
+
+func TestConvertServiceWaypoint(t *testing.T) {
+	testcases := []struct {
+		name     string
+		waypoint *workloadapi.GatewayAddress
+		expect   *Waypoint
+	}{
+		{
+			name:     "no waypoint",
+			waypoint: nil,
+			expect:   nil,
+		},
+		{
+			name: "waypoint by address",
+			waypoint: &workloadapi.GatewayAddress{
+				Destination: &workloadapi.GatewayAddress_Address{
+					Address: &workloadapi.NetworkAddress{
+						Network: "testnetwork",
+						Address: net.ParseIP("192.168.1.10").To4(),
+					},
+				},
+			},
+			expect: &Waypoint{Destination: "testnetwork/192.168.1.10"},
+		},
+		{
+			name: "waypoint by hostname",
+			waypoint: &workloadapi.GatewayAddress{
+				Destination: &workloadapi.GatewayAddress_Hostname{
+					Hostname: &workloadapi.NamespacedHostname{
+						Namespace: "default",
+						Hostname:  "waypoint.default.svc.cluster.local",
+					},
+				},
+			},
+			expect: &Waypoint{Destination: "default/waypoint.default.svc.cluster.local"},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ConvertService(&workloadapi.Service{
+				Name:      "productpage",
+				Namespace: "default",
+				Hostname:  "productpage.default.svc.cluster.local",
+				Waypoint:  tc.waypoint,
+			})
+			assert.Equal(t, tc.expect, got.Waypoint)
+		})
+	}
+}
+
+// A service without a waypoint must serialise waypoint as null, the same way a
+// service without load balancing already serialises loadBalancer as null.
+// Otherwise a consumer cannot tell "no waypoint" apart from "waypoint whose
+// destination happens to be empty".
+func TestConvertServiceOmitsEmptyWaypointInJSON(t *testing.T) {
+	got := ConvertService(&workloadapi.Service{
+		Name:      "productpage",
+		Namespace: "default",
+		Hostname:  "productpage.default.svc.cluster.local",
+		Addresses: []*workloadapi.NetworkAddress{
+			{Network: "testnetwork", Address: net.ParseIP("10.96.0.21").To4()},
+		},
+	})
+
+	data, err := json.Marshal(got)
+	assert.NoError(t, err)
+
+	var decoded map[string]interface{}
+	assert.NoError(t, json.Unmarshal(data, &decoded))
+
+	assert.Contains(t, decoded, "waypoint")
+	assert.Nil(t, decoded["waypoint"])
+	assert.Nil(t, decoded["loadBalancer"])
+}
+
+func TestConvertServiceAddresses(t *testing.T) {
+	got := ConvertService(&workloadapi.Service{
+		Name:      "reviews",
+		Namespace: "default",
+		Hostname:  "reviews.default.svc.cluster.local",
+		Addresses: []*workloadapi.NetworkAddress{
+			{Network: "testnetwork", Address: net.ParseIP("10.96.0.22").To4()},
+		},
+		LoadBalancing: &workloadapi.LoadBalancing{
+			Mode: workloadapi.LoadBalancing_FAILOVER,
+			RoutingPreference: []workloadapi.LoadBalancing_Scope{
+				workloadapi.LoadBalancing_NETWORK,
+				workloadapi.LoadBalancing_REGION,
+			},
+		},
+	})
+
+	assert.Equal(t, []string{"testnetwork/10.96.0.22"}, got.Addresses)
+	assert.Equal(t, &LoadBalancer{
+		Mode:               "FAILOVER",
+		RoutingPreferences: []string{"NETWORK", "REGION"},
+	}, got.LoadBalancer)
+}

--- a/pkg/status/api_test.go
+++ b/pkg/status/api_test.go
@@ -98,6 +98,7 @@ func TestConvertServiceOmitsEmptyWaypointInJSON(t *testing.T) {
 
 	assert.Contains(t, decoded, "waypoint")
 	assert.Nil(t, decoded["waypoint"])
+	assert.Contains(t, decoded, "loadBalancer")
 	assert.Nil(t, decoded["loadBalancer"])
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`ConvertService` always allocates a `Waypoint`, even when the service does not have one. The `LoadBalancer` branch three lines below already guards for the empty case, and `ConvertWorkload` uses `omitempty` for the same concept. So a service with neither currently dumps as:

```json
"loadBalancer": null,
"waypoint": { "destination": "" }
```

Two optional fields, two different shapes. A client reading the dump cannot tell "no waypoint" from "a waypoint whose destination happens to be empty" without special-casing the empty string.

This guards the waypoint the same way `s.LoadBalancing` is guarded immediately below, so it serialises as `null`.

Also adds `pkg/status/api_test.go`, which the package did not have. It covers the three waypoint cases (absent, by address, by hostname), the resulting JSON shape, and the `vips` and `loadBalancer` conversion.

**How I found it**:

I was building an MCP client against `/debug/config_dump/dual-engine` and shaping test fixtures from the marshalled output. I wanted to list the services routed through a waypoint, checked for `null`, and got nothing back because every service had a waypoint object. Traced it to `ConvertService`.

**Which issue(s) this PR fixes**:

None, found while reading the code.

**Special notes for your reviewer**:

I could not run `go test ./pkg/status/...` locally. The package reaches the bpf2go packages that `//go:embed` the compiled `.o` artifacts, and those are not in the tree, so it does not build outside a full eBPF build. I checked the test's types, enum names and assertions against the real `workloadapi` types in a scratch harness and am relying on CI for the real run. Flagging it rather than implying I ran it.

If you would rather keep emitting the object for compatibility, I am happy to drop the `api.go` change and keep the tests documenting the current behaviour instead.

**Does this PR introduce a user-facing change?**:

```release-note
The workload config dump now reports `"waypoint": null` for services that have no waypoint, instead of an object with an empty destination.
```
