### PR TITLE
fix(secret): print confirmation on IPsec secret create/update

### DIFF
--- a/ctl/secret/secret.go
+++ b/ctl/secret/secret.go
@@ -189,12 +189,14 @@ func CreateOrUpdateSecret(cmd *cobra.Command, args []string) {
 			log.Errorf("failed to create %v secret, %v", SecretName, err)
 			os.Exit(1)
 		}
+		fmt.Printf("IPsec secret created (SPI: %d)\n", ipSecKey.Spi)
 	} else {
 		_, err = clientset.Kube().CoreV1().Secrets(utils.KmeshNamespace).Update(context.TODO(), secret, metav1.UpdateOptions{})
 		if err != nil {
 			log.Errorf("failed to update %v secret, %v", SecretName, err)
 			os.Exit(1)
 		}
+		fmt.Printf("IPsec secret updated (SPI: %d)\n", ipSecKey.Spi)
 	}
 }
 


### PR DESCRIPTION
Fixes #1940 

kmeshctl secret create printed nothing on success - no indication whether it created a new secret or rotated an existing one, or what the new SPI is. Running create twice silently rotated the live key with zero output.

CreateOrUpdateSecret in ctl/secret/secret.go returned silently after both the Create and Update branches. Added a fmt.Printf after each confirming the action and SPI.

Verified locally against a kind cluster:

$ kmeshctl secret create
IPsec secret created (SPI: 1)

$ kmeshctl secret create --key=...
IPsec secret updated (SPI: 2)