### PR TITLE
fix(ctl/dump): stop execution when port-forward fails to start

### DIFF
--- a/ctl/dump/dump.go
+++ b/ctl/dump/dump.go
@@ -87,6 +87,7 @@ func RunDump(cmd *cobra.Command, args []string, outputFormat string) error {
 	}
 	if err := fw.Start(); err != nil {
 		log.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
+		os.Exit(1)
 	}
 
 	url := fmt.Sprintf("http://%s%s/%s", fw.Address(), configDumpPrefix, mode)

--- a/ctl/dump/dump.go
+++ b/ctl/dump/dump.go
@@ -89,6 +89,7 @@ func RunDump(cmd *cobra.Command, args []string, outputFormat string) error {
 		log.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
 		os.Exit(1)
 	}
+	defer fw.Close()
 
 	url := fmt.Sprintf("http://%s%s/%s", fw.Address(), configDumpPrefix, mode)
 	resp, err := http.Get(url)


### PR DESCRIPTION
Fixes: #1926 
RunDump logged a port-forward start failure but kept running, going on to call http.Get() against a local address with nothing forwarded to it. This produced a confusing secondary connection refused error that masked the real failure reason.