### PR TITLE
Feature/mcp server pr3

### DIFF
--- a/ctl/common/common.go
+++ b/ctl/common/common.go
@@ -26,6 +26,7 @@ import (
 	"kmesh.net/kmesh/ctl/secret"
 	"kmesh.net/kmesh/ctl/version"
 	"kmesh.net/kmesh/ctl/waypoint"
+	"kmesh.net/kmesh/ctl/mcp"
 )
 
 func GetRootCommand() *cobra.Command {
@@ -45,6 +46,7 @@ func GetRootCommand() *cobra.Command {
 	rootCmd.AddCommand(monitoring.NewCmd())
 	rootCmd.AddCommand(authz.NewCmd())
 	rootCmd.AddCommand(secret.NewCmd())
+	rootCmd.AddCommand(mcp.NewCmd())
 
 	return rootCmd
 }

--- a/ctl/mcp/mcp.go
+++ b/ctl/mcp/mcp.go
@@ -1,0 +1,30 @@
+package mcp
+
+import (
+	"github.com/spf13/cobra"
+	mcpserver "kmesh.net/kmesh/mcp/server"
+	"kmesh.net/kmesh/pkg/logger"
+)
+
+var log = logger.NewLoggerScope("kmeshctl/mcp")
+
+func NewCmd() *cobra.Command {
+	mcpCmd := &cobra.Command{
+		Use:   "mcp",
+		Short: "Manage Kmesh Model Context Protocol (MCP) integrations",
+	}
+
+	serveCmd := &cobra.Command{
+		Use:   "serve",
+		Short: "Start the Kmesh MCP server",
+		Run: func(cmd *cobra.Command, args []string) {
+			srv := mcpserver.NewKmeshMCPServer()
+			if err := srv.StartStdio(); err != nil {
+				log.Errorf("failed to start MCP server: %v", err)
+			}
+		},
+	}
+
+	mcpCmd.AddCommand(serveCmd)
+	return mcpCmd
+}

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/go-multierror v1.1.1
+	github.com/mark3labs/mcp-go v0.8.3
 	github.com/miekg/dns v1.1.66
 	github.com/prometheus/client_golang v1.21.0
 	github.com/prometheus/common v0.62.0

--- a/go.sum
+++ b/go.sum
@@ -287,6 +287,8 @@ github.com/magiconair/properties v1.8.9 h1:nWcCbLq1N2v/cpNsy5WvQ37Fb+YElfq20WJ/a
 github.com/magiconair/properties v1.8.9/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.9.0 h1:PrnmzHw7262yW8sTBwxi1PdJA3Iw/EKBa8psRf7d9a4=
 github.com/mailru/easyjson v0.9.0/go.mod h1:1+xMtQp2MRNVL/V1bOzuP3aP8VNwRW55fQUto+XFtTU=
+github.com/mark3labs/mcp-go v0.8.3 h1:IzlyN8BaP4YwUMUDqxOGJhGdZXEDQiAPX43dNPgnzrg=
+github.com/mark3labs/mcp-go v0.8.3/go.mod h1:cjMlBU0cv/cj9kjlgmRhoJ5JREdS7YX83xeIG9Ko/jE=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=

--- a/mcp/cmd/mcp-server/main.go
+++ b/mcp/cmd/mcp-server/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"os"
+
+	mcpserver "kmesh.net/kmesh/mcp/server"
+	"kmesh.net/kmesh/pkg/logger"
+)
+
+var log = logger.NewLoggerScope("mcp-server")
+
+func main() {
+	srv := mcpserver.NewKmeshMCPServer()
+	
+	if err := srv.StartStdio(); err != nil {
+		log.Errorf("failed to start MCP server: %v", err)
+		os.Exit(1)
+	}
+}

--- a/mcp/server/server.go
+++ b/mcp/server/server.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"github.com/mark3labs/mcp-go/server"
+)
+
+type KmeshMCPServer struct {
+	server *server.MCPServer
+}
+
+func NewKmeshMCPServer() *KmeshMCPServer {
+	// Initialize the MCP server
+	srv := server.NewMCPServer("kmesh-mcp-server", "1.0.0")
+
+	// We'll register tools here later
+
+	return &KmeshMCPServer{
+		server: srv,
+	}
+}
+
+func (s *KmeshMCPServer) StartStdio() error {
+	return server.ServeStdio(s.server)
+}
+
+func (s *KmeshMCPServer) StartSSE(port int) error {
+	// Stub for SSE transport
+	return nil
+}

--- a/mcp/server/server.go
+++ b/mcp/server/server.go
@@ -4,6 +4,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"kmesh.net/kmesh/mcp/tools/daemon"
+	"kmesh.net/kmesh/mcp/tools/log"
 )
 
 type KmeshMCPServer struct {
@@ -16,6 +17,7 @@ func NewKmeshMCPServer() *KmeshMCPServer {
 
 	// Register tools
 	daemon.Register(srv)
+	log.Register(srv)
 
 	return &KmeshMCPServer{
 		server: srv,

--- a/mcp/server/server.go
+++ b/mcp/server/server.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"github.com/mark3labs/mcp-go/server"
+
+	"kmesh.net/kmesh/mcp/tools/daemon"
 )
 
 type KmeshMCPServer struct {
@@ -12,7 +14,8 @@ func NewKmeshMCPServer() *KmeshMCPServer {
 	// Initialize the MCP server
 	srv := server.NewMCPServer("kmesh-mcp-server", "1.0.0")
 
-	// We'll register tools here later
+	// Register tools
+	daemon.Register(srv)
 
 	return &KmeshMCPServer{
 		server: srv,

--- a/mcp/tools/daemon/daemon.go
+++ b/mcp/tools/daemon/daemon.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"kmesh.net/kmesh/ctl/utils"
+	"kmesh.net/kmesh/pkg/logger"
+)
+
+var log = logger.NewLoggerScope("mcp-server/tools/daemon")
+
+// Register registers the daemon related tools to the MCP server
+func Register(srv *server.MCPServer) {
+	// Define the get_kmesh_daemon_pods tool
+	tool := mcp.NewTool("get_kmesh_daemon_pods",
+		mcp.WithDescription("Retrieves a list of all currently running Kmesh daemon pods in the Kubernetes cluster. This is essential for determining which pod to target for subsequent log/dump tools."),
+	)
+
+	// Add tool to the server
+	srv.AddTool(tool, getKmeshDaemonPodsHandler)
+	log.Infof("Registered tool: get_kmesh_daemon_pods")
+}
+
+func getKmeshDaemonPodsHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	// Create Kubernetes client
+	cli, err := utils.CreateKubeClient()
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to create Kubernetes client: %v", err)), nil
+	}
+
+	// Fetch Kmesh daemon pods
+	podList, err := cli.PodsForSelector(ctx, utils.KmeshNamespace, utils.KmeshLabel)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("Failed to get kmesh pods: %v", err)), nil
+	}
+
+	if len(podList.Items) == 0 {
+		return mcp.NewToolResultText(fmt.Sprintf("No Kmesh daemon pods found in namespace '%s' with label '%s'.", utils.KmeshNamespace, utils.KmeshLabel)), nil
+	}
+
+	// Format output
+	var result string
+	result += "Kmesh Daemon Pods:\n"
+	for _, pod := range podList.Items {
+		result += fmt.Sprintf("- Name: %s (Node: %s, Status: %s, IP: %s)\n",
+			pod.Name,
+			pod.Spec.NodeName,
+			pod.Status.Phase,
+			pod.Status.PodIP,
+		)
+	}
+
+	return mcp.NewToolResultText(result), nil
+}

--- a/mcp/tools/log/log.go
+++ b/mcp/tools/log/log.go
@@ -1,0 +1,184 @@
+package log
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+
+	"kmesh.net/kmesh/ctl/utils"
+	"kmesh.net/kmesh/pkg/logger"
+)
+
+var logScope = logger.NewLoggerScope("mcp-server/tools/log")
+
+const patternLoggers = "/debug/loggers"
+
+type LoggerInfo struct {
+	Name  string `json:"name,omitempty"`
+	Level string `json:"level,omitempty"`
+}
+
+// Register registers the log related tools to the MCP server
+func Register(srv *server.MCPServer) {
+	// 1. Tool to GET logs
+	getTool := mcp.NewTool("kmesh_log_get",
+		mcp.WithDescription("Get the kmesh-daemon's logger levels. Returns a list of loggers if loggerName is empty, or the specific logger level if provided."),
+		mcp.WithString("podName", mcp.Description("The Kmesh daemon pod name to target (e.g., kmesh-xxx)"), mcp.Required()),
+		mcp.WithString("loggerName", mcp.Description("Optional logger name. If omitted, lists all available loggers.")),
+	)
+	srv.AddTool(getTool, kmeshLogGetHandler)
+
+	// 2. Tool to SET logs
+	setTool := mcp.NewTool("kmesh_log_set",
+		mcp.WithDescription("Set the kmesh-daemon's logger level (e.g., debug, info, warn, error)."),
+		mcp.WithString("podName", mcp.Description("The Kmesh daemon pod name to target"), mcp.Required()),
+		mcp.WithString("loggerName", mcp.Description("The logger name to update (e.g., 'default' or 'bpf')"), mcp.Required()),
+		mcp.WithString("loggerLevel", mcp.Description("The new logger level (e.g., debug, info, warn, error)"), mcp.Required()),
+	)
+	srv.AddTool(setTool, kmeshLogSetHandler)
+
+	logScope.Infof("Registered tools: kmesh_log_get, kmesh_log_set")
+}
+
+func kmeshLogGetHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	podName, ok := request.Params.Arguments["podName"].(string)
+	if !ok || podName == "" {
+		return mcp.NewToolResultError("podName argument is required"), nil
+	}
+
+	loggerName, _ := request.Params.Arguments["loggerName"].(string)
+
+	cli, err := utils.CreateKubeClient()
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to create kube client: %v", err)), nil
+	}
+
+	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to create port forwarder for pod %s: %v", podName, err)), nil
+	}
+	if err := fw.Start(); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to start port forwarder: %v", err)), nil
+	}
+	defer fw.Close()
+
+	url := fmt.Sprintf("http://%s%s", fw.Address(), patternLoggers)
+	if loggerName != "" {
+		url += fmt.Sprintf("?name=%s", loggerName)
+		
+		// Get specific logger
+		var loggerInfo LoggerInfo
+		if err := getJSON(url, &loggerInfo); err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("failed to get logger level: %v", err)), nil
+		}
+		return mcp.NewToolResultText(fmt.Sprintf("Logger Name: %s\nLogger Level: %s", loggerInfo.Name, loggerInfo.Level)), nil
+	}
+
+	// Get all loggers
+	var loggerNames []string
+	if err := getJSON(url, &loggerNames); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to get logger names: %v", err)), nil
+	}
+
+	result := "Existing Loggers:\n"
+	for _, name := range loggerNames {
+		result += fmt.Sprintf("- %s\n", name)
+	}
+	return mcp.NewToolResultText(result), nil
+}
+
+func kmeshLogSetHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	podName, ok := request.Params.Arguments["podName"].(string)
+	if !ok || podName == "" {
+		return mcp.NewToolResultError("podName argument is required"), nil
+	}
+
+	loggerName, ok := request.Params.Arguments["loggerName"].(string)
+	if !ok || loggerName == "" {
+		return mcp.NewToolResultError("loggerName argument is required"), nil
+	}
+
+	loggerLevel, ok := request.Params.Arguments["loggerLevel"].(string)
+	if !ok || loggerLevel == "" {
+		return mcp.NewToolResultError("loggerLevel argument is required"), nil
+	}
+
+	cli, err := utils.CreateKubeClient()
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to create kube client: %v", err)), nil
+	}
+
+	fw, err := utils.CreateKmeshPortForwarder(cli, podName)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to create port forwarder for pod %s: %v", podName, err)), nil
+	}
+	if err := fw.Start(); err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to start port forwarder: %v", err)), nil
+	}
+	defer fw.Close()
+
+	url := fmt.Sprintf("http://%s%s", fw.Address(), patternLoggers)
+
+	loggerInfo := LoggerInfo{
+		Name:  loggerName,
+		Level: loggerLevel,
+	}
+	data, err := json.Marshal(loggerInfo)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("error marshaling logger info: %v", err)), nil
+	}
+
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(data))
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("error creating request: %v", err)), nil
+	}
+	req.Header.Set("Content-Type", "application/json")
+	
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to make HTTP request: %v", err)), nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return mcp.NewToolResultError(fmt.Sprintf("error: received status code %d", resp.StatusCode)), nil
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to read HTTP response body: %v", err)), nil
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf("Success: %s", string(body))), nil
+}
+
+func getJSON(url string, val any) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed making GET request(%s): %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed reading response body(%s): %v", url, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("received status code %d, Response body: %s", resp.StatusCode, body)
+	}
+
+	err = json.Unmarshal(body, val)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal response body: %v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
This PR implements the **Kmesh Log MCP Tools** (`kmesh_log_get` and `kmesh_log_set`). 

To make Kmesh AI-Native, AI agents need the ability to inspect and dynamically modify internal debugging states. This PR:
1. Introduces the new `mcp/tools/log` package.
2. Implements `kmesh_log_get`: Allows AI agents to retrieve a list of all available loggers or query the active logging level (e.g., debug, info, warn) of a specific logger on a given Kmesh daemon pod.
3. Implements `kmesh_log_set`: Allows AI agents to dynamically update the logging level of a specific logger in real-time.
4. Registers these tools with the central Kmesh MCP Server.

By exposing these as MCP tools, an AI agent can dynamically increase the logging level to `debug`, reproduce or observe a failure, retrieve the resulting logs, and then revert the logging level back to `info`—all autonomously.

**Which issue(s) this PR fixes**:
Fixes #1922

**Special notes for your reviewer**:
This tool reuses the existing `kmeshctl` logic and `CreateKmeshPortForwarder` to ensure that HTTP API requests hitting the Kmesh daemon (`/debug/loggers`) follow the exact same security and routing paths as the standard CLI. 

**Does this PR introduce a user-facing change?**:
```release-note
Added the `kmesh_log_get` and `kmesh_log_set` tools to the Kmesh MCP server, enabling AI agents to dynamically retrieve and modify daemon logging levels.

