### PR TITLE
fix(kolog): stop watching kmsg log if boot time can't be read

### DIFF
--- a/pkg/kolog/kolog.go
+++ b/pkg/kolog/kolog.go
@@ -89,11 +89,20 @@ func parseKmsgLine(line string, bootTime time.Time, appStartTimestamp uint64) {
 	}
 }
 
+// without a real boot time every kmsg timestamp compares as older than
+// startTimestamp, so watching would just run forever without logging anything
+func canWatchKmsg(bootTime time.Time) bool {
+	return !bootTime.IsZero()
+}
+
 func KmeshModuleLog(stopCh <-chan struct{}) {
 	go func() {
 		bootTime, err := getBootTime()
 		if err != nil {
-			log.Errorf("getBootTime: %v, ko log time is inaccurate", err)
+			log.Errorf("getBootTime: %v, ko log will not be watched", err)
+		}
+		if !canWatchKmsg(bootTime) {
+			return
 		}
 		startTimestamp := uint64(time.Now().UnixMicro() - bootTime.UnixMicro())
 

--- a/pkg/kolog/kolog_test.go
+++ b/pkg/kolog/kolog_test.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kolog
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCanWatchKmsg(t *testing.T) {
+	if canWatchKmsg(time.Time{}) {
+		t.Error("canWatchKmsg(zero time) = true, want false")
+	}
+	if !canWatchKmsg(time.Now()) {
+		t.Error("canWatchKmsg(real time) = false, want true")
+	}
+}
+
+func TestTimeParse(t *testing.T) {
+	boot := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	got := timeParse(2_500_000, boot) // 2.5s in kmsg microseconds
+	want := boot.Add(2500 * time.Millisecond)
+	if !got.Equal(want) {
+		t.Errorf("timeParse() = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
/kind bug

Noticed this while looking at the dns resolver locking. If /proc/stat can't be read, getBootTime() returns an error and KmeshModuleLog logs it but keeps going with a zero-value bootTime. startTimestamp then ends up computed against year 1, which is something like 60 quadrillion microseconds - way past anything a real kmsg timestamp could ever be. So the staleness check in parseKmsgLine is true for every line, forever, and the kernel module logs just go dark for the rest of the process's life with no further indication anything's wrong.

Added a small canWatchKmsg check so it bails instead of spinning up a goroutine that can structurally never print anything.

```release-note
NONE
```