### PR TITLE
fix: initialize port-forward namespace and address flags from provide…

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -95,8 +95,8 @@ func newPortForwarder(cliClient *client, podName string, ns string, localAddress
 
 	cmd := &cobra.Command{}
 	cmd.Flags().Duration("pod-running-timeout", DefaultPodRunningTimeout, "Timeout for waiting for pod to be running")
-	cmd.Flags().String("namespace", KmeshNamespace, "Specify the namespace to use")
-	cmd.Flags().StringSlice("address", []string{DefaultLocalAddress}, "Specify the addresses to bind")
+	cmd.Flags().String("namespace", ns, "Specify the namespace to use")
+	cmd.Flags().StringSlice("address", []string{localAddress}, "Specify the addresses to bind")
 	return &portForwarder{
 		cmd:              cmd,
 		RESTClientGetter: cliClient.clientFactory,

--- a/pkg/kube/portforwarder_test.go
+++ b/pkg/kube/portforwarder_test.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright The Kmesh Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kube
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPortForwarder(t *testing.T) {
+	tests := []struct {
+		name             string
+		ns               string
+		localAddress     string
+		localPort        int
+		podPort          int
+		wantAddress      []string
+		wantNamespace    string
+		wantLocalAddress string
+	}{
+		{
+			name:             "custom namespace and address",
+			ns:               "my-ns",
+			localAddress:     "0.0.0.0",
+			localPort:        8080,
+			podPort:          15008,
+			wantAddress:      []string{"0.0.0.0"},
+			wantNamespace:    "my-ns",
+			wantLocalAddress: "0.0.0.0",
+		},
+		{
+			name:             "empty address falls back to localhost",
+			ns:               "my-ns",
+			localAddress:     "",
+			localPort:        0,
+			podPort:          15001,
+			wantAddress:      []string{DefaultLocalAddress},
+			wantNamespace:    "my-ns",
+			wantLocalAddress: DefaultLocalAddress,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fw, err := newPortForwarder(&client{}, "test-pod", tt.ns, tt.localAddress, tt.localPort, tt.podPort)
+			require.NoError(t, err)
+
+			pf, ok := fw.(*portForwarder)
+			require.True(t, ok)
+
+			address, err := pf.cmd.Flags().GetStringSlice("address")
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantAddress, address)
+
+			namespace, err := pf.cmd.Flags().GetString("namespace")
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantNamespace, namespace)
+
+			assert.Equal(t, tt.ns, pf.ns)
+			assert.Equal(t, tt.podPort, pf.podPort)
+			assert.Equal(t, tt.wantLocalAddress, pf.localAddress)
+
+			if tt.localPort == 0 {
+				assert.NotZero(t, pf.localPort)
+			} else {
+				assert.Equal(t, tt.localPort, pf.localPort)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes `pkg/kube.NewPortForwarder()` so that `newPortForwarder()` initializes the Cobra `namespace` and `address` flags from the `ns` and `localAddress` arguments passed by the caller instead of the hardcoded `KmeshNamespace` (`kmesh-system`) and `DefaultLocalAddress` (`localhost`) defaults.

Previously the supplied namespace and bind address were stored in the `portForwarder` struct but never reflected in the Cobra flags, so the port-forward command bound to `localhost` regardless of the requested `localAddress` and exposed an inconsistent `namespace` flag value. Existing callers pass `""`/`kmesh-system`, so behavior is preserved for them.

Also adds unit tests in `pkg/kube/portforwarder_test.go` covering flag initialization, the localhost fallback, dynamic port selection, and struct field population.

**Which issue(s) this PR fixes**:
Fixes #1879

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
NONE