### PR TITLE
Feature/mcp server pr2

### DIFF
--- a/ctl/common/common.go
+++ b/ctl/common/common.go
@@ -26,6 +26,7 @@ import (
 	"kmesh.net/kmesh/ctl/secret"
 	"kmesh.net/kmesh/ctl/version"
 	"kmesh.net/kmesh/ctl/waypoint"
+	"kmesh.net/kmesh/ctl/mcp"
 )
 
 func GetRootCommand() *cobra.Command {
@@ -45,6 +46,7 @@ func GetRootCommand() *cobra.Command {
 	rootCmd.AddCommand(monitoring.NewCmd())
 	rootCmd.AddCommand(authz.NewCmd())
 	rootCmd.AddCommand(secret.NewCmd())
+	rootCmd.AddCommand(mcp.NewCmd())
 
 	return rootCmd
 }

--- a/ctl/mcp/mcp.go
+++ b/ctl/mcp/mcp.go
@@ -1,0 +1,30 @@
+package mcp
+
+import (
+	"github.com/spf13/cobra"
+	mcpserver "kmesh.net/kmesh/mcp/server"
+	"kmesh.net/kmesh/pkg/logger"
+)
+
+var log = logger.NewLoggerScope("kmeshctl/mcp")
+
+func NewCmd() *cobra.Command {
+	mcpCmd := &cobra.Command{
+		Use:   "mcp",
+		Short: "Manage Kmesh Model Context Protocol (MCP) integrations",
+	}
+
+	serveCmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Start the Kmesh MCP server",
+		Run: func(cmd *cobra.Command, args []string) {
+			srv := mcpserver.NewKmeshMCPServer()
+			if err := srv.StartStdio(); err != nil {
+				log.Errorf("failed to start MCP server: %v", err)
+			}
+		},
+	}
+
+	mcpCmd.AddCommand(serveCmd)
+	return mcpCmd
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/mark3labs/mcp-go v0.8.3
 	github.com/miekg/dns v1.1.66
 	github.com/prometheus/client_golang v1.21.0
 	github.com/prometheus/common v0.62.0

--- a/go.sum
+++ b/go.sum
@@ -287,6 +287,8 @@ github.com/magiconair/properties v1.8.9 h1:nWcCbLq1N2v/cpNsy5WvQ37Fb+YElfq20WJ/a
 github.com/magiconair/properties v1.8.9/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
+github.com/mark3labs/mcp-go v0.8.3 h1:IzlyN8BaP4YwUMUDqxOGJhGdZXEDQiAPX43dNPgnzrg=
+github.com/mark3labs/mcp-go v0.8.3/go.mod h1:cjMlBU0cv/cj9kjlgmRhoJ5JREdS7YX83xeIG9Ko/jE=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=

--- a/mcp/cmd/mcp-server/main.go
+++ b/mcp/cmd/mcp-server/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"os"
+
+	mcpserver "kmesh.net/kmesh/mcp/server"
+	"kmesh.net/kmesh/pkg/logger"
+)
+
+var log = logger.NewLoggerScope("mcp-server")
+
+func main() {
+	srv := mcpserver.NewKmeshMCPServer()
+	
+	if err := srv.StartStdio(); err != nil {
+		log.Errorf("failed to start MCP server: %v", err)
+		os.Exit(1)
+	}
+}

--- a/mcp/server/server.go
+++ b/mcp/server/server.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"github.com/mark3labs/mcp-go/server"
+)
+
+type KmeshMCPServer struct {
+	server *server.MCPServer
+}
+
+func NewKmeshMCPServer() *KmeshMCPServer {
+	// Initialize the MCP server
+	srv := server.NewMCPServer("kmesh-mcp-server", "1.0.0")
+
+	// We'll register tools here later
+
+	return &KmeshMCPServer{
+		server: srv,
+	}
+}
+
+func (s *KmeshMCPServer) StartStdio() error {
+	return server.ServeStdio(s.server)
+}
+
+func (s *KmeshMCPServer) StartSSE(port int) error {
+	// Stub for SSE transport
+	return nil
+}

--- a/mcp/server/server.go
+++ b/mcp/server/server.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"github.com/mark3labs/mcp-go/server"
+
+	"kmesh.net/kmesh/mcp/tools/daemon"
 )
 
 type KmeshMCPServer struct {
@@ -12,7 +14,8 @@ func NewKmeshMCPServer() *KmeshMCPServer {
 	// Initialize the MCP server
 	srv := server.NewMCPServer("kmesh-mcp-server", "1.0.0")
 
-	// We'll register tools here later
+	// Register tools
+	daemon.Register(srv)
 
 	return &KmeshMCPServer{
 		server: srv,

--- a/mcp/tools/daemon/daemon.go
+++ b/mcp/tools/daemon/daemon.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"kmesh.net/kmesh/ctl/utils"
+	"kmesh.net/kmesh/pkg/logger"
+)
+
+var log = logger.NewLoggerScope("mcp-server/tools/daemon")
+
+// Register registers the daemon related tools to the MCP server
+func Register(srv *server.MCPServer) {
+	// Define the get_kmesh_daemon_pods tool
+	tool := mcp.NewTool("get_kmesh_daemon_pods",
+		mcp.WithDescription("Retrieves a list of all currently running Kmesh daemon pods in the Kubernetes cluster. This is essential for determining which pod to target for subsequent log/dump tools."),
+	)
+
+	// Add tool to the server
+	srv.AddTool(tool, getKmeshDaemonPodsHandler)
+	log.Infof("Registered tool: get_kmesh_daemon_pods")
+}
+
+func getKmeshDaemonPodsHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	// Create Kubernetes client
+	cli, err := utils.CreateKubeClient()
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to create Kubernetes client: %v", err)), nil
+	}
+
+	// Fetch Kmesh daemon pods
+	podList, err := cli.PodsForSelector(ctx, utils.KmeshNamespace, utils.KmeshLabel)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to get kmesh pods: %v", err)), nil
+	}
+
+	if len(podList.Items) == 0 {
+		return mcp.NewToolResultText(fmt.Sprintf("No Kmesh daemon pods found in namespace '%s' with label '%s'.", utils.KmeshNamespace, utils.KmeshLabel)), nil
+	}
+
+	// Format output
+	var result string
+	result += "Kmesh Daemon Pods:\n"
+	for _, pod := range podList.Items {
+		result += fmt.Sprintf("- Name: %s (Node: %s, Status: %s, IP: %s)\n",
+			pod.Name,
+			pod.Spec.NodeName,
+			pod.Status.Phase,
+			pod.Status.PodIP,
+		)
+	}
+
+	return mcp.NewToolResultText(result), nil
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
This PR implements the **K8s Client & Daemon Discovery Tool** (`get_kmesh_daemon_pods`), the overall Model Context Protocol (MCP) Server integration roadmap.

For AI agents to diagnose Kmesh effectively via MCP (e.g., fetching daemon logs, checking authz status, or dumping xDS configs in future PRs), they must first know *which* daemon pods are actively running in the cluster. 

This PR:
1. Adds a new `mcp/tools/daemon` package.
2. Registers the `get_kmesh_daemon_pods` tool to the MCP server.
3. Leverages Kmesh's internal `utils.CreateKubeClient()` to securely query the Kubernetes API for all active pods in the `kmesh-system` namespace.
4. Formats the data (Pod Name, Node, Status, and IP) so AI agents can parse it and target specific pods dynamically.

**Which issue(s) this PR fixes**:
Fixes #1918 

**Special notes for your reviewer**:
This tool reuses the existing `kmeshctl` utility functions (`utils.KmeshNamespace`, `utils.KmeshLabel`, and `utils.CreateKubeClient`) to ensure the K8s API authentication behaves identically to the rest of the CLI.

**Does this PR introduce a user-facing change?**:
```release-note
Added the `get_kmesh_daemon_pods` tool to the Kmesh MCP server, allowing AI agents to dynamically discover active daemon pods in the cluster.

