### PR TITLE
feat: add mcp server foundation and CLI integration

### DIFF
--- a/ctl/common/common.go
+++ b/ctl/common/common.go
@@ -26,6 +26,7 @@ import (
 	"kmesh.net/kmesh/ctl/secret"
 	"kmesh.net/kmesh/ctl/version"
 	"kmesh.net/kmesh/ctl/waypoint"
+	"kmesh.net/kmesh/ctl/mcp"
 )
 
 func GetRootCommand() *cobra.Command {
@@ -45,6 +46,7 @@ func GetRootCommand() *cobra.Command {
 	rootCmd.AddCommand(monitoring.NewCmd())
 	rootCmd.AddCommand(authz.NewCmd())
 	rootCmd.AddCommand(secret.NewCmd())
+	rootCmd.AddCommand(mcp.NewCmd())
 
 	return rootCmd
 }

--- a/ctl/mcp/mcp.go
+++ b/ctl/mcp/mcp.go
@@ -1,0 +1,30 @@
+package mcp
+
+import (
+	"github.com/spf13/cobra"
+	mcpserver "kmesh.net/kmesh/mcp/server"
+	"kmesh.net/kmesh/pkg/logger"
+)
+
+var log = logger.NewLoggerScope("kmeshctl/mcp")
+
+func NewCmd() *cobra.Command {
+	mcpCmd := &cobra.Command{
+		Use:   "mcp",
+		Short: "Manage Kmesh Model Context Protocol (MCP) integrations",
+	}
+
+	serveCmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Start the Kmesh MCP server",
+		Run: func(cmd *cobra.Command, args []string) {
+			srv := mcpserver.NewKmeshMCPServer()
+			if err := srv.StartStdio(); err != nil {
+				log.Errorf("failed to start MCP server: %v", err)
+			}
+		},
+	}
+
+	mcpCmd.AddCommand(serveCmd)
+	return mcpCmd
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/mark3labs/mcp-go v0.8.3
 	github.com/miekg/dns v1.1.66
 	github.com/prometheus/client_golang v1.21.0
 	github.com/prometheus/common v0.62.0

--- a/go.sum
+++ b/go.sum
@@ -287,6 +287,8 @@ github.com/magiconair/properties v1.8.9 h1:nWcCbLq1N2v/cpNsy5WvQ37Fb+YElfq20WJ/a
 github.com/magiconair/properties v1.8.9/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
+github.com/mark3labs/mcp-go v0.8.3 h1:IzlyN8BaP4YwUMUDqxOGJhGdZXEDQiAPX43dNPgnzrg=
+github.com/mark3labs/mcp-go v0.8.3/go.mod h1:cjMlBU0cv/cj9kjlgmRhoJ5JREdS7YX83xeIG9Ko/jE=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=

--- a/mcp/cmd/mcp-server/main.go
+++ b/mcp/cmd/mcp-server/main.go
@@ -11,7 +11,7 @@ var log = logger.NewLoggerScope("mcp-server")
 
 func main() {
 	srv := mcpserver.NewKmeshMCPServer()
-	
+
 	if err := srv.StartStdio(); err != nil {
 		log.Errorf("failed to start MCP server: %v", err)
 		os.Exit(1)

--- a/mcp/cmd/mcp-server/main.go
+++ b/mcp/cmd/mcp-server/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"os"
+
+	mcpserver "kmesh.net/kmesh/mcp/server"
+	"kmesh.net/kmesh/pkg/logger"
+)
+
+var log = logger.NewLoggerScope("mcp-server")
+
+func main() {
+	srv := mcpserver.NewKmeshMCPServer()
+	
+	if err := srv.StartStdio(); err != nil {
+		log.Errorf("failed to start MCP server: %v", err)
+		os.Exit(1)
+	}
+}

--- a/mcp/server/server.go
+++ b/mcp/server/server.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"github.com/mark3labs/mcp-go/server"
+)
+
+type KmeshMCPServer struct {
+	server *server.MCPServer
+}
+
+func NewKmeshMCPServer() *KmeshMCPServer {
+	// Initialize the MCP server
+	srv := server.NewMCPServer("kmesh-mcp-server", "1.0.0")
+
+	// We'll register tools here later
+
+	return &KmeshMCPServer{
+		server: srv,
+	}
+}
+
+func (s *KmeshMCPServer) StartStdio() error {
+	return server.ServeStdio(s.server)
+}
+
+func (s *KmeshMCPServer) StartSSE(port int) error {
+	// Stub for SSE transport
+	return nil
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
This PR lays the architectural foundation for the **Kmesh Model Context Protocol (MCP) Server**
Specifically, this PR:
1. Adds the `github.com/mark3labs/mcp-go` SDK dependency to `go.mod`.
2. Creates the core `KmeshMCPServer` struct in `mcp/server/server.go` to handle MCP initialization.
3. Wires up the new `kmeshctl mcp serve` subcommand for local AI agents.
4. Creates a standalone entrypoint in `mcp/cmd/mcp-server/main.go` for future containerization.

This establishes the baseline infrastructure so that subsequent PRs can focus entirely on migrating the core `dump`, `log`, `authz`, and `secret` capabilities into callable MCP tools.

**Which issue(s) this PR fixes**:
Fixes #1916 

**Special notes for your reviewer**:
This is a foundational PR to establish the CLI skeleton and dependencies, so no core Kmesh data is being exposed yet. The `mcp-go` SDK was chosen because it provides robust, native support for both STDIO (used by Cursor/Claude Desktop) and SSE transport. 

**Does this PR introduce a user-facing change?**:
```release-note
Added the `kmeshctl mcp serve` command to run the Kmesh Model Context Protocol server.

