### PR TITLE
refactor(constants): share the daemon admin API paths

### DIFF
--- a/ctl/authz/authz.go
+++ b/ctl/authz/authz.go
@@ -28,12 +28,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"kmesh.net/kmesh/ctl/utils"
+	"kmesh.net/kmesh/pkg/constants"
 	"kmesh.net/kmesh/pkg/kube"
 	"kmesh.net/kmesh/pkg/logger"
-)
-
-const (
-	patternAuthz = "/authz"
 )
 
 var log = logger.NewLoggerScope("kmeshctl/authz")
@@ -184,7 +181,7 @@ func SetAuthzPerKmeshDaemon(cli kube.CLIClient, podName, info string) {
 	}
 	defer fw.Close()
 
-	url := fmt.Sprintf("http://%s%s?enable=%s", fw.Address(), patternAuthz, info)
+	url := fmt.Sprintf("http://%s%s?enable=%s", fw.Address(), constants.AdminPathAuthz, info)
 
 	req, err := http.NewRequest(http.MethodPost, url, nil)
 	if err != nil {
@@ -219,7 +216,7 @@ func fetchAuthzStatus(cli kube.CLIClient, podName string) (string, error) {
 	}
 	defer fw.Close()
 
-	url := fmt.Sprintf("http://%s%s", fw.Address(), patternAuthz)
+	url := fmt.Sprintf("http://%s%s", fw.Address(), constants.AdminPathAuthz)
 
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {

--- a/ctl/dump/dump.go
+++ b/ctl/dump/dump.go
@@ -36,10 +36,6 @@ import (
 	"kmesh.net/kmesh/pkg/logger"
 )
 
-const (
-	configDumpPrefix = "/debug/config_dump"
-)
-
 var log = logger.NewLoggerScope("kmeshctl/dump")
 
 func NewCmd() *cobra.Command {
@@ -89,7 +85,7 @@ func RunDump(cmd *cobra.Command, args []string, outputFormat string) error {
 		log.Errorf("failed to start port forwarder for Kmesh daemon pod %s: %v", podName, err)
 	}
 
-	url := fmt.Sprintf("http://%s%s/%s", fw.Address(), configDumpPrefix, mode)
+	url := fmt.Sprintf("http://%s%s/%s", fw.Address(), constants.AdminPathConfigDumpPrefix, mode)
 	resp, err := http.Get(url)
 	if err != nil {
 		log.Errorf("failed to make HTTP request: %v", err)

--- a/ctl/log/log.go
+++ b/ctl/log/log.go
@@ -28,11 +28,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"kmesh.net/kmesh/ctl/utils"
+	"kmesh.net/kmesh/pkg/constants"
 	"kmesh.net/kmesh/pkg/logger"
-)
-
-const (
-	patternLoggers = "/debug/loggers"
 )
 
 var log = logger.NewLoggerScope("kmeshctl/log")
@@ -176,7 +173,7 @@ func RunGetOrSetLoggerLevel(cmd *cobra.Command, args []string) {
 	}
 	defer fw.Close()
 
-	url := fmt.Sprintf("http://%s%s", fw.Address(), patternLoggers)
+	url := fmt.Sprintf("http://%s%s", fw.Address(), constants.AdminPathLoggers)
 
 	setFlag, _ := cmd.Flags().GetString("set")
 	if setFlag == "" {

--- a/ctl/monitoring/monitoring.go
+++ b/ctl/monitoring/monitoring.go
@@ -28,15 +28,9 @@ import (
 	"github.com/spf13/cobra"
 
 	"kmesh.net/kmesh/ctl/utils"
+	"kmesh.net/kmesh/pkg/constants"
 	"kmesh.net/kmesh/pkg/kube"
 	"kmesh.net/kmesh/pkg/logger"
-)
-
-const (
-	patternAccesslog         = "/accesslog"
-	patternMonitoring        = "/monitoring"
-	patternWorkloadMetrics   = "/workload_metrics"
-	patternConnectionMetrics = "/connection_metrics"
 )
 
 // Different types of monitoring
@@ -108,16 +102,16 @@ func ControlMonitoring(cmd *cobra.Command, args []string) {
 	if hasKmeshPod {
 		// Processes triggers for specified kmesh daemon.
 		if allFlag != "" {
-			SetObservabilityPerKmeshDaemon(client, podName, allFlag, MONITORING, patternMonitoring)
+			SetObservabilityPerKmeshDaemon(client, podName, allFlag, MONITORING, constants.AdminPathMonitoring)
 		}
 		if accesslogFlag != "" {
-			SetObservabilityPerKmeshDaemon(client, podName, accesslogFlag, ACCESSLOG, patternAccesslog)
+			SetObservabilityPerKmeshDaemon(client, podName, accesslogFlag, ACCESSLOG, constants.AdminPathAccesslog)
 		}
 		if workloadMetricsFlag != "" {
-			SetObservabilityPerKmeshDaemon(client, podName, workloadMetricsFlag, WORKLOAD, patternWorkloadMetrics)
+			SetObservabilityPerKmeshDaemon(client, podName, workloadMetricsFlag, WORKLOAD, constants.AdminPathWorkloadMetrics)
 		}
 		if connectionMetricsFlag != "" {
-			SetObservabilityPerKmeshDaemon(client, podName, connectionMetricsFlag, CONNECTION, patternConnectionMetrics)
+			SetObservabilityPerKmeshDaemon(client, podName, connectionMetricsFlag, CONNECTION, constants.AdminPathConnectionMetrics)
 		}
 	} else {
 		// Perform operations on all kmesh daemons.
@@ -128,16 +122,16 @@ func ControlMonitoring(cmd *cobra.Command, args []string) {
 		}
 		for _, pod := range podList.Items {
 			if allFlag != "" {
-				SetObservabilityPerKmeshDaemon(client, pod.GetName(), allFlag, MONITORING, patternMonitoring)
+				SetObservabilityPerKmeshDaemon(client, pod.GetName(), allFlag, MONITORING, constants.AdminPathMonitoring)
 			}
 			if accesslogFlag != "" {
-				SetObservabilityPerKmeshDaemon(client, pod.GetName(), accesslogFlag, ACCESSLOG, patternAccesslog)
+				SetObservabilityPerKmeshDaemon(client, pod.GetName(), accesslogFlag, ACCESSLOG, constants.AdminPathAccesslog)
 			}
 			if workloadMetricsFlag != "" {
-				SetObservabilityPerKmeshDaemon(client, pod.GetName(), workloadMetricsFlag, WORKLOAD, patternWorkloadMetrics)
+				SetObservabilityPerKmeshDaemon(client, pod.GetName(), workloadMetricsFlag, WORKLOAD, constants.AdminPathWorkloadMetrics)
 			}
 			if connectionMetricsFlag != "" {
-				SetObservabilityPerKmeshDaemon(client, pod.GetName(), connectionMetricsFlag, CONNECTION, patternConnectionMetrics)
+				SetObservabilityPerKmeshDaemon(client, pod.GetName(), connectionMetricsFlag, CONNECTION, constants.AdminPathConnectionMetrics)
 			}
 		}
 	}

--- a/ctl/version/version.go
+++ b/ctl/version/version.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"kmesh.net/kmesh/ctl/utils"
+	"kmesh.net/kmesh/pkg/constants"
 	"kmesh.net/kmesh/pkg/kube"
 	"kmesh.net/kmesh/pkg/logger"
 	"kmesh.net/kmesh/pkg/version"
@@ -118,7 +119,7 @@ func getVersion(client kube.CLIClient, podName string) (version version.Info) {
 	}
 	defer fw.Close()
 
-	url := fmt.Sprintf("http://%s/version", fw.Address())
+	url := fmt.Sprintf("http://%s%s", fw.Address(), constants.AdminPathVersion)
 	resp, err := http.Get(url)
 	if err != nil {
 		log.Errorf("failed to make HTTP request: %v", err)

--- a/pkg/constants/admin.go
+++ b/pkg/constants/admin.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package constants
+
+const (
+	AdminPathVersion    = "/version"
+	AdminPathReadyProbe = "/debug/ready"
+	AdminPathLoggers    = "/debug/loggers"
+	AdminPathAuthz      = "/authz"
+
+	AdminPathConfigDumpPrefix   = "/debug/config_dump"
+	AdminPathConfigDumpAds      = AdminPathConfigDumpPrefix + "/" + KernelNativeMode
+	AdminPathConfigDumpWorkload = AdminPathConfigDumpPrefix + "/" + DualEngineMode
+	AdminPathBpfAdsMaps         = AdminPathConfigDumpPrefix + "/bpf/" + KernelNativeMode
+	AdminPathBpfWorkloadMaps    = AdminPathConfigDumpPrefix + "/bpf/" + DualEngineMode
+
+	AdminPathAccesslog         = "/accesslog"
+	AdminPathMonitoring        = "/monitoring"
+	AdminPathWorkloadMetrics   = "/workload_metrics"
+	AdminPathConnectionMetrics = "/connection_metrics"
+)

--- a/pkg/constants/admin_test.go
+++ b/pkg/constants/admin_test.go
@@ -1,0 +1,45 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package constants
+
+import "testing"
+
+func TestAdminPaths(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"version", AdminPathVersion, "/version"},
+		{"ready probe", AdminPathReadyProbe, "/debug/ready"},
+		{"loggers", AdminPathLoggers, "/debug/loggers"},
+		{"authz", AdminPathAuthz, "/authz"},
+		{"config dump prefix", AdminPathConfigDumpPrefix, "/debug/config_dump"},
+		{"config dump kernel-native", AdminPathConfigDumpAds, "/debug/config_dump/kernel-native"},
+		{"config dump dual-engine", AdminPathConfigDumpWorkload, "/debug/config_dump/dual-engine"},
+		{"bpf maps kernel-native", AdminPathBpfAdsMaps, "/debug/config_dump/bpf/kernel-native"},
+		{"bpf maps dual-engine", AdminPathBpfWorkloadMaps, "/debug/config_dump/bpf/dual-engine"},
+		{"accesslog", AdminPathAccesslog, "/accesslog"},
+		{"monitoring", AdminPathMonitoring, "/monitoring"},
+		{"workload metrics", AdminPathWorkloadMetrics, "/workload_metrics"},
+		{"connection metrics", AdminPathConnectionMetrics, "/connection_metrics"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s path = %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}

--- a/pkg/status/status_server.go
+++ b/pkg/status/status_server.go
@@ -47,20 +47,6 @@ var log = logger.NewLoggerScope("status")
 const (
 	adminAddr = "localhost:15200"
 
-	patternVersion            = "/version"
-	patternBpfAdsMaps         = "/debug/config_dump/bpf/kernel-native"
-	patternBpfWorkloadMaps    = "/debug/config_dump/bpf/dual-engine"
-	configDumpPrefix          = "/debug/config_dump"
-	patternConfigDumpAds      = configDumpPrefix + "/kernel-native"
-	patternConfigDumpWorkload = configDumpPrefix + "/dual-engine"
-	patternReadyProbe         = "/debug/ready"
-	patternLoggers            = "/debug/loggers"
-	patternAccesslog          = "/accesslog"
-	patternMonitoring         = "/monitoring"
-	patternWorkloadMetrics    = "/workload_metrics"
-	patternConnectionMetrics  = "/connection_metrics"
-	patternAuthz              = "/authz"
-
 	bpfLoggerName = "bpf"
 
 	httpTimeout = time.Second * 20
@@ -90,20 +76,20 @@ func NewServer(c *controller.XdsClient, configs *options.BootstrapConfigs, loade
 		WriteTimeout: httpTimeout,
 	}
 
-	s.mux.HandleFunc(patternVersion, s.version)
-	s.mux.HandleFunc(patternBpfAdsMaps, s.bpfAdsMaps)
-	s.mux.HandleFunc(patternBpfWorkloadMaps, s.bpfWorkloadMaps)
-	s.mux.HandleFunc(patternConfigDumpAds, s.configDumpAds)
-	s.mux.HandleFunc(patternConfigDumpWorkload, s.configDumpWorkload)
-	s.mux.HandleFunc(patternLoggers, s.loggersHandler)
-	s.mux.HandleFunc(patternAccesslog, s.accesslogHandler)
-	s.mux.HandleFunc(patternMonitoring, s.monitoringHandler)
-	s.mux.HandleFunc(patternWorkloadMetrics, s.workloadMetricHandler)
-	s.mux.HandleFunc(patternConnectionMetrics, s.connectionMetricHandler)
-	s.mux.HandleFunc(patternAuthz, s.authzHandler)
+	s.mux.HandleFunc(constants.AdminPathVersion, s.version)
+	s.mux.HandleFunc(constants.AdminPathBpfAdsMaps, s.bpfAdsMaps)
+	s.mux.HandleFunc(constants.AdminPathBpfWorkloadMaps, s.bpfWorkloadMaps)
+	s.mux.HandleFunc(constants.AdminPathConfigDumpAds, s.configDumpAds)
+	s.mux.HandleFunc(constants.AdminPathConfigDumpWorkload, s.configDumpWorkload)
+	s.mux.HandleFunc(constants.AdminPathLoggers, s.loggersHandler)
+	s.mux.HandleFunc(constants.AdminPathAccesslog, s.accesslogHandler)
+	s.mux.HandleFunc(constants.AdminPathMonitoring, s.monitoringHandler)
+	s.mux.HandleFunc(constants.AdminPathWorkloadMetrics, s.workloadMetricHandler)
+	s.mux.HandleFunc(constants.AdminPathConnectionMetrics, s.connectionMetricHandler)
+	s.mux.HandleFunc(constants.AdminPathAuthz, s.authzHandler)
 
 	// TODO: add dump certificate, authorizationPolicies and services
-	s.mux.HandleFunc(patternReadyProbe, s.readyProbe)
+	s.mux.HandleFunc(constants.AdminPathReadyProbe, s.readyProbe)
 
 	// support pprof
 	s.mux.HandleFunc("/debug/pprof/", pprof.Index)

--- a/pkg/status/status_server_test.go
+++ b/pkg/status/status_server_test.go
@@ -62,7 +62,7 @@ func TestServer_getLoggerLevel(t *testing.T) {
 	}
 	loggerNames := logger.GetLoggerNames()
 	for _, loggerName := range loggerNames {
-		getLoggerUrl := patternLoggers + "?name=" + loggerName
+		getLoggerUrl := constants.AdminPathLoggers + "?name=" + loggerName
 		req := httptest.NewRequest(http.MethodGet, getLoggerUrl, nil)
 		w := httptest.NewRecorder()
 		server.getLoggerLevel(w, req)
@@ -80,7 +80,7 @@ func TestServer_getLoggerLevel(t *testing.T) {
 		assert.Equal(t, loggerInfo.Name, loggerName)
 	}
 
-	req := httptest.NewRequest(http.MethodGet, patternLoggers, nil)
+	req := httptest.NewRequest(http.MethodGet, constants.AdminPathLoggers, nil)
 	w := httptest.NewRecorder()
 	server.getLoggerLevel(w, req)
 
@@ -114,7 +114,7 @@ func TestServer_setLoggerLevel(t *testing.T) {
 		logrus.TraceLevel.String(),
 	}
 	for _, loggerName := range loggerNames {
-		setLoggerUrl := patternLoggers
+		setLoggerUrl := constants.AdminPathLoggers
 		for _, testLoggerLevel := range testLoggerLevels {
 			loggerInfo := LoggerInfo{
 				Name:  loggerName,
@@ -365,7 +365,7 @@ func TestServer_dumpWorkloadBpfMap(t *testing.T) {
 
 		// ads mode will failed
 		server := &Server{}
-		req := httptest.NewRequest(http.MethodPost, patternBpfWorkloadMaps, nil)
+		req := httptest.NewRequest(http.MethodPost, constants.AdminPathBpfWorkloadMaps, nil)
 		w := httptest.NewRecorder()
 		server.configDumpWorkload(w, req)
 
@@ -440,7 +440,7 @@ func TestServer_dumpWorkloadBpfMap(t *testing.T) {
 		_, err = bpfMaps.KmService.BatchUpdate(testServiceKeys, testServiceVals, nil)
 		assert.Nil(t, err)
 
-		req := httptest.NewRequest(http.MethodPost, patternBpfWorkloadMaps, nil)
+		req := httptest.NewRequest(http.MethodPost, constants.AdminPathBpfWorkloadMaps, nil)
 		w := httptest.NewRecorder()
 		server.bpfWorkloadMaps(w, req)
 		body, err := io.ReadAll(w.Body)
@@ -470,7 +470,7 @@ func TestServer_dumpAdsBpfMap(t *testing.T) {
 
 		// dual engine mode will fail
 		server := &Server{}
-		req := httptest.NewRequest(http.MethodGet, patternBpfWorkloadMaps, nil)
+		req := httptest.NewRequest(http.MethodGet, constants.AdminPathBpfWorkloadMaps, nil)
 		w := httptest.NewRecorder()
 		server.configDumpWorkload(w, req)
 
@@ -515,7 +515,7 @@ func TestServer_dumpAdsBpfMap(t *testing.T) {
 			maps_v2.ListenerUpdate(testListenerKey, testListener)
 		}
 
-		req := httptest.NewRequest(http.MethodGet, patternBpfAdsMaps, nil)
+		req := httptest.NewRequest(http.MethodGet, constants.AdminPathBpfAdsMaps, nil)
 		w := httptest.NewRecorder()
 		server.bpfAdsMaps(w, req)
 		body, err := io.ReadAll(w.Body)
@@ -553,26 +553,26 @@ func TestServerMetricHandler(t *testing.T) {
 		server.xdsClient.WorkloadController.MetricController.EnableConnectionMetric.Store(true)
 		server.xdsClient.WorkloadController.MetricController.EnableAccesslog.Store(false)
 
-		url := fmt.Sprintf("%s?enable=%s", patternMonitoring, "true")
+		url := fmt.Sprintf("%s?enable=%s", constants.AdminPathMonitoring, "true")
 		req := httptest.NewRequest(http.MethodPost, url, nil)
 		w := httptest.NewRecorder()
 		server.monitoringHandler(w, req)
 
-		url = fmt.Sprintf("%s?enable=%s", patternAccesslog, "false")
+		url = fmt.Sprintf("%s?enable=%s", constants.AdminPathAccesslog, "false")
 		req = httptest.NewRequest(http.MethodPost, url, nil)
 		w = httptest.NewRecorder()
 		server.accesslogHandler(w, req)
 
 		assert.Equal(t, false, server.xdsClient.WorkloadController.GetAccesslogTrigger())
 
-		url = fmt.Sprintf("%s?enable=%s", patternWorkloadMetrics, "false")
+		url = fmt.Sprintf("%s?enable=%s", constants.AdminPathWorkloadMetrics, "false")
 		req = httptest.NewRequest(http.MethodPost, url, nil)
 		w = httptest.NewRecorder()
 		server.workloadMetricHandler(w, req)
 
 		assert.Equal(t, false, server.xdsClient.WorkloadController.GetWorklaodMetricTrigger())
 
-		url = fmt.Sprintf("%s?enable=%s", patternConnectionMetrics, "false")
+		url = fmt.Sprintf("%s?enable=%s", constants.AdminPathConnectionMetrics, "false")
 		req = httptest.NewRequest(http.MethodPost, url, nil)
 		w = httptest.NewRecorder()
 		server.connectionMetricHandler(w, req)
@@ -600,28 +600,28 @@ func TestServerMetricHandler(t *testing.T) {
 
 		server.xdsClient.WorkloadController.MetricController.EnableAccesslog.Store(false)
 
-		url := fmt.Sprintf("%s?enable=%s", patternMonitoring, "false")
+		url := fmt.Sprintf("%s?enable=%s", constants.AdminPathMonitoring, "false")
 		req := httptest.NewRequest(http.MethodPost, url, nil)
 		w := httptest.NewRecorder()
 		server.monitoringHandler(w, req)
 
 		assert.Equal(t, false, server.xdsClient.WorkloadController.GetMonitoringTrigger())
 
-		url = fmt.Sprintf("%s?enable=%s", patternAccesslog, "true")
+		url = fmt.Sprintf("%s?enable=%s", constants.AdminPathAccesslog, "true")
 		req = httptest.NewRequest(http.MethodPost, url, nil)
 		w = httptest.NewRecorder()
 		server.accesslogHandler(w, req)
 
 		assert.Equal(t, false, server.xdsClient.WorkloadController.GetAccesslogTrigger())
 
-		url = fmt.Sprintf("%s?enable=%s", patternWorkloadMetrics, "true")
+		url = fmt.Sprintf("%s?enable=%s", constants.AdminPathWorkloadMetrics, "true")
 		req = httptest.NewRequest(http.MethodPost, url, nil)
 		w = httptest.NewRecorder()
 		server.workloadMetricHandler(w, req)
 
 		assert.Equal(t, false, server.xdsClient.WorkloadController.GetWorklaodMetricTrigger())
 
-		url = fmt.Sprintf("%s?enable=%s", patternConnectionMetrics, "true")
+		url = fmt.Sprintf("%s?enable=%s", constants.AdminPathConnectionMetrics, "true")
 		req = httptest.NewRequest(http.MethodPost, url, nil)
 		w = httptest.NewRecorder()
 		server.connectionMetricHandler(w, req)
@@ -651,7 +651,7 @@ func TestServerMonitoringHandler(t *testing.T) {
 		server.xdsClient.WorkloadController.MetricController.EnableMonitoring.Store(false)
 		server.xdsClient.WorkloadController.MetricController.EnableAccesslog.Store(false)
 
-		url := fmt.Sprintf("%s?enable=%s", patternMonitoring, "true")
+		url := fmt.Sprintf("%s?enable=%s", constants.AdminPathMonitoring, "true")
 		req := httptest.NewRequest(http.MethodPost, url, nil)
 		w := httptest.NewRecorder()
 		server.monitoringHandler(w, req)


### PR DESCRIPTION
While exploring the admin APIs , I noticed that the daemon's admin API paths are declared in `pkg/status`, and then declared again by every client that talks to it. I guess the reason for this is that `pkg/status` needs the generated eBPF objects to build, so no client can import it. so each one keeps its own copy instead. This kind of duplication can cause bugs in the repo I did raise #1854  fixing a similar kind of bug. 

This PR moves the paths to `pkg/constants` and has both sides use them. `pkg/constants` has no eBPF dependencies and is already imported by `pkg/status` and by `ctl/dump`, so no new dependency edges are introduced. It aslo updates the call sites and adds a test to check the value of these constants.

No behaviour change.

**What type of PR is this?**

<!--
Add one of the following kinds:
/kind cleanup

-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required.
-->
```release-note
No
```
