### PR TITLE
fix: handle IPv6 waypoint addresses in service routing

### DIFF
--- a/bpf/include/common.h
+++ b/bpf/include/common.h
@@ -89,6 +89,14 @@ static inline bool is_ipv4_mapped_addr(__u32 ip6[4])
     return ip6[0] == 0 && ip6[1] == 0 && ip6[2] == 0xFFFF0000;
 }
 
+static inline bool is_ip_addr_zero(const struct ip_addr *addr)
+{
+    if (!addr)
+        return true;
+
+    return addr->ip4 == 0 && addr->ip6[0] == 0 && addr->ip6[1] == 0 && addr->ip6[2] == 0 && addr->ip6[3] == 0;
+}
+
 #define V4_MAPPED_REVERSE(v4_mapped)                                                                                   \
     do {                                                                                                               \
         (v4_mapped)[0] = (v4_mapped)[3];                                                                               \

--- a/bpf/kmesh/workload/include/backend.h
+++ b/bpf/kmesh/workload/include/backend.h
@@ -60,7 +60,7 @@ backend_manager(struct kmesh_context *kmesh_ctx, backend_value *backend_v, __u32
     ctx_buff_t *ctx = (ctx_buff_t *)kmesh_ctx->ctx;
     __u32 i, user_port = ctx->user_port;
 
-    if (backend_v->waypoint_port != 0) {
+    if (backend_v->waypoint_port != 0 && !is_ip_addr_zero(&backend_v->wp_addr)) {
         BPF_LOG(
             DEBUG,
             BACKEND,

--- a/bpf/kmesh/workload/include/frontend.h
+++ b/bpf/kmesh/workload/include/frontend.h
@@ -36,7 +36,7 @@ static inline int frontend_manager(struct kmesh_context *kmesh_ctx, frontend_val
 
     if (direct_backend) { // in this case, we donot check the healthy status of the backend, just let it go
         // For pod direct access, if a pod has waypoint captured, we will redirect to waypoint, otherwise we do nothing.
-        if (backend_v->waypoint_port != 0) {
+        if (backend_v->waypoint_port != 0 && !is_ip_addr_zero(&backend_v->wp_addr)) {
             BPF_LOG(
                 DEBUG,
                 FRONTEND,

--- a/bpf/kmesh/workload/include/service.h
+++ b/bpf/kmesh/workload/include/service.h
@@ -107,7 +107,7 @@ static inline int service_manager(struct kmesh_context *kmesh_ctx, __u32 service
 {
     int ret = 0;
 
-    if (service_v->wp_addr.ip4 != 0 && service_v->waypoint_port != 0) {
+    if (!is_ip_addr_zero(&service_v->wp_addr) && service_v->waypoint_port != 0) {
         BPF_LOG(
             DEBUG,
             SERVICE,


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

- This PR fixes IPv6 waypoint detection in the workload service routing path. 
- The service waypoint check only considered IPv4 addresses before redirecting traffic to a waypoint. As a result, valid IPv6 waypoint entries were skipped when `wp_addr.ip4` was zero, preventing IPv6 traffic from being routed through the configured waypoint.

**Which issue(s) this PR fixes**:
Fixes #1460 

**Special notes for your reviewer**:

- The fix validates the waypoint address as non-zero regardless of IP family
- The check is applied consistently in the service, backend, and direct-backend waypoint paths
- Validation was performed with the BPF unit-test build flow:
  - `bash test/bpf_ut/build_bpf_ut_tests.sh`

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
