### PR TITLE
fix(restart): handle daemonset names with dashes in InferNextStartType

### DIFF
--- a/pkg/bpf/restart/bpf_restart.go
+++ b/pkg/bpf/restart/bpf_restart.go
@@ -75,13 +75,22 @@ func GetExitType() StartType {
 	return kmeshExitType
 }
 
+// daemonSetNameFromPod strips the random suffix Kubernetes appends to a
+// DaemonSet pod's name. The daemonset name itself can contain dashes (e.g.
+// helm releases named "cluster-kmesh"), so only the last segment goes.
+func daemonSetNameFromPod(podName string) string {
+	if i := strings.LastIndex(podName, "-"); i >= 0 {
+		return podName[:i]
+	}
+	return podName
+}
+
 func InferNextStartType() StartType {
 	clientset, err := kube.CreateKubeClient("")
 	if err != nil {
 		return Normal
 	}
-	podName := strings.Split(env.Register("POD_NAME", "", "").Get(), "-")
-	daemonSetName := podName[0]
+	daemonSetName := daemonSetNameFromPod(env.Register("POD_NAME", "", "").Get())
 	daemonSetNamespace := env.Register("POD_NAMESPACE", "", "").Get()
 	daemonSet, err := clientset.AppsV1().DaemonSets(daemonSetNamespace).Get(context.TODO(), daemonSetName, metav1.GetOptions{})
 	if err == nil {

--- a/pkg/bpf/restart/bpf_restart_test.go
+++ b/pkg/bpf/restart/bpf_restart_test.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package restart
+
+import "testing"
+
+func TestDaemonSetNameFromPod(t *testing.T) {
+	cases := map[string]string{
+		"kmesh-x7g2p":              "kmesh",
+		"cluster-kmesh-x7g2p":      "cluster-kmesh",
+		"prod-cluster-kmesh-x7g2p": "prod-cluster-kmesh",
+		"noDashes":                 "noDashes",
+	}
+	for pod, want := range cases {
+		if got := daemonSetNameFromPod(pod); got != want {
+			t.Errorf("daemonSetNameFromPod(%q) = %q, want %q", pod, got, want)
+		}
+	}
+}


### PR DESCRIPTION
/kind bug

InferNextStartType grabs the daemonset name by splitting POD_NAME on "-" and taking the first piece. That only works if the daemonset is literally named one word. Install through the helm chart with a release name that doesn't already contain "kmesh" and kmesh.fullname renders as e.g. "cluster-kmesh", so a pod like cluster-kmesh-x7g2p gets looked up as daemonset "cluster", which doesn't exist. The Get() errors out and it always falls back to Normal start, even on a real restart where it should detect Restart/Update and reuse the existing bpf state.

Pulled the derivation into its own daemonSetNameFromPod so it strips only the trailing random suffix instead of keeping only the first segment.

```release-note
NONE
```