### PR TITLE
feat(cli): add structured output formatting (-o json/yaml)

### DIFF
--- a/ctl/authz/authz.go
+++ b/ctl/authz/authz.go
@@ -113,11 +113,11 @@ func NewStatusCmd() *cobra.Command {
 			}
 
 			// Prepare a slice of podStatuses. We can pre-allocate since we know how many pods we'll check.
-			type podStatus struct {
-				Pod    string
-				Status string
+			type PodStatus struct {
+				Pod    string `json:"pod"`
+				Status string `json:"status"`
 			}
-			statuses := make([]podStatus, 0, len(podNames))
+			statuses := make([]PodStatus, 0, len(podNames))
 
 			// Collect the status for each pod.
 			for _, podName := range podNames {
@@ -126,7 +126,14 @@ func NewStatusCmd() *cobra.Command {
 					log.Errorf("failed to get authz status for pod %s: %v", podName, err)
 					continue
 				}
-				statuses = append(statuses, podStatus{Pod: podName, Status: status})
+				statuses = append(statuses, PodStatus{Pod: podName, Status: status})
+			}
+
+			if handled, err := utils.PrintOutput(cmd, statuses); err != nil {
+				log.Errorf("failed to print output: %v", err)
+				os.Exit(1)
+			} else if handled {
+				return
 			}
 
 			// Output the results in a table format.

--- a/ctl/common/common.go
+++ b/ctl/common/common.go
@@ -38,6 +38,8 @@ func GetRootCommand() *cobra.Command {
 		},
 	}
 
+	rootCmd.PersistentFlags().StringP("output", "o", "", "Output format. One of: json|yaml")
+
 	rootCmd.AddCommand(logcmd.NewCmd())
 	rootCmd.AddCommand(dump.NewCmd())
 	rootCmd.AddCommand(waypoint.NewCmd())

--- a/ctl/log/log.go
+++ b/ctl/log/log.go
@@ -87,10 +87,17 @@ func GetJson(url string, val any) error {
 	return nil
 }
 
-func GetLoggerNames(url string) {
+func GetLoggerNames(cmd *cobra.Command, url string) {
 	var loggerNames []string
 	if err := GetJson(url, &loggerNames); err != nil {
 		log.Errorf("failed to get logger names: %v", err)
+		return
+	}
+
+	if handled, err := utils.PrintOutput(cmd, loggerNames); err != nil {
+		log.Errorf("failed to print output: %v", err)
+		os.Exit(1)
+	} else if handled {
 		return
 	}
 
@@ -100,10 +107,17 @@ func GetLoggerNames(url string) {
 	}
 }
 
-func GetLoggerLevel(url string) {
+func GetLoggerLevel(cmd *cobra.Command, url string) {
 	var loggerInfo LoggerInfo
 	if err := GetJson(url, &loggerInfo); err != nil {
 		log.Errorf("failed to get logger level: %v", err)
+		return
+	}
+
+	if handled, err := utils.PrintOutput(cmd, loggerInfo); err != nil {
+		log.Errorf("failed to print output: %v", err)
+		os.Exit(1)
+	} else if handled {
 		return
 	}
 
@@ -182,9 +196,9 @@ func RunGetOrSetLoggerLevel(cmd *cobra.Command, args []string) {
 	if setFlag == "" {
 		if len(args) >= 2 {
 			url += fmt.Sprintf("?name=%s", args[1])
-			GetLoggerLevel(url)
+			GetLoggerLevel(cmd, url)
 		} else {
-			GetLoggerNames(url)
+			GetLoggerNames(cmd, url)
 		}
 	} else {
 		SetLoggerLevel(url, setFlag)

--- a/ctl/secret/secret.go
+++ b/ctl/secret/secret.go
@@ -85,7 +85,7 @@ kmeshctl secret create --key=$(echo -n "{36-character user-defined key here}" | 
 kmeshctl secret get`,
 		Args: cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			GetSecret()
+			GetSecret(cmd)
 		},
 	}
 
@@ -198,7 +198,7 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 	}
 }
 
-func GetSecret() {
+func GetSecret(cmd *cobra.Command) {
 	secret, err := clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Get(context.TODO(), SecretName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
@@ -232,6 +232,13 @@ func GetSecret() {
 		AeadKeyName: ipSecKey.AeadKeyName,
 		AeadKey:     hex.EncodeToString(ipSecKey.AeadKey),
 		Length:      ipSecKey.Length,
+	}
+
+	if handled, err := utils.PrintOutput(cmd, displayKey); err != nil {
+		log.Errorf("failed to print output: %v", err)
+		os.Exit(1)
+	} else if handled {
+		return
 	}
 
 	displayData, err := json.MarshalIndent(displayKey, "", "  ")

--- a/ctl/utils/printer.go
+++ b/ctl/utils/printer.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+)
+
+// PrintOutput checks if the global --output (-o) flag is set on the command.
+// If it is set to "json" or "yaml", it marshals the data appropriately, prints it to stdout,
+// and returns true (indicating to the caller that default table/text formatting can be skipped).
+// If no output format is specified, it returns false.
+func PrintOutput(cmd *cobra.Command, data interface{}) (bool, error) {
+	outputFlag, err := cmd.Flags().GetString("output")
+	if err != nil {
+		// Flag might not be defined on some commands, default to normal output
+		return false, nil
+	}
+
+	switch outputFlag {
+	case "json":
+		b, err := json.MarshalIndent(data, "", "  ")
+		if err != nil {
+			return false, fmt.Errorf("failed to marshal json: %w", err)
+		}
+		fmt.Println(string(b))
+		return true, nil
+	case "yaml", "yml":
+		b, err := yaml.Marshal(data)
+		if err != nil {
+			return false, fmt.Errorf("failed to marshal yaml: %w", err)
+		}
+		fmt.Print(string(b)) // yaml.Marshal already appends a newline
+		return true, nil
+	case "":
+		return false, nil
+	default:
+		// Unsupported output format, fallback to default or throw error
+		return false, fmt.Errorf("unsupported output format: %s", outputFlag)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
This PR introduces structured output formatting to `kmeshctl`, a highly requested quality-of-life feature for DevOps engineers and CI/CD pipelines.

Currently, `kmeshctl` commands output data strictly as plain-text tables or strings, making it difficult to parse programmatically. This PR:
1. Adds a global `--output` (or `-o`) persistent flag to the root `kmeshctl` command.
2. Introduces a centralized `ctl/utils/printer.go` utility to marshal internal Go structs into JSON or YAML seamlessly.
3. Refactors the `authz status`, `log`, and `secret get` commands to natively support structured output via the new printer. 

When the `-o json` or `-o yaml` flag is omitted, the CLI gracefully falls back to the exact same human-readable table/text formats as before, ensuring 100% backward compatibility.

**Which issue(s) this PR fixes**:
Fixes #1924 

**Special notes for your reviewer**:
The `sigs.k8s.io/yaml` and `encoding/json` libraries are leveraged within `printer.go` for the struct marshaling. We've ensured that internal data structures (like `PodStatus` in the `authz` command) have their fields correctly exported and tagged with `json:""` decorators so they serialize cleanly.

**Does this PR introduce a user-facing change?**:
```release-note
Added `--output json` and `--output yaml` (or `-o`) flags to `kmeshctl` commands to support structured, machine-readable output formatting.
