### PR TITLE
fix(dns): use write lock when updating cache entry addresses

### DIFF
--- a/pkg/dns/dns.go
+++ b/pkg/dns/dns.go
@@ -147,9 +147,9 @@ func (r *DNSResolver) resolve(domainName string) ([]string, time.Duration, error
 		return []string{}, DeRefreshInterval, fmt.Errorf("dns resolve failed: %v", err)
 	}
 
-	r.RLock()
+	r.Lock()
 	entry.Addresses = addrs
-	r.RUnlock()
+	r.Unlock()
 
 	return addrs, ttl, nil
 }

--- a/pkg/dns/dns_test.go
+++ b/pkg/dns/dns_test.go
@@ -142,3 +142,32 @@ func TestDNS(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// resolve() writes entry.Addresses after taking only RLock, so two resolves for
+// the same domain running at once race on that write. Catches it under -race.
+func TestResolveConcurrentSameDomain(t *testing.T) {
+	fakeDNSServer := NewFakeDNSServer()
+	fakeDNSServer.SetHosts("concurrent.test.", 9)
+
+	r, err := NewDNSResolver()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dnsServer := fakeDNSServer.Server.PacketConn.LocalAddr().String()
+	r.delegates = []Resolver{NewUpstreamResolver(dnsServer)}
+
+	domain := "concurrent.test."
+	r.Lock()
+	r.cache[domain] = &DomainCacheEntry{}
+	r.Unlock()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _, _ = r.resolve(domain)
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
/kind bug

resolve() grabs RLock before doing `entry.Addresses = addrs`, which is a read lock and gives no protection against a concurrent writer. If two refreshes for the same domain land at the same time (easy to hit once refreshDns is running against a live queue), they race writing to the same slice field.

Switched both to Lock/Unlock, matching how the rest of the mutating paths in this file already handle the cache (RemoveUnwatchDomain, AddDomainInQueue, etc).

Added a test that spins up several concurrent resolve() calls for one domain. Confirmed it flags the race under -race on main and is clean with the fix.

Fixes: N/A, found by reading through the resolver while poking at something else.

```release-note
NONE
```