### PR TITLE
fix(cache): assign real cluster ids in kernel-native mode

### DIFF
--- a/pkg/cache/v2/cluster.go
+++ b/pkg/cache/v2/cluster.go
@@ -190,7 +190,7 @@ func (cache *ClusterCache) Flush() {
 	defer cache.mutex.Unlock()
 	for name, cluster := range cache.apiClusterCache {
 		if cluster.GetApiStatus() == core_v2.ApiStatus_UPDATE {
-			cluster.Id = cache.hashName.StrToNum(name)
+			cluster.Id = cache.hashName.Hash(name)
 			err := maps_v2.ClusterUpdate(name, cluster)
 			if cluster.GetLbPolicy() == cluster_v2.Cluster_MAGLEV {
 				// create consistent lb here and update table to bpf map

--- a/pkg/cache/v2/cluster_test.go
+++ b/pkg/cache/v2/cluster_test.go
@@ -391,3 +391,58 @@ func TestClearClusterStats(t *testing.T) {
 		assert.Nil(t, iter.Err())
 	}
 }
+
+func TestClusterFlushAssignsIds(t *testing.T) {
+	patches := gomonkey.NewPatches()
+	patches.ApplyFunc(maps_v2.ClusterUpdate, func(key string, value *cluster_v2.Cluster) error {
+		return nil
+	})
+	defer patches.Reset()
+
+	// Circuit breaker stats are held in a map keyed by {netns_cookie,
+	// cluster_id}, so two clusters only keep independent connection counters
+	// and limits while their ids differ.
+	newCluster := func(name string, maxConnections uint32) *cluster_v2.Cluster {
+		return &cluster_v2.Cluster{
+			ApiStatus:       core_v2.ApiStatus_UPDATE,
+			Name:            name,
+			LbPolicy:        cluster_v2.Cluster_RANDOM,
+			CircuitBreakers: &cluster_v2.CircuitBreakers{MaxConnections: maxConnections},
+		}
+	}
+
+	t.Run("clusters get distinct non-zero ids", func(t *testing.T) {
+		hashName := utils.NewHashName()
+		defer hashName.Reset()
+		cache := NewClusterCache(nil, hashName)
+		reviews := newCluster("outbound|9080||reviews.default.svc.cluster.local", 10)
+		ratings := newCluster("outbound|9080||ratings.default.svc.cluster.local", 100)
+		cache.SetApiCluster(reviews.Name, reviews)
+		cache.SetApiCluster(ratings.Name, ratings)
+
+		cache.Flush()
+
+		assert.NotZero(t, reviews.Id)
+		assert.NotZero(t, ratings.Id)
+		assert.NotEqual(t, reviews.Id, ratings.Id)
+	})
+
+	t.Run("id is stable across flushes", func(t *testing.T) {
+		hashName := utils.NewHashName()
+		defer hashName.Reset()
+		cache := NewClusterCache(nil, hashName)
+		cluster := newCluster("outbound|9080||reviews.default.svc.cluster.local", 10)
+		cache.SetApiCluster(cluster.Name, cluster)
+
+		cache.Flush()
+		firstId := cluster.Id
+		assert.NotZero(t, firstId)
+
+		// A later config push re-flushes the same cluster; its stats entries
+		// are keyed by the id, so reallocating one would strand them.
+		cluster.ApiStatus = core_v2.ApiStatus_UPDATE
+		cache.Flush()
+
+		assert.Equal(t, firstId, cluster.Id)
+	})
+}

--- a/pkg/cache/v2/cluster_test.go
+++ b/pkg/cache/v2/cluster_test.go
@@ -358,14 +358,15 @@ func TestClearClusterStats(t *testing.T) {
 	adsObj := loader.GetBpfKmesh()
 	assert.NotNil(t, adsObj)
 	hashName := utils.NewHashName()
+	defer hashName.Reset()
 	clusterCache := NewClusterCache(adsObj, hashName)
 	testClusters := []string{"test_cluster1", "test_cluster2", "test_cluster3"}
 	testKeys := []ClusterStatsKey{
-		{NetnsCookie: 0, ClusterId: hashName.StrToNum(testClusters[0])},
-		{NetnsCookie: 1, ClusterId: hashName.StrToNum(testClusters[0])},
-		{NetnsCookie: 2, ClusterId: hashName.StrToNum(testClusters[0])},
-		{NetnsCookie: 0, ClusterId: hashName.StrToNum(testClusters[1])},
-		{NetnsCookie: 0, ClusterId: hashName.StrToNum(testClusters[2])},
+		{NetnsCookie: 0, ClusterId: hashName.Hash(testClusters[0])},
+		{NetnsCookie: 1, ClusterId: hashName.Hash(testClusters[0])},
+		{NetnsCookie: 2, ClusterId: hashName.Hash(testClusters[0])},
+		{NetnsCookie: 0, ClusterId: hashName.Hash(testClusters[1])},
+		{NetnsCookie: 0, ClusterId: hashName.Hash(testClusters[2])},
 	}
 
 	testValues := []ClusterStatsValue{
@@ -377,18 +378,33 @@ func TestClearClusterStats(t *testing.T) {
 	}
 
 	clusterStatsMap := adsObj.GetClusterStatsMap()
-	clusterStatsMap.BatchUpdate(testKeys, testValues, nil)
+	_, err := clusterStatsMap.BatchUpdate(testKeys, testValues, nil)
+	assert.Nil(t, err)
+
+	expected := make(map[ClusterStatsKey]ClusterStatsValue, len(testKeys))
+	for i, testKey := range testKeys {
+		expected[testKey] = testValues[i]
+	}
 
 	var key ClusterStatsKey
 	var value ClusterStatsValue
 	for _, cluster := range testClusters {
-		clusterCache.clearClusterStats(cluster)
-		iter := clusterStatsMap.Iterate()
 		clusterId := hashName.StrToNum(cluster)
+		clusterCache.clearClusterStats(cluster)
+
+		for expectedKey := range expected {
+			if expectedKey.ClusterId == clusterId {
+				delete(expected, expectedKey)
+			}
+		}
+
+		remaining := make(map[ClusterStatsKey]ClusterStatsValue, len(expected))
+		iter := clusterStatsMap.Iterate()
 		for iter.Next(&key, &value) {
-			assert.NotEqual(t, clusterId, key.ClusterId)
+			remaining[key] = value
 		}
 		assert.Nil(t, iter.Err())
+		assert.Equal(t, expected, remaining)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

In kernel-native mode every cluster is flushed to the BPF map with `Id = 0`.

`ClusterCache.Flush` took the id from `HashName.StrToNum`, which is a plain map read rather than the allocator:

```go
func (h *HashName) StrToNum(str string) uint32 {
	return h.strToNum[str]
}
```

`HashName.Hash` is the only function that inserts into `strToNum`, and it is called exclusively from `pkg/controller/workload/workload_processor.go` — the workload path. Nothing on the ads path ever calls it. `NewAdsCache` builds a fresh `utils.NewHashName()` and hands it only to `NewClusterCache`, and the persist file that `NewHashName` restores from is written only by `Hash` and `Delete`, so in kernel-native mode it stays empty too. The lookup therefore returned the zero value for every cluster.

That matters because circuit breaker stats are keyed by `{netns_cookie, cluster_id}` (`bpf/kmesh/ads/include/circuit_breaker.h`), and `on_cluster_sock_bind` reads the id straight off the cluster:

```c
struct cluster_stats_key {
    __u64 netns_cookie;
    __u32 cluster_id;
};
```

So with every id at 0:

- All clusters in a network namespace collapse onto a single `cluster_stats` entry. A pod calling `reviews` (`maxConnections: 10`) and `ratings` (`maxConnections: 100`) shares one counter: after 10 *combined* connections `on_cluster_sock_bind` returns `-1` and further connections to `reviews` are rejected, while `ratings` is throttled at the wrong threshold.
- `clearClusterStats` resolves `clusterId = 0` and `BatchDelete`s every key with `ClusterId == 0`, which is all of them. Removing one cluster wipes the live connection counters of every cluster in every netns, and subsequent closes then hit the `-delta > stats->active_connections` guard, so the counters stay skewed.

The fix is to use the allocator:

```go
cluster.Id = cache.hashName.Hash(name)
```

`Hash` returns the existing id when the name is already registered, so a cluster keeps its id across config pushes and its stats entries stay reachable.

The second commit is a test-only fix. `TestClearClusterStats` built its stats keys from `StrToNum` on a `HashName` nothing had registered into, so all five keys carried `ClusterId 0` and collapsed to three distinct entries; the first `clearClusterStats` call then deleted all of them and the per-cluster assertions never ran. It now registers the names through `Hash` and asserts the whole remaining map, which is the property the test is named for: clearing one cluster leaves the other clusters' counters untouched.

**Which issue(s) this PR fixes**:
Fixes #1936

**Special notes for your reviewer**:

- **`clearClusterStats` deliberately stays on `StrToNum`.** It resolves an id that `Flush` has already registered, and it runs before `hashName.Delete(name)` on the delete path, so the entry is still present. Using the allocator there would mint an id for a cluster that is being removed.
- **New behaviour worth knowing:** because `Hash` persists new entries, the ads path now writes `/mnt/hash_name.yaml`, which it never did before. `/mnt` is already a hostPath mount in the daemonset (`deploy/yaml/kmesh.yaml`, `deploy/charts/kmesh-helm/templates/daemonset.yaml`), and this is what makes cluster ids survive a restart, so the `cluster_stats` entries written before the restart stay addressable afterwards.
- **Relation to #1904.** This makes the ads path depend on `HashName.Hash`, which has a separate edge case: `for num = h.hash.Sum32(); num < math.MaxUint32; num++` never enters the body when the hash is exactly `math.MaxUint32`, so it returns an id it never registered. On this path that would mean a live cluster whose name is missing from `strToNum`, and a later `clearClusterStats` resolving 0 for it. It is a 1-in-2^32 case and #1905 already fixes it, so I have not touched it here; flagging the interaction since it becomes reachable from the ads path with this change.
- **Verification.** `TestClusterFlushAssignsIds` fails on the unmodified line (`Should not be zero, but was 0` for both clusters, and the two ids equal) and passes with the fix, under the same `-race -gcflags=all=-l` flags CI uses. `pkg/controller/ads/...` and the rest of `pkg/cache/v2` show no new failures against `main`; five tests in `pkg/cache/v2` (`TestClusterLookupAll`, `TestClearClusterStats`, `TestListenerLookupAll`, `TestListenerFlushAndLookup`, `TestListenerUpdateAndDeleteFlush`) fail identically on unmodified `main` in my environment because I cannot attach real BPF maps there. That means the `TestClearClusterStats` change in the second commit is exercised by CI rather than by me locally.
- **Coverage I did not add.** @AnouarMohamed suggested asserting that two clusters with different circuit-breaker limits do not share `cluster_stats`. That property lives in the BPF map, not in the Go cache, so it needs an e2e test rather than a unit test; what the unit test can show is what it now shows, that the two clusters resolve to distinct non-zero ids, with the differing `maxConnections` in the fixture to keep the scenario recognisable. Happy to follow up with the e2e case if you would like it.
- **AI disclosure**, per CONTRIBUTING.md: I used Claude Code while preparing this PR — tracing the call paths, drafting the tests, and drafting this description. I have reviewed and run every change myself.

**Does this PR introduce a user-facing change?**:

```release-note
Fix kernel-native mode assigning cluster id 0 to every cluster, which made all clusters in a network namespace share a single circuit breaker counter and let the removal of one cluster wipe every cluster's connection stats.
```
