### PR TITLE
kmeshctl: escape logger name in the log query URL

### DIFF
--- a/ctl/log/log.go
+++ b/ctl/log/log.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 
@@ -61,6 +62,20 @@ kmeshctl log <kmesh-daemon-pod> default`,
 	}
 	cmd.Flags().String("set", "", "Set the logger level (e.g., default:debug)")
 	return cmd
+}
+
+// loggerLevelURL builds the URL that queries a single logger's level.
+//
+// The name comes straight from the command line, so it has to be escaped. A
+// name containing a space builds a malformed request line that the daemon's
+// HTTP server rejects before routing, and the caller sees a bare
+// "400 Bad Request" instead of the daemon's own "logger <name> does not exist".
+// That matters because Kmesh logs tag every line with a subsys field, and those
+// values ("cni installer", "cache/v2") read like logger names even though the
+// daemon only registers default, fileOnly and bpf. Someone reading logs will
+// reasonably try one, and should get told what is actually wrong.
+func loggerLevelURL(base, name string) string {
+	return base + "?name=" + url.QueryEscape(name)
 }
 
 func GetJson(url string, val any) error {
@@ -176,17 +191,16 @@ func RunGetOrSetLoggerLevel(cmd *cobra.Command, args []string) {
 	}
 	defer fw.Close()
 
-	url := fmt.Sprintf("http://%s%s", fw.Address(), patternLoggers)
+	loggersURL := fmt.Sprintf("http://%s%s", fw.Address(), patternLoggers)
 
 	setFlag, _ := cmd.Flags().GetString("set")
 	if setFlag == "" {
 		if len(args) >= 2 {
-			url += fmt.Sprintf("?name=%s", args[1])
-			GetLoggerLevel(url)
+			GetLoggerLevel(loggerLevelURL(loggersURL, args[1]))
 		} else {
-			GetLoggerNames(url)
+			GetLoggerNames(loggersURL)
 		}
 	} else {
-		SetLoggerLevel(url, setFlag)
+		SetLoggerLevel(loggersURL, setFlag)
 	}
 }

--- a/ctl/log/log_test.go
+++ b/ctl/log/log_test.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package logs
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestLoggerLevelURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		loggerName string
+		want       string
+	}{
+		{
+			name:       "plain name is unchanged",
+			loggerName: "default",
+			want:       "http://127.0.0.1:15200/debug/loggers?name=default",
+		},
+		{
+			// Kmesh tags log lines with subsys values like this one, so it is a
+			// plausible thing for someone to type even though it is not a
+			// registered logger.
+			name:       "name containing a space is escaped",
+			loggerName: "cni installer",
+			want:       "http://127.0.0.1:15200/debug/loggers?name=cni+installer",
+		},
+		{
+			name:       "name containing slashes is escaped",
+			loggerName: "cache/v2",
+			want:       "http://127.0.0.1:15200/debug/loggers?name=cache%2Fv2",
+		},
+	}
+
+	const base = "http://127.0.0.1:15200/debug/loggers"
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := loggerLevelURL(base, tt.loggerName); got != tt.want {
+				t.Errorf("loggerLevelURL(%q) = %q, want %q", tt.loggerName, got, tt.want)
+			}
+		})
+	}
+}
+
+// The name must survive the round trip to the daemon. An unescaped space builds
+// a malformed request line that the server rejects before routing, so the
+// handler never sees the name and the caller gets a bare 400 rather than the
+// daemon's own explanation.
+func TestLoggerLevelURLReachesHandler(t *testing.T) {
+	for _, loggerName := range []string{"default", "cni installer", "cache/v2"} {
+		t.Run(loggerName, func(t *testing.T) {
+			var got string
+			handlerRan := false
+
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handlerRan = true
+				got = r.URL.Query().Get("name")
+				fmt.Fprintf(w, `{"name":%q,"level":"info"}`, got)
+			}))
+			defer srv.Close()
+
+			var info LoggerInfo
+			if err := GetJson(loggerLevelURL(srv.URL+patternLoggers, loggerName), &info); err != nil {
+				t.Fatalf("GetJson for logger %q: %v", loggerName, err)
+			}
+
+			if !handlerRan {
+				t.Fatalf("the daemon handler never ran for logger %q", loggerName)
+			}
+			if got != loggerName {
+				t.Errorf("daemon received name %q, want %q", got, loggerName)
+			}
+			if info.Name != loggerName {
+				t.Errorf("decoded name %q, want %q", info.Name, loggerName)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The logger name comes straight from the command line and went into the query string unescaped. A name containing a space builds a malformed request line, which the daemon's HTTP server rejects before routing, so the handler never runs and the user gets a bare `400 Bad Request`.

Before:

```
$ kmeshctl log <pod> "cni installer"
failed to get logger level: received status code 400, Response body: 400 Bad Request
```

After:

```
$ kmeshctl log <pod> "cni installer"
failed to get logger level: received status code 400, Response body: 	logger cni installer does not exist
```

Both verified against a kmesh-daemon running in a kind cluster, using kmeshctl built from `upstream/main` and from this branch.

This is worth fixing because the daemon registers only `default`, `fileOnly` and `bpf`, while Kmesh tags every log line with a `subsys` field whose values (`cni installer`, `cache/v2`, `manage_controller`) read like logger names. Someone who tries one of those is already asking for something that doesn't exist, and the daemon has a message saying so. The unescaped URL is what stops them from seeing it.

This moves the URL building into `loggerLevelURL` and escapes the name there. The local variable was renamed from `url` to `loggersURL` since it shadowed the `net/url` package.

`--set` is unaffected, since that path sends the name in the POST body.

**Which issue(s) this PR fixes**:
Fixes #1929

**Testing**:

Added `ctl/log/log_test.go`, which this package did not have. `TestLoggerLevelURL` covers the escaping directly and `TestLoggerLevelURLReachesHandler` asserts the name arrives at the handler intact.

Without the fix the second one fails with the same error the CLI shows:

```
--- FAIL: TestLoggerLevelURLReachesHandler/cni_installer
    log_test.go:78: GetJson for logger "cni installer": received status code 400, Response body: 400 Bad Request
```

**Special notes for your reviewer**:

I found this while building a prototype MCP server for #1800 that wraps `/debug/loggers` as a tool. My own client had the same bug.

Worth flagging: the first version of #1929 claimed `cni installer` was a registered logger that `kmeshctl log <pod>` lists. That was wrong. `NewLoggerScope` attaches a `subsys` field to the default logger rather than registering a new one, so the real list is just the three above. I caught it by standing up a kind cluster and testing against a real daemon, and I have corrected the issue. The escaping bug itself reproduces exactly as shown.

I used an AI coding assistant (Claude) to help investigate this and write the test. I reviewed and understand every line here and can answer questions about any of it in review.

**Does this PR introduce a user-facing change?**:
```release-note
fix: `kmeshctl log <pod> <logger>` now escapes the logger name, so a name containing a space returns the daemon's error instead of a bare 400.
```
